### PR TITLE
replace outdated emberfest news

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,9 +46,9 @@ title:
         </div>
         <div class="col-sm-6 content-teaser">
           <div>
-            <h4>EmberFest 2018, Amsterdam</h4>
-            <p>As in 2017, <strong>simplabs is part of the organisational committee behind EmberFest</strong>. This year the conference is headed to Amsterdam in the Netherlands and our team is looking forward to <strong>meeting up with the European Ember community on October 11th and 12th</strong>!</p>
-            <a href="https://emberfest.eu" class="custom-button">learn more</a>
+            <h4>EmberFest 2018 Videos</h4>
+            <p>We are part of the organisational committee behind EmberFest. This year, we also sponsored the <strong>video recordings of all talks which are now <a href="https://www.youtube.com/watch?v=oRzmDobMZ_Q&list=PLN4SpDLOSVkSB9034lDNdP1JoNBGssax9">available on YouTube</a></strong>. We hope everyone enjoys the videos and are already looking forward to another great EmberFest in 2019!</p>
+            <a href="https://www.youtube.com/watch?v=oRzmDobMZ_Q&list=PLN4SpDLOSVkSB9034lDNdP1JoNBGssax9" class="custom-button">watch</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This replaces the outdated news about EmberFest 2018 on the website with a link to the videos that we sponsored:

<img width="1437" alt="bildschirmfoto 2018-11-13 um 15 30 57" src="https://user-images.githubusercontent.com/1510/48419797-209bff00-e759-11e8-9340-d4b197e915a2.png">
