### PR TITLE
update news on start page

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ title:
         <div class="col-sm-6 content-teaser">
           <div>
             <h4>EmberFest 2018, Amsterdam</h4>
-            <p>As in 2017, <strong>simplabs is part of the organisational committee behind EmberFest</strong>. This year the conference is headed to Amsterdam in the Netherlands and our team is looking forward to <strong>meeting up with there with the european Ember community on October 11th and 12th</strong>!</p>
+            <p>As in 2017, <strong>simplabs is part of the organisational committee behind EmberFest</strong>. This year the conference is headed to Amsterdam in the Netherlands and our team is looking forward to <strong>meeting up with the european Ember community on October 11th and 12th</strong>!</p>
             <a href="https://emberfest.eu" class="custom-button">learn more</a>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ title:
         <div class="col-sm-6 content-teaser">
           <div>
             <h4>EmberFest 2018, Amsterdam</h4>
-            <p>As in 2017, <strong>simplabs is part of the organisational committee behind EmberFest</strong>. This year the conference is headed to Amsterdam in the Netherlands and our team is looking forward to <strong>meeting up with the european Ember community on October 11th and 12th</strong>!</p>
+            <p>As in 2017, <strong>simplabs is part of the organisational committee behind EmberFest</strong>. This year the conference is headed to Amsterdam in the Netherlands and our team is looking forward to <strong>meeting up with the European Ember community on October 11th and 12th</strong>!</p>
             <a href="https://emberfest.eu" class="custom-button">learn more</a>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -39,16 +39,16 @@ title:
       <div class="row content-section">
         <div class="col-sm-6 content-teaser">
           <div>
-            <h4>EmberConf 2018</h4>
-            <p><a href="http://emberconf.com">EmberConf 2018</a> is set for March 13th &amp; 14th in Portland, OR with <strong>simplabs engineers <a href="https://twitter.com/jjordan_dev">@jjordan_dev</a> and <a href="https://twitter.com/tobiasbieniek">@tobiasbieniek</a> among the speakers</strong>.</p>
-            <a href="http://emberconf.com" class="custom-button">learn more</a>
+            <h4>JSConf EU 2018, Berlin</h4>
+            <p>We are happy to be part of JSConf EU again in 2018 as a community sponsor. Visit us at our booth if you're in Berlin on June 2nd and 3rd - we have <strong><a href="https://twitter.com/locks">@locks</a> form the Ember.js core team</strong> join us and will present some cutting edge <strong>demos with Ember.js and Glimmer.js</strong>!</p>
+            <a href="https://2018.jsconf.eu" class="custom-button">learn more</a>
           </div>
         </div>
         <div class="col-sm-6 content-teaser">
           <div>
-            <h4>Bulgaria Web Summit 2018, April 14th</h4>
-            <p><a href="https://twitter.com/jjordan_dev">@jjordan_dev</a> will talk about <strong>testing against time in JavaScript applications</strong> at Bulgaria Web Summit in Sofia this April.</p>
-            <a href="https://bulgariawebsummit.com/" class="custom-button">learn more</a>
+            <h4>EmberFest 2018, Amsterdam</h4>
+            <p>As in 2017, <strong>simplabs is part of the organisational committee behind EmberFest</strong>. This year the conference is headed to Amsterdam in the Netherlands and our team is looking forward to <strong>meeting up with there with the european Ember community on October 11th and 12th</strong>!</p>
+            <a href="https://emberfest.eu" class="custom-button">learn more</a>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@ title:
         <div class="col-sm-6 content-teaser">
           <div>
             <h4>JSConf EU 2018, Berlin</h4>
-            <p>We are happy to be part of JSConf EU again in 2018 as a community sponsor. Visit us at our booth if you're in Berlin on June 2nd and 3rd - we have <strong><a href="https://twitter.com/locks">@locks</a> form the Ember.js core team</strong> join us and will present some cutting edge <strong>demos with Ember.js and Glimmer.js</strong>!</p>
+            <p>We are happy to be part of JSConf EU again in 2018 as a community sponsor. Visit us at our booth if you're in Berlin on June 2nd and 3rd - we have <strong><a href="https://twitter.com/locks">@locks</a> from the Ember.js core team</strong> join us and will present some cutting edge <strong>demos with Ember.js and Glimmer.js</strong>!</p>
             <a href="https://2018.jsconf.eu" class="custom-button">learn more</a>
           </div>
         </div>


### PR DESCRIPTION
This replaces the outdated news on the start page with announcements about JSConf and EmberFest.