### PR TITLE
better privacy page text

### DIFF
--- a/privacy/index.html
+++ b/privacy/index.html
@@ -18,7 +18,7 @@ title: Privacy
     <div class="col-md-10 col-md-offset-1 col-sm-12">
       <div class="row content-section">
         <div class="col-sm-12">
-          <p>simplabs.com uses Google Analytics to collect user statistics.</p>
+          <p>simplabs uses Google Analytics to collect user statistics.</p>
           <p>Google Analytics is a service that collects data about website visitors.</p>
           <h4>What Google Analytics records</h4>
           <ul>


### PR DESCRIPTION
As we're now linking to this page from other domains it doesn't really make sense if we're referring to simplabs.com specifically. Instead, we just refer to us as a company so it doesn't sound like it doesn't refer to the other domains.