### PR TITLE
update talks and fix description

### DIFF
--- a/ember/index.html
+++ b/ember/index.html
@@ -209,7 +209,7 @@ title: Ember
               </p>
 
               <p class="card-text">
-                Tobias Bieniek at EmberFest 2018
+                Tobias Bieniek at EmberConf 2018
               </p>
             </div>
           </a>
@@ -219,39 +219,39 @@ title: Ember
 
         <div class="d-flex flex-column flex-md-row justify-content-between section-features">
           
-          <a class="card card-we-share-our-expertise" href="https://www.youtube.com/watch?v=81-jwnlg1pQ">
+          <a class="card card-we-share-our-expertise" href="https://www.youtube.com/watch?v=5NrsB2FYBlQ">
             <div class="card-video-wrapper">
               <div class="embed-responsive embed-responsive-16by9">
-                <iframe width="560" height="315" src="https://www.youtube.com/embed/81-jwnlg1pQ?rel=0&amp;controls=0&amp;showinfo=0"
-                  frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+                <iframe width="560" height="315" src="https://www.youtube.com/embed/5NrsB2FYBlQ"
+                  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
                 </iframe>
               </div>
             </div>
 
             <div class="card-body">
               <p class="card-title">
-                Better Test Selectors Leveraging the...
+                Delivering fast apps even faster
               </p>
 
-              <p class="card-text">Marco Otte-Witte at EmberCamp 2017</p>
+              <p class="card-text">Marco Otte-Witte at EmberFest 2018</p>
             </div>
           </a>
 
-          <a class="card card-we-share-our-expertise" href="https://www.youtube.com/watch?v=wFJPIjRTIVU">
+          <a class="card card-we-share-our-expertise" href="https://www.youtube.com/watch?v=OnDUp2AhuNo">
             <div class="card-video-wrapper">
               <div class="embed-responsive embed-responsive-16by9">
-                <iframe width="560" height="315" src="https://www.youtube.com/embed/wFJPIjRTIVU?rel=0&amp;controls=0&amp;showinfo=0"
-                  frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+                <iframe width="560" height="315" src="https://www.youtube.com/embed/OnDUp2AhuNo"
+                  frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
                 </iframe>
               </div>
             </div>
 
             <div class="card-body">
               <p class="card-title">
-                Animate the Web with Ember.js
+                 An introduction to Ember Ghost
               </p>
 
-              <p class="card-text">Jessica Jordan at EmberConf 2017</p>
+              <p class="card-text">Chris Manson at EmberConf 2018</p>
             </div>
           </a>
 


### PR DESCRIPTION
This updates the talks on the Ember page to newer ones and fixes the description of Tobi's:

<img width="1491" alt="bildschirmfoto 2018-12-06 um 17 59 16" src="https://user-images.githubusercontent.com/1510/49599210-b4d83b00-f980-11e8-9548-8243ad69a912.png">
