### PR TITLE
Fix blog article layout

### DIFF
--- a/_layouts/article.html
+++ b/_layouts/article.html
@@ -19,7 +19,7 @@
                 {{page.content}}
               </div>
             </div>
-            <div class="row content-section separated">
+            <div class="row content-section">
               <div class="col-sm-12">
                 <p class="author">
                   <i class="{{page.author | split: ' ' | first | downcase}} img-circle author"></i>


### PR DESCRIPTION
This removes the extra unnecessary line in the blog article layout. That was only necessary when we had comments to separate that section but since comments have been removed the line serves no purpose and is inconsistent with the layout of the rest of the page:

![bildschirmfoto 2018-08-07 um 10 18 59](https://user-images.githubusercontent.com/1510/43763626-7f13f25c-9a2b-11e8-9c31-59075570fc32.png)
