### PR TITLE
ignore .jekyll-metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.rbc
 .bundle
 .config
+.jekyll-metadata
 coverage
 InstalledFiles
 lib/bundler/man


### PR DESCRIPTION
This seems to be a new file that Jekyll now creates.