### PR TITLE
add bottom margin to contact form on mobile

### DIFF
--- a/css/app.scss
+++ b/css/app.scss
@@ -662,4 +662,8 @@ pre.highlight {
       }
     }
   }
+
+  #contact-form {
+    margin-bottom: 20px;
+  }
 }


### PR DESCRIPTION
now looks like this:

![localhost_4000_contact_](https://user-images.githubusercontent.com/1510/33179609-56febac6-d06a-11e7-9123-7fa97b5f3dbb.png)

closes #162 