### PR TITLE
fix(ci): update outdated link failing htmlcheck

### DIFF
--- a/blog/_posts/2018-12-20-factories-best-practices.md
+++ b/blog/_posts/2018-12-20-factories-best-practices.md
@@ -183,7 +183,7 @@ My arguments for not using Mirage:
 
 In my opinion the main use for Mirage is as a rapid prototyping tool. It can also be used for testing, but by default, only testing in acceptance tests. Mirage provides you with a Javascript server that runs in the browser and intercepts API requests, responding to them before a network request is even made, either those requests made by your application in `dev` or those made during acceptance tests.
 
-If you want to use Mirage in testing, and you write more than acceptance tests then you will need to use a ['hack' or 'workaround'](http://www.ember-cli-mirage.com/docs/v0.4.x/manually-starting-mirage/) to manually start and stop the mirage server during integration and unit tests. And you definitely should be writing integration and unit tests.
+If you want to use Mirage in testing, and you write more than acceptance tests then you will need to use a ['hack' or 'workaround'](http://www.ember-cli-mirage.com/versions/v0.4.x/manually-starting-mirage/) to manually start and stop the mirage server during integration and unit tests. And you definitely should be writing integration and unit tests.
 
 #### 2. Test Clarity
 Using Mirage in an acceptance test look like this.


### PR DESCRIPTION
The Ember CLI Mirage docs url structure has changed. This updates a link that returned a `404` previously to http://www.ember-cli-mirage.com/versions/v0.4.x/manually-starting-mirage/

| before | after |
|--|--|
| <img width="886" alt="screenshot 2019-02-11 at 15 01 39" src="https://user-images.githubusercontent.com/8811742/52568073-14821500-2e0e-11e9-8f02-0ed4e3e14124.png">|<img width="791" alt="screenshot 2019-02-11 at 15 01 52" src="https://user-images.githubusercontent.com/8811742/52568095-22379a80-2e0e-11e9-9a0c-d16e13608b0a.png">|

See also an [example build here](https://travis-ci.org/simplabs/simplabs.github.io/builds/491635809?utm_source=github_status&utm_medium=notification)

Unblocks #276

