### PR TITLE
fix workshop header

### DIFF
--- a/_includes/workshop_header.html
+++ b/_includes/workshop_header.html
@@ -2,8 +2,8 @@
   <div class="container">
     <div class="row">
       <div class="col-md-6 col-md-offset-3 col-sm-10 col-sm-offset-1">
-        <h2>Blog</h2>
-        <p>We write about <strong>Ember.js</strong>, <strong>Ruby on Rails</strong> as well as <strong>Elixir</strong> and <strong>Phoenix</strong>.</p>
+        <h2>Training</h2>
+        <p>We offer training workshops on a <strong>variety of tools and technologies</strong>.</p>
     	</div>
     </div>
   </div>


### PR DESCRIPTION
We are currently showing the blog header on the workshop pages, e.g. https://simplabs.com/training/2016-12-19-ember-pro.html 🤦‍♂️ 