### PR TITLE
decrease padding of start page banner

### DIFF
--- a/css/app.scss
+++ b/css/app.scss
@@ -187,7 +187,7 @@ ul {
   height: 180px;
 
   &.main-page {
-    padding: 100px 0;
+    padding: 80px 0;
     height: auto;
 
     p {


### PR DESCRIPTION
This fixes the background image appearing cropped at the top and bottom but isn't an actual fix for #13 - it's only a temporary fix until we have a larger background image.
