### PR TITLE
ignore vimeo url

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -2,4 +2,4 @@
 set -e # halt script on error
 
 bundle exec jekyll build
-bundle exec htmlproofer ./_site --check-html --url-ignore https://t.co/6yhjmjQrYD,http://localhost:4000/my_page --only-4xx --url-swap simplabs.com:localhost\:4000
+bundle exec htmlproofer ./_site --check-html --url-ignore https://t.co/6yhjmjQrYD,http://localhost:4000/my_page,https://vimeo.com/139125310 --only-4xx --url-swap simplabs.com:localhost\:4000


### PR DESCRIPTION
This particular URL seems to cause problems during tests - maybe Vimeo doesn't allow requests that are not coming from real browsers or so…