### PR TITLE
Blog: Turn Blog Subheadlines into H2s, Sub-subheadlines into H3s

### DIFF
--- a/blog/_posts/2013-06-15-authentication-in-emberjs.md
+++ b/blog/_posts/2013-06-15-authentication-in-emberjs.md
@@ -20,7 +20,7 @@ When we started our first project with [ember.js](http://emberjs.com), **the fir
 
 The only more elaborate sample project I found was the [ember-auth](https://github.com/heartsentwined/ember-auth) plugin. While that seemed to be very complete and high quality it is also very heavy weight and I didn’t want to add such a big thing to our codebase only to implement simple authentication into our app. So I rolled my own implementation.
 
-#### The basics
+## The basics
 
 The general route to go with authentication in ember.js is to use **token based authentication** where the client submits the regular username/password credentials to the server once and if those are valid receives an authentication token in response. That token is then sent along with every request the client makes to the server. Having understood this the first thing to do is to implement a regular login form with username and password fields:
 
@@ -82,7 +82,7 @@ $.cookie('auth_token', App.Auth.get('authToken'));
 $.cookie('auth_account', App.Auth.get('accountId'));
 ```
 
-#### Making authenticated requests
+## Making authenticated requests
 
 The next step is to actually send the authentication token to the server. As the only point point of interaction between client and server in an ember.js app is **when the store adapter reads or writes data, the token has to be integrated in that adapter somehow**. As there’s not (yet) any out-off-the-box support for authentication in the [DS.RESTAdapter](https://github.com/emberjs/data/blob/master/addon/adapters/rest.js), I simply added it myself:
 
@@ -108,7 +108,7 @@ DS.rejectionHandler = function(reason) {
 };
 ```
 
-#### Enforcing authentication on the client
+## Enforcing authentication on the client
 
 Now that the general authentication mechanism is in place it would be cool to have a way of enforcing authentication on the client for specific routes so the user never gets to see any pages that they aren’t allowed to. This can be done by simply **introducing a custom route class that will check for the presence of a session and if none is present redirects to the login screen**. Any other routes that require authentication can then inherit from that one instead if the regular [`Ember.Route`](http://emberjs.com/api/classes/Ember.Route.html)
 
@@ -132,7 +132,7 @@ class AuthenticatedController < ApplicationController
 end
 ```
 
-#### Cleanup
+## Cleanup
 
 As the code is now spread up into a number of files and classes, I added a `Session` model:
 

--- a/blog/_posts/2013-08-08-better-authentication-in-emberjs.md
+++ b/blog/_posts/2013-08-08-better-authentication-in-emberjs.md
@@ -18,13 +18,13 @@ _I’m using the latest (as of early August 2013) [ember.js](http://emberjs.com)
 
 _**Update:**I changed the section on actually using the token to use [$.ajaxPrefilter](http://api.jquery.com/jQuery.ajaxPrefilter/) instead of a custom ember-data adapter_
 
-#### The basics
+## The basics
 
 The basic approach is still the same as in our initial implementation - we have a **`/session` route in our Rails app that the client `POST`s its credentials to and if those are valid gets back an authentication token** together with an id that identifies the user’s account on the server side.
 
 This data is stored in a _"session"_ object on the client side (while technically there is no session in this stateless authentication mechanism, I still call it session in absence of an idea for a better name). The **authentication token is then sent in a header** with every request the client makes.
 
-#### The client _"session"_
+## The client _"session"_
 
 The _"session"_ object on the client side is a **plain `Ember.Object` that simply keeps the data that is received from the server** on session creation. It also stores the authentication token and the user’s account ID in cookies so the user doesn’t have to login again after a page reload (As Ed points out in a comment on the old post it’s a security issue to store the authentication token in a cookie without the user’s permission - I think using a session cookie like I do should be ok as it’s deleted when the browser window is closed. Of course you could also use sth. like localStorage like Marc points out. I’m creating this object in an initializer so I can be sure it exists (of course it might be empty) when the application starts.
 
@@ -85,7 +85,7 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-#### Logging in
+## Logging in
 
 As described above, the login API is a simple `/session` route on the server side that accepts the user’s login and password and **responds with either HTTP status 401 when the credentials are invalid or a session JSON when the authentication was successful**. On the client side we have routes for creating and destroying the session:
 
@@ -138,7 +138,7 @@ The template is just a simple form (actual elements, classes etc. of course depe
 </form>
 {% endraw %}```
 
-#### Logging out
+## Logging out
 
 Logging out is actually pretty simple as well. The **client just sends a `DELETE` to the same `/session` route** that makes the server reset the authentication token in the database so that the token on the client side is invalidated. The client also deletes the saved session information in `App.Session` so there’s no stale data.
 
@@ -170,7 +170,7 @@ App.SessionDestroyRoute = Ember.Route.extend({
 });
 ```
 
-#### Authenticated routes
+## Authenticated routes
 
 To easily enable authentication for any route in the application, I created an **`App.AuthenticatedRoute` that extends `Ember.Route`** and that all routes that need to enforce user authentication can extend again:
 

--- a/blog/_posts/2013-10-09-embersimpleauth.md
+++ b/blog/_posts/2013-10-09-embersimpleauth.md
@@ -16,7 +16,7 @@ After I wrote 2 [blog](http://simplabs.com/blog/2013/06/15/authentication-in-emb
 
 Instead of providing a heavyweight out-of-the-box solution with predefined routes, controllers etc., Ember.SimpleAuth defines lightweight mixins that the application code implements. It also **does not dictate anything with respect to application structure, routing etc**. However, setting up Ember.SimpleAuth is **very straight forward** and it can be **completely customized**. The requirements on the server interface are minimal ([see the README for more information on the server side](https://github.com/simplabs/ember-simple-auth#the-server-side)).
 
-#### Using Ember.SimpleAuth
+## Using Ember.SimpleAuth
 
 Using Ember.SimpleAuth in an application only requires a few simple steps. First, it must be enabled which is best done in a custom initializer:
 
@@ -63,7 +63,7 @@ At this point, everything that’s necessary for users to log in and out is set 
 App.ProtectedRoute = Ember.Route.extend(Ember.SimpleAuth.AuthenticatedRouteMixin);
 ```
 
-#### More
+## More
 
 There is more documentation as well as examples in the [repository on github](https://github.com/simplabs/ember-simple-auth). Also the **code base is quite small so I suggest to read through it** to better understand what’s going on internally.
 

--- a/blog/_posts/2013-10-28-embersimpleauth-implements-rfc-6749-oauth-20.md
+++ b/blog/_posts/2013-10-28-embersimpleauth-implements-rfc-6749-oauth-20.md
@@ -16,7 +16,7 @@ With the [release of Ember.SimpleAuth 0.0.4](https://github.com/simplabs/ember-s
 
 With the OAuth 2.0 support also comes **support for access token expiration and [refresh tokens](http://tools.ietf.org/html/rfc6749#section-6)**. Using expiring access tokens improves overall security as replay attacks are less likely while with refresh tokens **Ember.SimpleAuth can automatically obtain new access tokens** before they expire so that the user doesn’t recognize the token actually changes.
 
-#### Other changes
+## Other changes
 
 Other smaller additions include **support for [external OAuth/OpenID providers](https://github.com/simplabs/ember-simple-auth#external-oauthopenid-providers)** and [manipulation of the request used to obtain the access token](https://github.com/simplabs/ember-simple-auth#custom-server-protocols). Also the API was simplified and the `login` and `logout` actions were moved to the `ApplicationControllerMixin` and the `/logout` route has been removed. The new API now looks like this:
 
@@ -37,6 +37,6 @@ App.ApplicationRoute = Ember.Route.extend(Ember.SimpleAuth.ApplicationRouteMixin
 App.LoginController  = Ember.Controller.extend(Ember.SimpleAuth.LoginControllerMixin);
 ```
 
-#### Future plans
+## Future plans
 
 Currently I’m working on adding API documentation within the source together with a means of generating some nice HTML out of that. I don’t currently see that there is much else missing in the library so **I’d like to release a 1.0.0 version soon**. Of course I’d like to make sure that Ember.SimpleAuth is actually being used and working so [please submit bug reports, patches etc.](https://github.com/simplabs/ember-simple-auth) or **provide general feedback/ideas!**

--- a/blog/_posts/2014-01-20-embersimpleauth-010.md
+++ b/blog/_posts/2014-01-20-embersimpleauth-010.md
@@ -12,7 +12,7 @@ Since [Ember.SimpleAuth](https://github.com/simplabs/ember-simple-auth) was rele
 
 <!--break-->
 
-#### What changed?
+## What changed?
 
 The most significant change is the **extraction of everything specific to specific authentication/authorization mechanisms (e.g. the default OAuth 2.0 implementation) into strategy classes** which significantly improves customizability and extensibility. Instead of having to override parts of the library, using e.g. a custom authentication method is now as simple as specifying the class in the respective controller:
 
@@ -26,7 +26,7 @@ This **makes implementations cleaner and also helps defining the public API that
 
 Other changes include the introduction of store strategies (Ember.SimpleAuth comes with a cookie store that is equivalent to the old store, a store that uses the browser’s localStorage API and which is the new default as well as an in-memory store which is mainly useful for testing) as well as error handling/token invalidation, added callback actions like `sessionInvalidationSucceeded` etc. See the [README](https://github.com/simplabs/ember-simple-auth#readme) and the [API docs](http://ember-simple-auth.com/api/) for complete documentation.
 
-#### Upgrading
+## Upgrading
 
 Upgrading will be pretty straight forward in most cases. The main change that could bite you is probably the change in `Ember.SimpleAuth.setup`’s signature. While it used to expect the `container` as well as the application instance, **the `container` argument was dropped** as it wasn’t actually needed. So in the initializer, change this:
 
@@ -84,6 +84,6 @@ to this:
 
 These are really the only changes needed if your application is using Ember.SimpleAuth’s default settings, the default OAuth 2.0 mechanism etc. For other scenarios, see the [README](https://github.com/simplabs/ember-simple-auth#readme), [API docs](http://ember-simple-auth.com/api/) and also the examples provided in the repository.
 
-#### Outlook
+## Outlook
 
 **I hope that this release can pave the way towards a stable API for Ember.SimpleAuth.** It would also be great of course if many people came up with authenticator and authorizer implementations for all kinds of backends to prove the design of Ember.SimpleAuth’s strategy approach as well as to build a library of ready-to-use strategies for the most common setups.

--- a/blog/_posts/2014-06-30-using-ember-simple-auth-with-ember-cli.md
+++ b/blog/_posts/2014-06-30-using-ember-simple-auth-with-ember-cli.md
@@ -12,7 +12,7 @@ With the latest release of [Ember Simple Auth](https://github.com/simplabs/ember
 
 <!--break-->
 
-#### Setting up the basic project
+## Setting up the basic project
 
 First of all you need to install [PhantomJS](http://phantomjs.org), [bower](http://bower.io) and of course ember-cli (Ember Simple Auth requires **at least Ember CLI 0.0.44**):
 
@@ -35,7 +35,7 @@ cd my-auth-app
 ember server
 ```
 
-#### Installing Ember Simple Auth
+## Installing Ember Simple Auth
 
 Installing Ember Simple Auth in an ember-cli project is really easy now. All you have to do is install [the ember-cli addon from npm](https://www.npmjs.com/package/ember-cli-simple-auth):
 
@@ -78,7 +78,7 @@ import ApplicationRouteMixin from 'simple-auth/mixins/application-route-mixin';
 export default Ember.Route.extend(ApplicationRouteMixin);
 ```
 
-#### Setting up authentication
+## Setting up authentication
 
 To actually give the user the option to login, we need to add an authentication package for Ember Simple Auth. Let’s assume you have an OAuth 2.0 compatible server running at `http://localhost:3000`. To use that, install the [OAuth 2.0 extension library](https://github.com/simplabs/ember-simple-auth/blob/master/addon/authenticators/oauth2-password-grant.js) which again is as easy as installing the [package from npm](https://www.npmjs.com/package/ember-cli-simple-auth-oauth2):
 
@@ -128,6 +128,6 @@ if (environment === 'development') {
 
 You also need to make sure that your server allows cross origin requests by [enabling CORS](http://enable-cors.org) (e.g. with [rack-cors](https://github.com/cyu/rack-cors) if you’re using a rack based server).
 
-#### Conclusion
+## Conclusion
 
 This is how you set up an ember-cli project with Ember Simple Auth. For further documentation and examples see the [github repository](https://github.com/simplabs/ember-simple-auth) and the [API docs for Ember Simple Auth](http://ember-simple-auth.com/api/) and the [OAuth 2.0 extension library](http://ember-simple-auth.com/api/).

--- a/blog/_posts/2014-07-25-testing-with-ember-simple-auth-and-ember-cli.md
+++ b/blog/_posts/2014-07-25-testing-with-ember-simple-auth-and-ember-cli.md
@@ -12,7 +12,7 @@ topic: ember
 
 <!--break-->
 
-#### The testing package
+## The testing package
 
 First of all **install the new [ember-cli-simple-auth-testing package](https://www.npmjs.com/package/ember-cli-simple-auth-testing)**:
 
@@ -32,7 +32,7 @@ export default function startApp(attrs) {
 …
 ```
 
-#### Configuring the `test` environment
+## Configuring the `test` environment
 
 The next step is to configure the `test` environment. As the tests should be isolated and leave no traces of any kind so that subsequent tests don’t have implicit dependencies on the ones that have run earlier, Ember Simple Auth’s default `localStorage` store cannot be used as that would leave data in the `localStorage`. **Instead configure the [ephemeral store](http://ember-simple-auth.com/api/classes/EphemeralStore.html) to be used in the `test` environment**:
 
@@ -47,7 +47,7 @@ if (environment === 'test') {
 
 The ephemeral store stores data in memory and thus will be completely fresh for every test so that tests cannot influence each other.
 
-#### Adding the Tests
+## Adding the Tests
 
 Now everything is set up and a test can be added. To e.g. test that a certain route can only be accessed when the session is authenticated, add tests like these (notice the use of the test helpers `authenticateSession` and `invalidateSession`):
 

--- a/blog/_posts/2015-07-29-ember-simple-auth-10-a-first-look.md
+++ b/blog/_posts/2015-07-29-ember-simple-auth-10-a-first-look.md
@@ -12,11 +12,11 @@ The **first beta of Ember Simple Auth 1.0 will be released soon** and this post 
 
 <!--break-->
 
-#### Ember 2.0 Compatibility
+## Ember 2.0 Compatibility
 
 The biggest improvement of course is that the **library will be compatible with Ember 2.0** (which is mainly due to the fact that it now uses instance initializers for a majority of its setup work). Also when using Ember 1.13 you shouldn’t be seeing any deprecations triggered by Ember Simple Auth anymore so that the upgrade path to 2.0 is clean.
 
-#### Session as a Service
+## Session as a Service
 
 While previous versions of Ember Simple Auth injected the session into routes, controllers and components, **Ember Simple Auth 1.0 drops that and instead provides a new `Session` service** that encapsulates all access to the actual session and can simply be injected wherever necessary, e.g.:
 
@@ -62,7 +62,7 @@ export default Ember.Service.extend({
 });
 ```
 
-#### Ember CLI only
+## Ember CLI only
 
 While previous versions of Ember Simple Auth provided 3 different versions (AMD, globals and the Ember CLI addons) where the Ember CLI addon was also split up into several sub addons, **1.0 will come as one single Ember CLI addon**. This offers 3 main advantages:
 
@@ -70,7 +70,7 @@ While previous versions of Ember Simple Auth provided 3 different versions (AMD,
 *   It is now much simpler to install Ember CLI as it’s now only `ember install ember-simple-auth` command instead of install at least 2 packages or potentially more.
 *   Since all the source is now transpiled with Babel as part of the Ember CLI build process, all the source code has been updated to use thinks like template strings, function literals, deconstruction etc., making the code far more concise and readable.
 
-#### Getting to 1.0
+## Getting to 1.0
 
 1.0 is still not fully finished and ready for release. While I plan to release a first beta until next week latest, getting to the final release still requires some work:
 

--- a/blog/_posts/2015-08-07-rails-api-auth.md
+++ b/blog/_posts/2015-08-07-rails-api-auth.md
@@ -11,11 +11,11 @@ We are happy to announce the first public release of the [rails_api_auth gem](ht
 
 <!--break-->
 
-#### Why another Authentication Engine?
+## Why another Authentication Engine?
 
 Of course there are lots of authentication libraries for Rails already. While all of them are great and work well especially with traditional server rendered applications none of them are really lightweight and simple. In fact they are all pretty massive - all of them provide a lot more functionality than rails_api_auth does of course though. However, when you’re building an API and all you want is to provide a mechanism for users to exchange their login credentials for a token and then validate that incoming requests include a valid token in the `Authorization` header, you just don’t need most of that functionality and could use sth. much smaller, easier to understand and debug. In fact, rails_api_auth is basically just the controller and model plus a few helper methods that we use in most of our Rails-based API projects. When we realized we were reimplementing those in most projects we decided to extract them into an engine so they could be easily reused and also shared with others.
 
-#### The _"Resource Owner Password Credentials Grant"_
+## The _"Resource Owner Password Credentials Grant"_
 
 The _"Resource Owner Password Credentials Grant"_ flow is really **just a formalization of the process where the users send their login credentials to the server and in return receive a token** (we’re using random Bearer tokens for now but will also support JSON Web Tokens (JWTs) soon). That **token will then be sent in the `Authorization` header** in subsequent requests so that the server can validate the user’s identity. The engine stores these credentials and tokens in `Login` models. Storing that data in a separate model instead of the application’s `User` model keeps the authentication code clearly separated from user profile data etc. and makes the engine easier to integrate. The `Login` model can be associated to the application’s `User` model by setting the `user_model_relation` configuration value ([see the README for more info on configuring the engine).](https://github.com/simplabs/rails_api_auth#configuration)
 
@@ -40,12 +40,12 @@ end
 
 When a valid token is present and a `Login` with that token exists, the method will save that in the `current_login` attribute so that it can be used in the controller. If no token is present or no `Login` exists for the token, it will respond with 401 and prevent the actual controller action from being executed. The `authenticate!` method can also be called with a block to add custom checks for the user’s authentication state.
 
-#### Facebook Authentication
+## Facebook Authentication
 
 Another common way of authenticating users that we’re using in many projects is Facebook authentication. The typical flow for this authentication type in web applications is opening a popup that displays Facebook’s login page and - after that - a page where the users grants your application access to their profile data. Once the user did that, Facebook will redirect to the web app and include an `auth_code` in the response that the web app then takes and sends to its API to validate it and exchange it for a Bearer token.
 
 rails_api_auth implements the API part of that in the `POST /token` route as well - [see the demo project for an example of how to use it](https://github.com/simplabs/rails_api_auth-demo#facebook-authentication).
 
-#### Feedback and contributions welcome!
+## Feedback and contributions welcome!
 
 As rails_api_auth is quite new and not yet widely used we’re happy to get feedback and suggestions for things we have missed. Also please **try the gem and report bugs** as you encounter them. **Contributions and pull requests are also appreciated** of course!

--- a/blog/_posts/2015-11-27-updating-to-ember-simple-auth-1.0.md
+++ b/blog/_posts/2015-11-27-updating-to-ember-simple-auth-1.0.md
@@ -14,11 +14,11 @@ With Ember Simple Auth 1.0.0 having been [released a few days ago](https://githu
 
 As 1.0.0 marks the first stable release of Ember Simple Auth, upcoming versions will adhere to the [Semantic Versioning](http://semver.org) rule of not including breaking changes in patch level or minor releases. In fact, **Ember Simple Auth will follow Ember’s example and only make additive, backwards compatible changes in all 1.x releases** and only remove deprecated parts of the library in the next major release.
 
-#### Uninstall previous versions
+## Uninstall previous versions
 
 **Ember Simple Auth 1.0.0 is only distributed as an Ember CLI Addon** and drops the previous bower distribution as well as the individual `ember-cli-simple-auth-*` packages. The first step when upgrading to 1.0.0 is to uninstall these packages from the application. To do that simply remove the `ember-simple-auth` package from `bower.json` as well as all `ember-cli-simple-auth-*` packages from `packages.json`.
 
-#### Install 1.0.0
+## Install 1.0.0
 
 Once the previous versions are uninstalled, install the 1.0.0 release:
 
@@ -26,7 +26,7 @@ Once the previous versions are uninstalled, install the 1.0.0 release:
 ember install ember-simple-auth
 ```
 
-#### Fix the imports
+## Fix the imports
 
 With 1.0.0 all modules that it defines now live in the `ember-simple-auth` namespace as opposed to the `simple-auth` namespace of previous versions. All the `import` statements that import code from Ember Simple Auth need to be updated accordingly, e.g.
 
@@ -42,7 +42,7 @@ import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mi
 
 Also the modules for the OAuth 2.0 authenticator and authorizer have been renamed from just `oauth2` to `oauth2-password-grant` and `oauth2-bearer` respectively so that `'simple-auth/authenticators/oauth2'` is now `'ember-simple-auth/authenticators/oauth2-password-grant'` and `'simple-auth/authorizers/oauth2'` is now `'ember-simple-auth/authorizers/oauth2-bearer'`.
 
-#### Inject the session service
+## Inject the session service
 
 With Ember Simple Auth 1.0.0 the **session is no longer automatically injected into all routes, controllers and components** but instead is **now available as an [Ember.Service](http://emberjs.com/api/classes/Ember.Service.html)** so in all routes, controllers and components that use the session (or back a template that uses it), that session service needs to be injected, e.g.:
 
@@ -54,7 +54,7 @@ export default Ember.Controller.extend({
 });
 ```
 
-#### Define Authenticators and Authorizers
+## Define Authenticators and Authorizers
 
 Ember Simple Auth 1.0.0 does not automatically merge all the predefined authenticators and authorizers into the application anymore but instead **requires authenticators and authorizers the application actually uses to be defined explicitly**. So if you e.g. were previously using the OAuth 2.0 authenticator simply define an authenticator that extends the OAuth 2.0 authenticator in `app/authenticators`:
 
@@ -83,7 +83,7 @@ this.get('session').authenticate('authenticator:oauth2', identification, passwor
 
 Also authenticators and authorizers are not configured via `config/environment.js` anymore but instead the respective properties are simply overridden in the extended classes as for the `serverTokenRevocationEndpoint` property in the example above.
 
-#### Setup authorization
+## Setup authorization
 
 Ember Simple Auth’s **old auto-authorization mechanism** was complex (especially when working with cross origin requests where configuring the `crossOriginWhitelist` was causing big problems for many people) and **has been removed in 1.0.0**. Instead authorization is now explicit. To authorize a block of code use the [session service’s `authorize` method](http://ember-simple-auth.com/api/classes/SessionService.html#method_authorize), e.g.:
 
@@ -105,11 +105,11 @@ export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
 });
 ```
 
-#### Migrating custom sessions
+## Migrating custom sessions
 
 While previous versions of Ember Simple Auth allowed to configure a custom session class in order to add properties and methods to the session, Ember Simple Auth 1.0.0 makes the session private and only exposes the session service. In order to migrate a custom session class to work with the service there are 2 options.
 
-##### Extend the session service
+### Extend the session service
 
 You can simply extend the session service and add custom properties and methods in the subclass, e.g.:
 
@@ -133,7 +133,7 @@ export default SessionService.extend({
 });
 ```
 
-##### Create dedicated services
+### Create dedicated services
 
 You can also create dedicated services that use the session service internally, e.g.:
 
@@ -160,7 +160,7 @@ In this case the session service remains unchanged and whenever you need the cur
 
 Both solutions work fine but **the latter results in cleaner code and better separation of concerns.**
 
-#### Session Stores
+## Session Stores
 
 Previous versions of Ember Simple Auth allowed the session store to be configured in `config/environment.js`. **Ember Simple Auth 1.0.0 removes that configuration setting and will always use the `'application'` session store**. If not overridden by the application that session store will be an instance of the new [`AdaptiveStore`](http://ember-simple-auth.com/api/classes/AdaptiveStore.html) that internally uses the [`LocalStorageStore`](http://ember-simple-auth.com/api/classes/LocalStorageStore.html) if `localStorage` storage is available and the [`CookieStore`](http://ember-simple-auth.com/api/classes/CookieStore.html) if it is not. To customize the application store, define it in `app/session-stores/application.js`, extend a predefined session store and customize properties (as done for authenticators and authorizers as described above) or implement a fully custom store, e.g.:
 
@@ -175,7 +175,7 @@ export default CookieStore.extend({
 
 **Ember Simple Auth 1.0.0 will also automatically use the [`EphemeralStore`](http://ember-simple-auth.com/api/classes/EphemeralStore.html) when running tests** so there is no need anymore to configure that for the test environment (in fact the configuration setting has been removed).
 
-#### Update acceptance tests
+## Update acceptance tests
 
 While previous versions of Ember Simple Auth automatically injected the test helpers, version 1.0.0 requires them to be imported in the respective acceptance tests, e.g.:
 
@@ -195,10 +195,10 @@ one would now write
 authenticateSession(App);
 ```
 
-#### Update the application route if necessary
+## Update the application route if necessary
 
 The [`ApplicationRouteMixin`](http://ember-simple-auth.com/api/classes/ApplicationRouteMixin.html) in Ember Simple Auth 1.0.0 now only defines the two methods [`sessionAuthenticated`](http://ember-simple-auth.com/api/classes/ApplicationRouteMixin.html#method_sessionAuthenticated) and [`sessionInvalidated`](http://ember-simple-auth.com/api/classes/ApplicationRouteMixin.html#method_sessionInvalidated) as opposed to the previous four actions. If the application overrides any of these actions it would now have to override these methods.
 
-#### Wrapping up
+## Wrapping up
 
 I hope this gives a good overview of how upgrading an Ember application to Ember Simple Auth 1.0.0 works. **There is lots of documentation available** in the [README](https://github.com/simplabs/ember-simple-auth#readme) and the [API Docs](http://ember-simple-auth.com/api/index.html). You might also want to check out the [dummy application](https://github.com/simplabs/ember-simple-auth/tree/master/tests/dummy) in the github repo and the [intro video on the website](http://ember-simple-auth.com).

--- a/blog/_posts/2015-12-3-ember-cli-deploy-notifications.md
+++ b/blog/_posts/2015-12-3-ember-cli-deploy-notifications.md
@@ -18,7 +18,7 @@ Aaron Chambers and me gave detailed walkthroughs of the basic ideas behind the p
 
 The new release **encourages heavy use of [deploy plugins](http://emberobserver.com/categories/ember-cli-deploy-plugins) that all implement different parts of a deployment via [hooks](http://ember-cli-deploy.com/docs/v0.5.x/pipeline-hooks/)** and are themselves Ember CLI addons. What wasn’t available though was a plugin for notifying external webservices (e.g. an error-tracking service) during or after deployments so we decided to write one.
 
-#### Introducing ember-cli-deploy-notifications
+## Introducing ember-cli-deploy-notifications
 
 [ember-cli-deploy-notifications](https://github.com/simplabs/ember-cli-deploy-notifications) **makes it easy to notify external services** by adding them to a `notifications.services.<service>` property in `config/deploy.js`. First you have to install the addon:
 
@@ -51,13 +51,13 @@ module.exports = function(deployTarget) {
 
 Every time a new revision gets activated now by `ember-cli-deploy`, `ember-cli-deploy-notifications` will sent a `POST` request to the bugsnag service to notify it of the newly activated deployment revision.
 
-#### Customization
+## Customization
 
 We figured out that there are a lot of different internal and external services that users of ember-cli-deploy wanted to notify when executing the deploy pipeline. Thus **we wanted to make `ember-cli-deploy-notifications` as flexible as possible but still keep things easy and simple** for the most basic use cases.
 
 Based on that assumption we came up with the idea of _"preconfigured"_ and _"custom"_ services.
 
-##### Custom services
+### Custom services
 
 **Services need to be configured with values for `url`, `headers`, `method` and `body`**. We figured out that these are all the necessary parts of a webservice request that you need to be able to customize.
 
@@ -153,7 +153,7 @@ module.exports = function(deployTarget) {
 };
 ```
 
-##### Preconfigured services
+### Preconfigured services
 
 As we wanted to make it as easy as possible to get started with ember-cli-deploy-notifications **there are already some preconfigured services**.
 
@@ -181,7 +181,7 @@ module.exports = function(deployTarget) {
 
 There is also a preconfigured service for slack.
 
-#### Next Steps
+## Next Steps
 
 **We are excited to share this small ember-cli-deploy plugin with the ember community and would like to hear your feedback!** We are already using it in client projects and, though pretty small, found it to be a very useful addition to our deployment workflow.
 

--- a/blog/_posts/2016-03-04-ember-test-selectors.md
+++ b/blog/_posts/2016-03-04-ember-test-selectors.md
@@ -12,11 +12,11 @@ We just released [ember-test-selectors](https://github.com/simplabs/ember-test-s
 
 <!--break-->
 
-#### Why even use `data` attributes as test selectors?
+## Why even use `data` attributes as test selectors?
 
 Integration and acceptance tests usually __interact with and assert on the presence of certain elements__ in the markup that an application renders. These elements are identified using CSS selectors. Most projects use one of three approaches for CSS selectors in tests:
 
-##### Selectors based on HTML structure
+### Selectors based on HTML structure
 
 This approach simply selects elements by their position in the rendered HTML. For the following template:
 
@@ -29,7 +29,7 @@ This approach simply selects elements by their position in the rendered HTML. Fo
 
 one might select the post's title with the selector `'article h1'`. Of course this breaks when changing the `<h1>` to a `<h2>` while the functionality being tested is probably not affected by that change.
 
-##### Selectors based on CSS classes
+### Selectors based on CSS classes
 
 This approach selects elements by CSS classes. For the following template:
 
@@ -44,7 +44,7 @@ one might select the post title with the selector `'.post-title'`. This of cours
 
 Many projects use CSS classes with special prefixes that are only used for testing to overcome this problem like `'js-post-title'`. While that approach is definitely more stable it is often hard to maintain. Also it doesn't easily allow to encode additional information like e.g. the post's id.
 
-##### Selectors based on `data` attributes
+### Selectors based on `data` attributes
 
 This approach uses HTML 5 `data` attributes to select elements. For the following template:
 
@@ -73,7 +73,7 @@ one would select the post's title with the selector `*[data-test-selector="post-
 </article>
 ```
 
-#### Future Plans
+## Future Plans
 
 We have some future plans for ember-test-selectors to make working with data attributes as test selectors even more convenient:
 

--- a/blog/_posts/2016-12-06-out-of-the-box-fastboot-support-in-ember-simple-auth.md
+++ b/blog/_posts/2016-12-06-out-of-the-box-fastboot-support-in-ember-simple-auth.md
@@ -12,11 +12,11 @@ Ever since <a href="https://www.youtube.com/watch?v=o12-90Dm-Qs">FastBoot was fi
 
 <!--break-->
 
-#### Seamless Session Synchronization
+## Seamless Session Synchronization
 
 Ember Simple Auth 1.2 seamlessly <strong>synchronizes the session state between the browser and FastBoot server</strong>. When a user logs in to an Ember.js application and refreshes the page or comes back to the app later - triggering a request that's handled by the FastBoot server - Ember Simple Auth will send the session state along with that request, pick it up in the app instance that's running in the FastBoot server and <strong>make sure the Ember route is being loaded and rendered in the correct session context</strong>. If the session turns out to be invalid for some reason, the server will invalidate it and the user will be redirected to the login page via a proper HTTP redirect.
 
-#### Under the hood
+## Under the hood
 
 Ember Simple Auth has always had the concept of session stores that persist the session state so that it survives page reloads (or users leaving the app and coming back later). <strong>One of these session stores turned out to be the perfect fit for the aforementioned session syncing mechanism – the cookie session store</strong>. Browsers will automatically send cookies for a particular origin along with any request to that origin. Also, servers can modify cookies sent by the browser and include updates in the response that the browser will automatically pick up - effectively enabling bidirectional state synchronization.
 
@@ -41,7 +41,7 @@ export default Ember.Controller.extend({
 });
 ```
 
-#### Using Ember Simple Auth with FastBoot
+## Using Ember Simple Auth with FastBoot
 
 As most of Ember Simple Auth's support for FastBoot is based on the cookie session store, <strong>enabling FastBoot support is as easy as defining the application session store</strong> as:
 
@@ -54,7 +54,7 @@ export default Cookie.extend();
 
 If you're interested in learning more about the underlying concepts check out the <a href="https://www.youtube.com/watch?v=jcAgi7fpTw8&index=6&list=PL4eq2DPpyBbmrPasP06vK7cUkPUCNn_rW">talk about Authentication and Session Management in FastBoot</a> that I gave at <a href="http://embercamp.com">EmberCamp</a> in London in June.
 
-#### Other Changes and Fixes
+## Other Changes and Fixes
 
 Out-of-the-box support for FastBoot is likely the most prominent addition in this release but there are <strong>quite some other changes</strong> as well, including:
 
@@ -67,10 +67,10 @@ In addition to these changes, fixed issues include:
 * Routes like the login route can now be configured inline in routes using the respective mixins as opposed to `config/environment.js`, see <a href="https://github.com/simplabs/ember-simple-auth/pull/1041">#1041</a>
 * The cookie session store will now rewrite its cookies when any of its configurable properties (like cookie name) change, see <a href="https://github.com/simplabs/ember-simple-auth/pull/1056">#1056</a>
 
-#### A Community Effort
+## A Community Effort
 
 This certainly is one of the larger releases in Ember Simple Auth's history and <strong>a lot of people have helped to make it happen</strong>. We'd like to thank all of our (at the time of this writing) <a href="https://github.com/simplabs/ember-simple-auth/graphs/contributors">141 contributors</a>, with particular mention to <a href="https://github.com/stevenwu">Steven Wu</a>, <a href="https://github.com/kylemellander">Kyle Mellander</a>, <a href="https://github.com/arjansingh">Arjan Singh</a> and <a href="https://github.com/josemarluedke">Josemar Luedke</a> for awesome contributions to the Fastboot effort and ember-cookies.
 
-#### Try it!
+## Try it!
 
 As this is a beta release, <strong>there are probably some rough edges</strong>. We'd like everyone to try it, regardless of whether they're using Fastboot already or not and <strong>report bugs, outdated or bad documentation etc. on <a href="https://github.com/simplabs/ember-simple-auth/releases">github</a></strong>.

--- a/blog/_posts/2017-01-13-ember-test-selectors.md
+++ b/blog/_posts/2017-01-13-ember-test-selectors.md
@@ -22,7 +22,7 @@ features.
 
 <!--break-->
 
-#### Automatic binding of `data-test-*` properties
+## Automatic binding of `data-test-*` properties
 
 As you may know from our [previous blog post](http://simplabs.com/blog/2016/03/04/ember-test-selectors.html)
 on this topic, the goal of this addon is to let you use attributes starting
@@ -62,7 +62,7 @@ automatically appear on the `<div>` tag wrapping the component:
 </div>
 ```
 
-##### How we implemented this
+### How we implemented this
 
 Since we wanted to make this feature available on all components by default
 we had to `reopen()` the `Ember.Component` class, figure out the list of
@@ -82,12 +82,12 @@ initializer and utility function in there. Since both of those are part
 of our `addon` and `app` folders, which are included in your builds by
 default, we borrowed a ["trick"](https://github.com/ember-cli/ember-cli-chai/blob/master/index.js#L119-L123)
 from [ember-cli-chai](https://github.com/ember-cli/ember-cli-chai/) which
-only includes both folders if we are in [testing mode](#testing-in-production-mode). 
+only includes both folders if we are in [testing mode](#testing-in-production-mode).
 
 ```js
 module.exports = {
   // ...
-  
+
   treeForAddon: function() {
     // only include our "addon" folder in the build if we're testing
     if (this.app.tests) {
@@ -116,7 +116,7 @@ We have released `0.1.1` including this change and are now also warning you
 if you try to use `data-test-*` attributes on tagless components.
 
 
-#### Stripping out `data-test-*` attributes in templates
+## Stripping out `data-test-*` attributes in templates
 
 Our initial goal with this library was stripping our `data-test-*` attributes
 from HTML tags in your templates. In the previous section we implemented
@@ -126,14 +126,14 @@ these properties were not stripped from the template yet.
 To modify templates from within an addon our best bet was to use an
 <abbr title="Abstract Syntax Tree">AST</abbr> transform on the Handlebars
 AST, that we get from the template parser. This can be accomplished by
-registering a Handlebars AST plugin in the 
+registering a Handlebars AST plugin in the
 [`setupPreprocessorRegistry()`](https://ember-cli.com/api/classes/Addon.html#method_setupPreprocessorRegistry)
 hook of the addon:
 
 ```js
 module.exports = {
   // ...
-  
+
   setupPreprocessorRegistry: function(type, registry) {
     if (type === 'parent' && !this.app.tests) {
       registry.add('htmlbars-ast-plugin', {
@@ -167,7 +167,7 @@ module.exports = class {
 
     return ast;
   }
-}; 
+};
 ```
 
 You can try out what this transform does in the
@@ -190,7 +190,7 @@ transform code, you will notice that the `data-test-comment-id=comment.id` part
 of the `some-component` invocation is now gone.
 
 
-#### Stripping out `data-test-*` properties in JS files
+## Stripping out `data-test-*` properties in JS files
 
 While one way of assigning data attributes to a component is in the template,
 data attributes can also be defined as properties on the component class.
@@ -248,7 +248,7 @@ addon:
 ```js
 module.exports = {
   // ...
-  
+
   included: function(app) {
     this._super.included.apply(this, arguments);
 
@@ -266,7 +266,7 @@ module.exports = {
 ```
 
 
-#### Testing in `production` mode
+## Testing in `production` mode
 
 In our previous releases we had offered an `environments` option to let you
 choose when to strip attributes and when to keep them in the templates. The
@@ -304,7 +304,7 @@ Note that using the `environments` option still works, but is deprecated and
 will be removed by the time we release `1.0.0`.
 
 
-#### Simplified `testSelector()` import
+## Simplified `testSelector()` import
 
 The `testSelector()` helper function can be used to simplify building the
 CSS/jQuery selector strings used for `find()` or `this.$()` in your tests.

--- a/blog/_posts/2017-02-01-class-based-computed-properties.md
+++ b/blog/_posts/2017-02-01-class-based-computed-properties.md
@@ -12,7 +12,7 @@ We think Computed Properties in Ember are awesome. We also think they [are in ma
 
 <!--break-->
 
-#### Computed Properties and Computed Property Macros
+## Computed Properties and Computed Property Macros
 
 Computed Properties are among the first things developers new to Ember learn. They are a great way of defining dependencies between data points in the application and __ensuring the UI stays consistent as these data points change__.
 
@@ -24,7 +24,7 @@ isActive: Ember.computed.equal('state', 'isActive')
 
 There are addons that provide even more macros for common use cases like [ember-cpm](https://github.com/cibernox/ember-cpm) or [ember-awesome-macros](https://github.com/kellyselden/ember-awesome-macros).
 
-#### Where Computed Property Macros fall short today
+## Where Computed Property Macros fall short today
 
 __Computed Properties are very similar to template helpers__ in the way that both are [pure functions](https://en.wikipedia.org/wiki/Pure_function) that can only depend on their inputs. While a template helpers receives its inputs as arguments, __Computed Properties define their inputs as dependent keys__.
 
@@ -48,7 +48,7 @@ and because the [`filter-by` helper is a Class based helper](https://github.com/
 
 With Computed Properties __it is not currently possible to implement something like this__ (at least not as a reusable macro).
 
-#### Enter Class based Computed Properties
+## Enter Class based Computed Properties
 
 With the Class based Computed Properties that [ember-classy-computed](https://github.com/simplabs/ember-classy-computed) introduces it is __actually possible now to implement something like the above mentioned `filterByProperty` macro__. The computed property returned by that macro can now correctly be invalidated when any of the user's `isActive`, `isBlocked` etc. properties change although it is not actually possible to know what these properties might be upfront. This __allows keeping the filtering logic in JavaScript as opposed to in the template__ when using a Class based template helper:
 
@@ -106,6 +106,6 @@ export default ClassBasedComputedProperty.property(DynamicFilterByComputed);
 
 Comparing this code to the implementation of the [`filter-by` helper](https://github.com/DockYard/ember-composable-helpers/blob/master/addon/helpers/filter-by.js) mentioned above you will recognize that both are almost identical. This illustrates very well what Class based Computed Properties are: a way to __use the same mechanisms that are already established for Class based template helpers for Computed Properties__ as well.
 
-#### Notice
+## Notice
 
 __[ember-classy-computed](https://github.com/simplabs/ember-classy-computed) is currently at a very early stage__ and we haven't thoroughly tested the implementation just yet. We have also not done any benchmarking to get a better understanding of what the performance implications are. That is to say, __while we encourage everyone to try this out, be aware you're currently doing so at your own risk__ as this is most likely not production ready (yet). We have the feeling though that this will be a valuable addition to Computed Properties in the future and can close the gap that currently exists between Computed Properties and template helpers.

--- a/blog/_posts/2017-02-13-npm-libs-in-ember-cli.md
+++ b/blog/_posts/2017-02-13-npm-libs-in-ember-cli.md
@@ -19,7 +19,7 @@ will explain how we can do that and what options are available to us.
 
 <!--break-->
 
-#### Status Quo
+## Status Quo
 
 The way to import Bower libraries into your app consists of three major steps.
 First we will have to install the library. We will use the popular
@@ -85,7 +85,7 @@ app.import('vendor/shims/moment.js');
 We are now able to use `import moment from 'moment';` in our Ember code.
 
 
-#### App vs. Addon
+## App vs. Addon
 
 The above instructions work great for apps, but what about addons? The
 `ember-cli-build.js` file for addons is only relevant for building the dummy
@@ -160,7 +160,7 @@ method returns a `Promise` we have to return it from the `afterInstall` hook
 to make sure that Ember CLI waits for the installation to finish.
 
 
-#### npm vs. Bower
+## npm vs. Bower
 
 <blockquote class="twitter-tweet" data-lang="de"><p lang="en" dir="ltr">&quot;What&#39;s bower?&quot;<br>&quot;A package manager, install it with npm.&quot;<br>&quot;What&#39;s npm?&quot;<br>&quot;A package manager, you can install it with brew&quot;<br>&quot;What&#39;s brew?&quot;<br>...</p>&mdash; Stefan Baumgartner (@ddprrt) <a href="https://twitter.com/ddprrt/status/529909875347030016">5. November 2014</a></blockquote>
 
@@ -255,7 +255,7 @@ Now that we've imported the `moment.js` file into our `vendor` tree we can
 finally `import()` it in the `included()` hook and everything works again.
 
 
-#### npm dependencies
+## npm dependencies
 
 As we are using npm now we can also take advantage of the way that npm
 resolves dependencies. That means instead of using a blueprint to install
@@ -297,7 +297,7 @@ though which makes the code a little more complicated compared to our
 simplified example here.
 
 
-#### App vs. Addon again
+## App vs. Addon again
 
 Now that we have converted our `ember-moment` addon to use npm instead of
 Bower, how could we do the same if we wanted to use Moment.js in our app
@@ -314,7 +314,7 @@ ember generate in-repo-addon ember-moment
 and use the same code as above inside the `lib/ember-moment/index.js` file.
 
 
-#### Next: CommonJS and ES6 modules 
+## Next: CommonJS and ES6 modules 
 
 Things get a little more complicated when you want to use npm packages that
 are not distributed in a prebuilt form like Moment.js. If they instead export

--- a/blog/_posts/2017-03-21-on-computed-properties-vs-helpers.md
+++ b/blog/_posts/2017-03-21-on-computed-properties-vs-helpers.md
@@ -19,7 +19,7 @@ what the drawbacks are.
 
 <!--break-->
 
-#### Computed Properties
+## Computed Properties
 
 Computed Properties allow defining properties as functions of other
 properties. Ember automatically re-evaluates computed properties (lazily) when
@@ -52,7 +52,7 @@ defined on the `user` here):
 </p>
 {% endraw %}```
 
-#### Template Helpers
+## Template Helpers
 
 The above example __could just as easily be implemented using a template
 helper__. Instead of defining the `isSenior` property with its dependents
@@ -75,7 +75,7 @@ and move the comparison into the template:
 </p>
 {% endraw %}```
 
-#### What's the difference?
+## What's the difference?
 
 Both alternatives are obviously very similar - both compare the user's `age`
 property with a comparison value and depending on the outcome of that
@@ -89,7 +89,7 @@ This might not seem like a big thing but there actually are some differences
 between the two alternatives that have consequences on certain aspects of the
 application.
 
-##### Separation vs. Unification
+### Separation vs. Unification
 
 The main difference is that with the computed property solution, the logic and
 its internals are separated from the template. The __logic lives in the
@@ -137,7 +137,7 @@ Instead of hiding this complexity behind a named interface all of it is right
 there in the template and cannot be ignored as it can be when using a computed
 property.
 
-##### Testability
+### Testability
 
 Another consequence of __moving logic into the template is that the logic
 itself becomes harder to test__. While logic that lives in the template context
@@ -159,7 +159,7 @@ again leads to a few other consequences:
   template requires the full context for that template to be set up which might
   include elements that are unrelated to the current test case.
 
-##### Helpers don't always work as expected
+### Helpers don't always work as expected
 
 One of the main reasons that we hear why people prefer template helpers over
 computed properties is the fact that computed properties need to list their
@@ -197,7 +197,7 @@ property on any of the arguments changes__. In this case changes of the user's
 `age` property would go unnoticed and the DOM would get out of sync with the
 underlying data.
 
-##### Performance
+### Performance
 
 In general, __performance should be more or less on par for computed properties
 and template helpers__ in comparable scenarios. There's one slight difference
@@ -231,7 +231,7 @@ helper. If calculating `propB` is a costly operation that is obviously not
 desirable but something that cannot actually be prevented with template
 helpers.
 
-#### Pick one
+## Pick one
 
 As shown above there are many cases in which either computed properties or
 template helpers can be used to implement the same functionality. There are
@@ -258,7 +258,7 @@ making computed properties easier accessible and more powerful recently. Check
 out
 [Kelly's talk on computed properties he gave at the recent Ember.js SF meetup](http://slides.com/kellyselden/the-world-of-ember-macros-and-how-to-create-your-own-2#/43).
 
-##### Pure Functions
+### Pure Functions
 
 One thing I hear a lot is that template helpers are better than computed
 properties because helpers are (supposed to be) pure functions. While __pure
@@ -275,7 +275,7 @@ also class based helpers whose whole purpose is to enable template helpers that
 can depend on global state and thus are not pure functions (and the same
 concept exists for computed properties with ember-classy-computed now).
 
-##### Original concerns of the template layer
+### Original concerns of the template layer
 
 The intention of this post is not to say template helpers are bad and computed
 properties should be used for everything. That would be a pretty ignorant
@@ -286,7 +286,7 @@ this kind of functionality which is usually only a small part part of any
 application though - we often only have a few helpers defined even in pretty
 big and involved applications.
 
-##### Missing a property context
+### Missing a property context
 
 There is one slightly more evolved scenario where computed properties cannot
 easily be used instead of template helpers to achieve the same functionality.
@@ -339,7 +339,7 @@ collection then:
 This pattern - __defining a wrapper context that combines two or more other
 contexts__ - should work in similar scenarios as well.
 
-#### Conclusion
+## Conclusion
 
 Computed properties and template helpers are both valuable parts of the Ember
 framework and __both have their use cases__. Being aware of which one is best

--- a/blog/_posts/2017-08-28-creating-web-components-with-glimmer.md
+++ b/blog/_posts/2017-08-28-creating-web-components-with-glimmer.md
@@ -14,7 +14,7 @@ At [this year's EmberConf the Ember core team officially announced](https://yout
 
 In addition to building standalone Glimmer applications, the library allows the creation of components **according to the Custom Elements v1 specification**, making it possible to build native web components which can be reused across all kinds of front end stacks.
 
-#### What's in the Custom Elements v1 specification
+## What's in the Custom Elements v1 specification
 
 The **Custom Elements spec** describes a technology which is - alongside of HTML templates, Shadow DOM and HTML imports - an integral part of the [current Web Component specification](https://www.w3.org/wiki/WebComponents/).
 The Custom Elements spec describes capabilities for creating custom HTML elements which can be used just like native HTML elements: `<my-customelement>`.
@@ -66,7 +66,7 @@ Third, using web components is very easy as only **knowledge of the HTML markup 
 
 Let’s now dive into how we can create our own custom elements using Glimmer.
 
-#### Glimmer Web Component Example: A Reusable Open Street Map
+## Glimmer Web Component Example: A Reusable Open Street Map
 
 A common use case for a reusable component is the interactive view of a street map which usually can be embedded into websites and apps quickly with some configuration using services like the Google Maps API or Leaflet. What if we could create our own custom element that can simply be shared and reused using HTML alone?
 
@@ -77,7 +77,7 @@ In the following we will **create a simple street map** based on [Leaflet.js](ht
 
 You can also check out the project on [Github](https://github.com/jessica-jordan/glimmer-map).
 
-##### Starting a new Glimmer Web Component Project
+### Starting a new Glimmer Web Component Project
 
 To get started with an initial, running project setup, we will be using [Ember CLI](https://ember-cli.com/) for scaffolding and configuration of our Glimmer app. From `ember-cli@2.14.0` onwards, we can get started to create a Glimmer-backed web component by using the `ember new` generator, the [respective glimmer blueprint](https://github.com/glimmerjs/glimmer-blueprint) and the `--web-component` flag:
 
@@ -142,7 +142,7 @@ The final line makes use of the `CustomElementRegistry`'s `define` method to reg
 
 So, after having that quick dive into how our component is spun up in Glimmer, let’s get started developing it:
 
-##### Developing a Web Component with Glimmer's API
+### Developing a Web Component with Glimmer's API
 
 So far the blueprint for our main component module has already been setup by Ember CLI's generator.
 The class used for generating our `glimmer-map` component is now defined in `src/ui/components/glimmer-map/component.ts`:
@@ -296,7 +296,7 @@ export default class GlimmerMap extends Component {
 With this we are already done and can get started with distributing our component.
 
 
-#### Reusing Glimmer components as custom elements
+## Reusing Glimmer components as custom elements
 
 As mentioned in the beginning of this article, the current blueprint for Glimmer web components comes with a wrapper for being able to package and reuse our Glimmer components as custom elements. To **create the assets** needed for reusage, let’s build those like we are already used to when building Ember apps:
 
@@ -333,6 +333,6 @@ And finally, we can see our Glimmer-based street map being rendered just as seen
 <script src="/assets/posts/2017-08-30-creating-web-components-with-glimmer/glimmer-map.js"></script>
 
 
-#### And the Glimmer Component story is not over yet
+## And the Glimmer Component story is not over yet
 
 Many more interesting developments are upcoming around Glimmer and the [glimmer-component](https://github.com/glimmerjs/glimmer-component) and [glimmer-web-component](https://github.com/glimmerjs/glimmer-web-component) modules specifically. For further reading, please check out another great discussion about the implementation of upcoming APIs according to the web component specification on [here](https://github.com/glimmerjs/glimmer-web-component/issues/19), check out [my talk on current state of web components and Glimmer’s place in it](https://www.youtube.com/watch?v=OzFgDBJcWuU) and stay tuned for our future blog post on testing Glimmer components.

--- a/blog/_posts/2017-10-24-high-level-assertions-with-qunit-dom.md
+++ b/blog/_posts/2017-10-24-high-level-assertions-with-qunit-dom.md
@@ -34,7 +34,7 @@ From the template above you can see that we have essentially two states that
 we need to test: one with and one without a `username` property being set.
 
 
-#### Status Quo
+## Status Quo
 
 An acceptance test for such a template could look roughly like this:
 
@@ -59,10 +59,10 @@ test('frontpage should be welcoming', function(assert) {
 First we will `visit` the index page `andThen` check if the welcome message
 matches our expectation. Next we will `fill` an `<input>` field with a custom
 `username` like "John Doe" `andThen` finally we will check if the welcome
-message was updated correctly. 
+message was updated correctly.
 
 
-#### Promise chains
+## Promise chains
 
 If you've used [Ember.js](https://emberjs.com/) for some time you will probably
 be used to the `andThen` blocks above. One of the reasons for them to exist is
@@ -94,7 +94,7 @@ reasons why a lot of Ember developers still prefer the `andThen` blocks over
 using `Promise` chains.
 
 
-#### async/await
+## async/await
 
 In one of the recent changes to the JavaScript language (or ECMAScript to be
 precise) two new keywords were introduced to simplify dealing with `Promises`:
@@ -134,7 +134,7 @@ hard to read, and it takes a short while to figure out what the intent of that
 assertion was.
 
 
-#### chai and chai-dom
+## chai and chai-dom
 
 If you're using [Mocha](https://mochajs.org/) and [Chai](http://chaijs.com/)
 to write your tests, you are already used to more readable assertions since
@@ -161,7 +161,7 @@ restart Ember CLI and now you can use the additional assertions that `chai-dom`
 provides.
 
 
-#### qunit-dom
+## qunit-dom
 
 While `ember-cli-chai` also works with QUnit it is essentially just a hack
 and not really supported properly by QUnit or Chai so be careful if you're
@@ -204,7 +204,7 @@ You can find examples of what assertions are available in the [README](https://g
 of the project and even more information in the [API reference](https://github.com/simplabs/qunit-dom/blob/master/API.md).
 
 
-#### qunit-dom-codemod
+## qunit-dom-codemod
 
 During the EmberFest conference we realized that while a lot of people would
 probably appreciate what we had built, nobody would go over their thousands of
@@ -231,7 +231,7 @@ jscodeshift -t https://raw.githubusercontent.com/simplabs/qunit-dom-codemod/mast
 ```
 
 
-#### Conclusion
+## Conclusion
 
 Moving the tests to `async/await` and `qunit-dom` makes them a lot more
 readable and easier to understand for new developers and is just a few

--- a/blog/_posts/2017-11-17-ember-test-selectors-road-to-1-0.md
+++ b/blog/_posts/2017-11-17-ember-test-selectors-road-to-1-0.md
@@ -17,7 +17,7 @@ before we feel comfortable promoting the addon to v1.0.0.
 
 <!--break-->
 
-#### v0.2.0: `data-test-*` attributes without values
+## v0.2.0: `data-test-*` attributes without values
 
 In HTML it is possible to add attributes to an element that don't have a value:
 
@@ -42,7 +42,7 @@ transform which transforms all such valueless `data-test-foo` instances to
 `data-test-foo=true` by default.
 
 While that seems like a convenient thing, it has drawbacks and does not always
-work as expected, as you can see in the following template: 
+work as expected, as you can see in the following template:
 
 ```handlebars
 {% raw %}{{! works }}
@@ -68,7 +68,7 @@ We will deprecate the usage of valueless `data-test-*` attributes on components
 in an upcoming release and remove the transform completely for the v1.0.0 release.
 
 
-#### v0.3.0: Support for Babel 6
+## v0.3.0: Support for Babel 6
 
 This year (2017) the Ember ecosystem finally moved from Babel 5 to Babel 6,
 which happened mostly without issues for app developers as it was just
@@ -93,7 +93,7 @@ different Babel transforms into the build pipeline so that we can support both
 major Babel versions with the same addon.
 
 
-#### v0.3.4: Support for test-selectors in nested addons
+## v0.3.4: Support for test-selectors in nested addons
 
 In April we were notified by [Luke Melia](https://github.com/lukemelia) that
 test-selectors in templates in an addon that he extracted were stripped
@@ -107,7 +107,7 @@ now possible to also use `ember-test-selectors` as a nested addon dependency
 and rely on correct test-selector stripping depending on the build environment.
 
 
-#### v0.3.7: Deprecation of the `testSelector` helper function
+## v0.3.7: Deprecation of the `testSelector` helper function
 
 A few weeks later [Kelly Selden](https://github.com/kellyselden) triggered a
 [conversation](https://github.com/simplabs/ember-test-selectors/issues/121)
@@ -141,7 +141,7 @@ that might be able to save you a few minutes or hours by converting the code
 for you automatically.
 
 
-#### v0.3.8: Support for Ember 1.11 and 1.12 
+## v0.3.8: Support for Ember 1.11 and 1.12 
 
 Only a few weeks ago [Chris Garrett](https://github.com/pzuraq/), better known
 as @pzuraq, approached us about supporting Ember 1.11 and 1.12 in
@@ -222,7 +222,7 @@ able to adjust our range of supported Ember versions all the way down to
 Ember 1.11.
 
 
-#### Conclusion
+## Conclusion
 
 A lot of things have happened on the project this year and we will continue to
 iterate forward on this. One exciting enhancement that we are looking into is

--- a/blog/_posts/2017-12-04-enginification.md
+++ b/blog/_posts/2017-12-04-enginification.md
@@ -16,7 +16,7 @@ we ran into along the way and how we solved them. So let's dive right in!
 
 <!--break-->
 
-#### Status quo
+## Status quo
 
 The app is a mobile ticket counter for rail tickets. The basic flow through the
 app is as follows: a user enters an departure and arrival station and specifies
@@ -49,7 +49,7 @@ booking flow on application startup. All of that code can be loaded lazily once
 the user proceeds to the next step by actually initiating a search or even
 while they are filling out the login form.
 
-#### Extract common functionality used in app into an addon
+## Extract common functionality used in app into an addon
 
 One fundamental design principle of engines is that they are isolated from the
 hosting app. It is possible to pass in services from the hosting app but apart
@@ -144,7 +144,7 @@ as common style definitions moved into the addon. The next step is to finally
 create the engine, which will contain most of the application code.
 
 
-#### Move functionality into engine
+## Move functionality into engine
 
 An engine is basically an Ember.js addon. Since the engine won't be reused
 within another application, we decided to go with the in-repo solution for the
@@ -230,7 +230,7 @@ So now we have moved all the non-essential logic not needed at the beginning of
 the app into an in-repo engine. As a next optimization, let's make use of a
 nifty feature of Ember Engines…
 
-#### Make it lazy
+## Make it lazy
 
 After we extracted the `common` addon and the `booking-flow` engine, we are
 ready to load the engine lazily to actually reduce the amount of JavaScript
@@ -271,7 +271,7 @@ as well:
 | `booking-flow.css`       |                                | 45.24 KB (7.97 KB gzipped)   |
 |--------------------------|--------------------------------|------------------------------|
 
-#### Conclusion
+## Conclusion
 
 We created an in-repo addon for commonly used components, helpers and style
 definitions. After that, everything which is not needed for the initial search

--- a/blog/_posts/2018-01-24-ember-freestyle.md
+++ b/blog/_posts/2018-01-24-ember-freestyle.md
@@ -23,7 +23,7 @@ in isolation.
 <!--break-->
 
 
-#### Component Playgrounds
+## Component Playgrounds
 
 You might be wondering "Why would would I need something like this? I can just
 test my components in the app!" and you're right. But imagine building a
@@ -48,7 +48,7 @@ by Dominic Nguyen that explains the benefits very well.
 [ui-component-explorers]: https://blog.hichroma.com/the-crucial-tool-for-modern-frontend-engineers-fb849b06187a
 
 
-#### Installing `ember-freestyle`
+## Installing `ember-freestyle`
 
 Installing and configuring `ember-freestyle` correctly is unfortunately a
 little complicated right now so if you want to take a look at the final
@@ -67,7 +67,7 @@ website:
 - `ember install ember-freestyle`
 - Add `this.route('freestyle');` to the `app/router.js` file
 
-##### Adjusting the `application` template
+### Adjusting the `application` template
 
 If you try this in a fresh new Ember app, run the development server using
 `ember serve` and visit <http://localhost:4200/freestyle> you will notice the
@@ -95,7 +95,7 @@ condition:
 `onFreestyleRoute` is a property on the `application` controller that will be
 set to `true` once we visit the `/freestyle` route and and back to `false`
 once we leave it again. This can be implemented in the `app/routes/freestyle.js`
-file, and since that does not exist yet, we can generate it using 
+file, and since that does not exist yet, we can generate it using
 `ember generate route freestyle` (choose not to overwrite the existing
 template!) and then adjusting it like this:
 
@@ -116,7 +116,7 @@ export default Route.extend({
 If you check `/freestyle` again you should see that now the only thing that is
 displayed is the `ember-freestyle` guide. 🎉
 
-##### Removing `ember-freestyle` from the production build
+### Removing `ember-freestyle` from the production build
 
 Once you try to ship this to production you might notice another issue: your
 asset size has increased significantly, so it seems that `ember-freestyle` is
@@ -135,7 +135,7 @@ module.exports = function(defaults) {
       blacklist: pluginsToBlacklist
     }
   });
-  
+
   return app.toTree();
 };
 ```
@@ -191,7 +191,7 @@ is good enough and we can finally focus on putting content into our new
 component playground! 🎉
 
 
-#### Using `ember-freestyle`
+## Using `ember-freestyle`
 
 The good news is that **using** `ember-freestyle` is much easier than setting
 it up correctly!

--- a/blog/_posts/2018-02-14-handling-webhooks-in-phoenix.md
+++ b/blog/_posts/2018-02-14-handling-webhooks-in-phoenix.md
@@ -11,7 +11,7 @@ I recently had to implement a controller, which took care of receiving and proce
 
 <!--break-->
 
-#### tl;dr
+## tl;dr
 
 Use `forward` on `MyApp.Router` to forward the request (`%Conn{}`) to a custom plug (`MyApp.Plugs.WebhookShunt`) which maps `%Conn{}` to a route (and thus a controller action) defined on `MyApp.WebhookRouter`, based on the data in the request body.
 
@@ -19,7 +19,7 @@ I.e.,
 
 `%Conn{}` -> `Router` -> `WebhookShunt` -> `WebhookRouter` -> `WebhookController`
 
-#### lv;e (long version; enjoy!)
+## lv;e (long version; enjoy!)
 
 Let's restate the problem:
 
@@ -58,7 +58,7 @@ It took three refactors to get to a satisfactory solution. I will, however, expl
 2. Plug called from endpoint
 3. Plug and second router
 
-#### Multiple function clauses
+## Multiple function clauses
 
 Let's start separating the computation into smaller fragments by moving the pattern matching from the `case` statement to the function's definition. We are still using only one route and only one controller action, but we write multiple clauses of that function to match a certain value of the `event` key in the params.
 
@@ -73,7 +73,7 @@ def hook(conn, %{"event" => "division"} = params), do: divide(params)
 
 The request payload will match the clauses for the `hook/2` function and execute different functions depending on what `event` was passed in. This refactor is a step in the right direction, but it still doesn't fit well with the idea that a controller action should handle one specific request. The router serves no real purpose, as there is still only one route, and our code has the potential to get very messy.
 
-#### Shunting incoming connections
+## Shunting incoming connections
 
 What if we could interfere with the incoming webhook before it hits the router? We could then modify the path of the request depending on the params, match a route and execute the corresponding controller action.
 
@@ -160,7 +160,7 @@ This strategy isn't great, however. We are placing code in the endpoint, which w
 
 Interfering with the request to map it to a route at this point would be unidiomatic Phoenix. It would also make the app slower, and harder to maintain and debug.
 
-#### Forwarding conn to the shunt and calling another router
+## Forwarding conn to the shunt and calling another router
 
 Instead of intercepting the `%Conn{}` in the endpoint, we could forward it from the application's main router to the `WebhookShunt`, modify it and call a second router whose sole purpose would be to handle the incoming webhooks.
 

--- a/blog/_posts/2018-05-30-a-little-encouragement-goes-a-long-way-in-2018.md
+++ b/blog/_posts/2018-05-30-a-little-encouragement-goes-a-long-way-in-2018.md
@@ -38,7 +38,7 @@ I'd love both Ember's core characteristics and its cutting-edge features to be u
 I believe Ember's bottleneck for adoption and community growth isn't about technical aspects, it's about visibility and outreach.
 
 
-### A Gap in Visibility
+## A Gap in Visibility
 
 As any other open-source project, the development of Ember lives and thrives through the time and amount of work that is being put into it. In contrast to some other major JavaScript frameworks, Ember is not being backed up by one single major company - neither financially nor contribution-wise.
 Instead Ember's user base is diverse in its professional backgrounds and interests. And this makes Ember more independent and free to evolve according to real developer needs instead of company requirements which is an amazing advantage.
@@ -57,7 +57,7 @@ Ember is still a somewhat hidden gem ([8](http://blog.agilityworks.co.uk/our-blo
 Of course, there are those who already have a clear vision in mind right now and who are making consistent efforts to create online tutorials, write blog posts, give talks, send pull requests to the Ember.js website repository ([10](https://github.com/emberjs/website/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged)) and much more without any prompting.
 What I'd wish for Ember's 2018 Roadmap though is to find ways to **lower the entry barriers** for newcomers to get started in their attempt to advocate Ember and to be creative on how to **encourage a sense of empowerment** in the wider community regarding outreach efforts.
 
-### Closing the Visibility Gap
+## Closing the Visibility Gap
 
 I believe one of the biggest actions that could be taken to make contribution to anything that is outreach-related easier is by increasing the discoverability of discussion channels and already ongoing Github projects and related issues. On the Ember Community Slack chat, most notably the [#st-website](https://embercommunity.slack.com/messages/CAHEZTMBK/), [#wb-marketing](https://embercommunity.slack.com/messages/C36ETE3DK/) and [#topic-talks](https://embercommunity.slack.com/messages/C9RSE508J/) channels are great first points of contact for anyone who was interested in helping out with marketing efforts to find something to help out with. I believe making these channels more discoverable for new developers, e.g. from having a noticeable call-to-action on the Ember.js website ([11](https://emberjs.com/)) or a dedicated, search-engine optimized landing page already goes a long way.
 
@@ -70,7 +70,7 @@ In fact, the Women Helping Women Program ([18](https://emberwomen.com/)) has alr
 Encouraging even larger parts of the community to speak and highlight Ember allows many great talks to come: I'd love to see so many of the cool and new things that recently landed or are just on their way to land in Ember highlighted: This year's EmberConf Opening Keynote by Ember Core Team members Yehuda Katz & Tom Dale ([19](https://www.youtube.com/watch?v=NhtpXs0ZtUc)) at EmberConf is among others ([20](https://twitter.com/skillsmatter/status/984752827904950273), [21](https://www.youtube.com/watch?v=8D-O4cSteRk)) an inspiring example of this type of advocacy for Ember.
 I feel that beyond that there is a quite urgent need for "introduction" type talks which are appealing to developers of any experience level and any (JavaScript) background. Features of Ember that might have already been around for a while and which have become obvious to the regular Ember user still need to be highlighted to audiences who are not that familiar with Ember yet on a regular basis. Therefore I'm confident supporting speakers in promoting their own "Why Ember" type of presentations to events outside of the Ember ecosystem is one of the most useful measures we as a community can take to advocate Ember as a framework.
 
-### Wishing Upon a Vocal Community
+## Wishing Upon a Vocal Community
 
 These are some of the ideas that came to my mind when thinking about what I'd wish for Ember in 2018. I'd like to see Ember's community grow even further and I believe one major way to achieve this goal is by improving its visibility - the degree by which it is seen by those who are already becoming part of the community and also by those outside of it.
 

--- a/blog/_posts/2018-06-05-ember-component-playground.md
+++ b/blog/_posts/2018-06-05-ember-component-playground.md
@@ -19,7 +19,7 @@ discovering new components and showing them in the playground.
 <!--break-->
 
 
-#### Status Quo
+## Status Quo
 
 You may remember that last time we closed with our `freestyle.hbs` template
 looking roughly like this:
@@ -48,7 +48,7 @@ If we now start to add subsections for all the components in our app you can
 imagine that our `freestyle.hbs` would soon grow out of proportion. As with any
 other template in Ember.js we can tackle that problem by extracting components.
 
-In this case we can create a 
+In this case we can create a
 `lib/freestyle/app/templates/components/usage/styled-button.hbs` file that
 looks like this:  
 
@@ -78,7 +78,7 @@ But there is always a way to improve the current situation so let's play around
 a little...
 
 
-#### Autodiscovery
+## Autodiscovery
 
 What if we could ask Ember what "usage components" it knows about and then
 render them automatically in the `freestyle.hbs` template...? 🤔
@@ -165,7 +165,7 @@ If we visit the `/freestyle` route now, we should see a list of all our
 them.
 
 
-#### Summary
+## Summary
 
 Just like Ember.js is able to automatically find components, models, and other
 modules when you put them in the right folder, our component playground can

--- a/blog/_posts/2018-06-11-actix.md
+++ b/blog/_posts/2018-06-11-actix.md
@@ -22,7 +22,7 @@ blog post is a short intro into what we've discovered so far.
 <!--break-->
 
 
-#### Rust
+## Rust
 
 What is Rust?
 
@@ -60,7 +60,7 @@ How to get started? Follow the instructions at <https://rustup.rs/>
 [Wikipedia]: https://en.wikipedia.org/wiki/Rust
 
 
-#### Actors
+## Actors
 
 The "actor model" is the main primitive that powers the [Erlang] programming
 language and its descendant, [Elixir]. It describes a programming model that
@@ -105,7 +105,7 @@ we will have a closer look at now.
 [Erlang]: https://www.erlang.org/
 
 
-#### actix
+## actix
 
 [actix] is the low-level actor framework that powers [actix-web], a
 [high-performance](https://www.techempower.com/benchmarks/#section=data-r15&hw=ph&test=plaintext)
@@ -181,7 +181,7 @@ message.
 [actix-web]: https://github.com/actix/actix-web
 
 
-##### Running our `CounterActor`
+### Running our `CounterActor`
 
 While building the actor was relatively easy, running it is unfortunately still
 a little hard while Rust figures out its version of `async/await` (see
@@ -261,7 +261,7 @@ actors have finished running.
 [`Arbiter`]: https://actix.rs/actix/actix/struct.Arbiter.html
 
 
-#### Summary
+## Summary
 
 This blog post covered some of the basic concepts of writing actors using the
 actix framework for Rust. In a follow-up post we will look into writing a small

--- a/blog/_posts/2018-06-18-intl-polyfill-loading.md
+++ b/blog/_posts/2018-06-18-intl-polyfill-loading.md
@@ -22,7 +22,7 @@ and the associated data.
 <!--break-->
 
 
-#### Loading Translations
+## Loading Translations
 
 Let's first start with how translations are loaded in ember-intl. By default
 ember-intl will bundle all translations into your `app.js` file, which works
@@ -73,7 +73,7 @@ export default IntlService.extend({
 });
 ```
 
-Now we can simplify our code in the `application` route to this: 
+Now we can simplify our code in the `application` route to this:
 
 ```js
 async beforeModel() {
@@ -90,7 +90,7 @@ browser we should see the app making an AJAX request for the translations
 before it starts. 🎉
 
 
-#### Loading the Intl.js polyfill
+## Loading the Intl.js polyfill
 
 As mentioned in the intro [some browsers](https://caniuse.com/#feat=internationalization)
 need a polyfill for the new `Intl` APIs. ember-intl makes this easy for us as
@@ -146,7 +146,7 @@ and then use it in the `application` route before downloading any translations:
 ```js
 async beforeModel() {
   let locale = figureOutLocale(); // e.g. "de" or "fr-ch"
-  
+
   if (!window.Intl) {
     await this.get('intl').loadPolyfill();
   }
@@ -166,7 +166,7 @@ Unfortunately we're not done yet. While we have loaded the polyfill correctly,
 we also need to load the locale data for the polyfill depending on what locale
 the user chooses. For that reason we implement two more methods on the `intl`
 service:
- 
+
 - a `loadPolyfillData()` method
 - a `loadLocale()` method that combines `loadTranslations()` and `loadPolyfillData()`
 
@@ -179,17 +179,17 @@ export default IntlService.extend({
     let response = await fetch(`/translations/${locale}.json`);
     let translations = await response.json();
     this.addTranslations(locale, translations);
-  }, 
+  },
 
   async loadPolyfill(locale) {
     await loadJS('/assets/intl/intl.min.js');
-  }, 
+  },
 
-  async loadPolyfillData(locale) { 
+  async loadPolyfillData(locale) {
     await loadJS(`/assets/intl/locales/${locale}.js`);
   },
 
-  async loadLocale(locale) { 
+  async loadLocale(locale) {
     let promises = [this.loadTranslations(locale)];
 
     if (window.Intl === window.IntlPolyfill) {
@@ -210,7 +210,7 @@ information for the Intl.js polyfill on how to format dates, time and numbers
 and several other things that are handled in a locale-aware way in the Intl API.
 
 
-#### Summary
+## Summary
 
 In this blog post we have learned how to reduce our bundle size in several ways
 when using the [ember-intl] addon. We are now loading only the code and data

--- a/blog/_posts/2018-06-27-actix-tcp-client.md
+++ b/blog/_posts/2018-06-27-actix-tcp-client.md
@@ -23,7 +23,7 @@ breaking changes. The content of this blog post is conceptually still relevant
 though and the code examples should work fine if you make sure to use the
 correct dependency versions.**
 
-#### The Goal
+## The Goal
 
 Our goal in this blog post is to build an `Actor` that connects to a certain
 TCP server, listens for new messages and forwards them to another `recipient`
@@ -31,7 +31,7 @@ actor. For simplicity we'll assume that the server is using a line break after
 each message.
 
 
-#### Project Setup
+## Project Setup
 
 In our last post we explained that the easiest solution to install Rust is
 currently <https://rustup.rs/>. Once you have followed the instructions there
@@ -64,7 +64,7 @@ afterwards running it, resulting in "Hello, world!" being printed in your
 Terminal.
 
 
-#### The Actor
+## The Actor
 
 Before we can start to implement our TCP client actor we need to tell `cargo`
 about the `actix` dependency. For that we open the `Cargo.toml` file in the
@@ -145,7 +145,7 @@ implemented nothing that would stop the actor.
 First milestone achieved! 🎉
 
 
-#### DNS resolution and TCP connection
+## DNS resolution and TCP connection
 
 Now that we have setup the basic scaffolding of our `Actor`, let's try to
 connect to a real TCP server. I'll first show you the code and then we'll
@@ -213,7 +213,7 @@ Great! We have successfully opened up a TCP connection to the
 is: keep reading! 😉
 
 
-#### Reading TCP streams
+## Reading TCP streams
 
 For the next part we'll need two more dependencies: `tokio-io` and
 `tokio-codec`. [tokio] is the low-level network IO library that `actix` is
@@ -303,7 +303,7 @@ I won't spoiler anything, but take a bit of time and see what happens now if
 you start `cargo run` again... 🚀
 
 
-#### Forward messages to other actors
+## Forward messages to other actors
 
 In case you're still reading, let's implement the final part of our goal:
 forwarding received messages to another actor.
@@ -390,11 +390,11 @@ fn main() {
 }
 ```
 
-After everything is assembled back together let's use `cargo run` again and we 
+After everything is assembled back together let's use `cargo run` again and we
 will see that everything still works! 🎥
 
 
-#### Summary
+## Summary
 
 We hope that by now you're a little more comfortable around actors and how to
 use and implement them in Rust. This blog post has shown how two actors can

--- a/blog/_posts/2018-07-03-building-a-pwa-with-glimmer-js.md
+++ b/blog/_posts/2018-07-03-building-a-pwa-with-glimmer-js.md
@@ -19,7 +19,7 @@ particular decisions and what the result looks like.
 
 <!--break-->
 
-#### Breethe
+## Breethe
 
 While this project was mostly meant as a technology spike to validate Glimmer's
 suitability for real projects as well as testing some techniques for running
@@ -37,7 +37,7 @@ daily lives.
 The application is open source and
 [available on GitHub](https://github.com/simplabs/breethe-client).
 
-#### Glimmer.js
+## Glimmer.js
 
 Glimmer.js is a thin component library built on top of Ember.js's rendering
 engine, the Glimmer VM. It is optimized for small application bundle sizes and
@@ -71,7 +71,7 @@ initial and update renders, watch the talk I gave at the
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/vIRZDCyfOJc?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen class="video"></iframe>
 
-#### Building Breethe with Glimmer.js
+## Building Breethe with Glimmer.js
 
 The Breethe app consists of two main screens, the Start page with the search
 form and the results page that shows the data and an air quality score for a
@@ -214,7 +214,7 @@ particularly how we load and manage data with Orbit.js. For a closer look on
 the inner workings of Breethe, check out the
 [code on github](https://github.com/simplabs/breethe-client).
 
-#### From Glimmer.js to Ember.js
+## From Glimmer.js to Ember.js
 
 Besides making the Glimmer VM available to be used outside of Ember.js and
 offering a solution for situations where bundle size and load time performance
@@ -247,7 +247,7 @@ Ember.js once they reach a certain size and complexity and the additional
 features and concepts that Ember.js provides over Glimmer.js justify a more
 heavyweight framework.
 
-#### Testing
+## Testing
 
 Glimmer.js' testing APIs are very similar to what Ember.js uses for
 [component tests](https://guides.emberjs.com/release/testing/testing-components/).
@@ -304,7 +304,7 @@ entirely ready for prime time. In order to test some more advanced component
 behaviors, we use [Puppeteer](https://pptr.dev) to run the entire application
 in a headless browser.
 
-#### Outlook
+## Outlook
 
 In future posts, we will look at some specific aspects of the application in
 more detail, including service workers and offline functionality (and testing

--- a/blog/_posts/2018-07-24-from-spa-to-pwa.md
+++ b/blog/_posts/2018-07-24-from-spa-to-pwa.md
@@ -17,7 +17,7 @@ how to turn a Single Page App into a Progressive Web App.
 
 <!--break-->
 
-### Breethe
+## Breethe
 
 Throughout this post, we will use [Breethe](https://breethe.app) as an example.
 Breethe is a Progressive Web App that gives users quick and easy access to air
@@ -36,7 +36,7 @@ To learn more about how we built Breethe with
 None of the contents in this post are specific to Glimmer.js in any way though,
 but all generally applicable to all frontend stacks.
 
-### Progressive Web Apps
+## Progressive Web Apps
 
 In short, Progressive Web Apps are **web apps that look and behave like native
 apps**. While the idea of building apps with web technologies has been around
@@ -106,7 +106,7 @@ only getting started - as Progressive Web Apps have only recently really took
 off, **it's fair to expect massive improvements in terms of what's possible
 over the next coming years**.
 
-### What are PWAs?
+## What are PWAs?
 
 Progressive Web Apps have some distinct characteristics, the main ones being:
 
@@ -124,7 +124,7 @@ Progressive Web Apps have some distinct characteristics, the main ones being:
 We will be focussing on two of these characteristics in this article -
 Installability and Connectivity Independence.
 
-### Installability
+## Installability
 
 Progressive Web apps can be installed on the user's home screen and thus
 _"taken out of the browser"_ so that they mingle with the user's native apps
@@ -194,7 +194,7 @@ browser UI:
 
 ![The Breethe PWA starting up standalone](/images/posts/2018-07-24-from-spa-to-pwa/breethe-startup-standalone.gif)
 
-### Connectivity Independence
+## Connectivity Independence
 
 The main requirement for any web application to be able to work independently
 of the network is that it **must be able to start up while there is no network
@@ -332,7 +332,7 @@ while the device is offline only solves half of the problem though when all of
 the app's data is loaded from a remote API and thus would be unavailable when
 offline.
 
-### Offline Data
+## Offline Data
 
 The web platform provides a number of APIs for storing data in the browser and
 thus making it available for offline use. The
@@ -467,7 +467,7 @@ when the device is offline. Modern libraries like Orbit.js make it easy to
 manage data independently of the network condition and abstract most of the
 details behind convenient APIs.
 
-### Testing
+## Testing
 
 Testing is an essential part of modern software engineering and we at simplabs
 (and I'm sure this is true for anyone reading this as well) would **never ship
@@ -554,7 +554,7 @@ to execute -
 completes in
 [around 1min](https://travis-ci.org/simplabs/breethe-client/jobs/403597086#L683).
 
-#### Outlook
+## Outlook
 
 This post and the
 [previous one](/blog/2018/07/03/building-a-pwa-with-glimmer-js.html) have given

--- a/blog/_posts/2018-11-27-open-source-maintenance.md
+++ b/blog/_posts/2018-11-27-open-source-maintenance.md
@@ -15,7 +15,7 @@ open-source and other projects.
 
 <!--break-->
 
-### Git
+## Git
 
 Version control systems have always been an important part of professional
 software development, but the development of [git] over a decade ago and the
@@ -49,7 +49,7 @@ like `v1.x` or `v2.3.x`.
 For remotes we use `upstream`, `origin` and for all other remotes the GitHub
 (or GitLab, BitBucket, etc.) username of the remote owner. `upstream` means the
 main project on GitHub and `origin` is my personal fork where I push feature
-branches, which will turn into PRs against the `upstream` repository. Here is an 
+branches, which will turn into PRs against the `upstream` repository. Here is an
 example for our `qunit-dom` project on my machine:
 
 | `upstream` | `git@github.com:simplabs/qunit-dom.git` |
@@ -64,8 +64,8 @@ graphical user interface. Here are a few examples of things we regularly use:
 | `cl` | `git clone` | Clones a repository |
 | `clu` | `git clone --origin=upstream` | Clones a repository, and uses `upstream` as the default remote name |
 | `ao` | `git remote add origin` | Adds a new remote called `origin` |
-| `gfu` | `git fetch upstream` | Updates the local copies of the `upstream` remote branches | 
-| `gfo` | `git fetch origin` | Updates the local copies of the `origin` remote branches | 
+| `gfu` | `git fetch upstream` | Updates the local copies of the `upstream` remote branches |
+| `gfo` | `git fetch origin` | Updates the local copies of the `origin` remote branches |
 | `gp` | `git push` | Pushes the current branch to the corresponding remote |
 | `gph` | `git push -u origin HEAD` | Pushes the current branch as a new branch to the `origin` remote |
 | `gpf` | `git push --force-with-lease` | Pushes the current branch to the corresponding remote, overwriting the existing history of the branch |
@@ -84,7 +84,7 @@ gph
 ```
 
 
-### Tests
+## Tests
 
 Having a good test suite is very important to be able to change code and be
 confident that the change is not breaking anything. This is one of the major
@@ -103,7 +103,7 @@ to make testing even more pleasant, including the very valuable [proptest]
 crate.
 
 
-### Linting
+## Linting
 
 Similar to testing frameworks, a lot of ecosystems have tools to run "static
 analysis" on your code to find bugs before you even run the applications. These
@@ -117,7 +117,7 @@ Again, similar tools also exist in other ecosystems like Rust ([clippy] and
 [rustfmt]), Python ([pyflakes] and [black]) or Elixir (`mix format`).
 
 
-### Continuous Integration
+## Continuous Integration
 
 The above points about testing and linting are nice to have, but if nobody runs
 your tests then they don't provide any value. This is where continuous
@@ -140,7 +140,7 @@ You can find instruction on how to configure this in their official
 [documentation](https://docs.travis-ci.com/user/deployment/npm/).
 
 
-### Semantic Versioning
+## Semantic Versioning
 
 Semantic Versioning (or short "semver") is a way to assign meaning to version
 numbers, and specifically to version number changes. The official
@@ -170,7 +170,7 @@ that it works with Node.js 4, and you release a new version that needs at least
 Node.js 6, then you should increase the **major** version.
 
 
-### Dependency Update Services
+## Dependency Update Services
 
 Any sufficiently large open source project has at least a few dependencies that
 it is built upon, and even smaller projects typically have at least a dependency
@@ -192,7 +192,7 @@ can also automatically merge those Pull Requests once CI has finished and the
 test suite passed.
 
 
-### Changelogs
+## Changelogs
 
 While Semantic Versioning helps your users to know if they need to expect
 breaking changes from a release, it is much better to have a human-readable
@@ -222,10 +222,10 @@ any of the other supported/configured labels. To ensure that all of our projects
 use the same set of labels we use [github-label-sync].
 
 An [example changelog](https://github.com/simplabs/qunit-dom/blob/master/CHANGELOG.md)
-can be seen on our qunit-dom project. 
+can be seen on our qunit-dom project.
 
 
-### Summary
+## Summary
 
 We hope that this blog post helped you improve your processes and speed up your
 own development. If you need help with any of these topics or if you have


### PR DESCRIPTION
Following the suggestion that we'd want top level headlines of blog post sections to be `h2` instead of `h4` or `h3`: https://simplabs.slack.com/archives/C0DBS7FCM/p1544103789003200?thread_ts=1544102911.001900&cid=C0DBS7FCM