### PR TITLE
don't always not wrap code in articles

### DIFF
--- a/stylesheets/components/article.scss
+++ b/stylesheets/components/article.scss
@@ -34,12 +34,6 @@
       white-space: nowrap;
     }
   }
-
-  p, ol, ul, table {
-    code {
-      white-space: nowrap;
-    }
-  }
 }
 
 .article-info-link {


### PR DESCRIPTION
We only really want to not wrap `code` in `table`s - otherwise we might get this (from @geekygrappler's latest post):

<img width="1457" alt="bildschirmfoto 2018-12-19 um 10 19 00" src="https://user-images.githubusercontent.com/1510/50210909-98240600-0377-11e9-8094-358a963dbd66.png">
