### PR TITLE
Fix prerender

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,8 @@ jobs:
       script: yarn lint:js
     - state: test
       script: yarn lint:hbs
+    - state: test
+      script: yarn build
 
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "morgan": "^1.3.2",
     "navigo": "^7.1.2",
     "prettier": "^1.16.4",
-    "puppeteer": "^1.11.0",
+    "puppeteer": "^1.14.0",
     "qunitjs": "^2.3.3",
     "rollup-plugin-commonjs": "^9.2.1",
     "rollup-plugin-node-resolve": "^4.0.1",

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -67,17 +67,15 @@ server.listen(3000, async function() {
   let routes = ROUTES_MAP;
   let paths = Object.keys(routes);
 
-  await Promise.all(
-    paths.map(async routePath => {
-      let html = await snapshot(browser, routePath);
-      let fileName = await persist(html, routePath);
-      await inlineCss(fileName);
+  for (routePath of paths) {
+    let html = await snapshot(browser, routePath);
+    let fileName = await persist(html, routePath);
+    await inlineCss(fileName);
 
-      console.log(colors.blue(`${routePath} => ${fileName}.`));
-    }),
-  );
+    console.log(colors.blue(`${routePath} => ${fileName}.`));
+  }
   console.log(colors.green(`\nRendered ${paths.length} routes.`));
-
+  
   await browser.close();
   process.exit(0);
 });

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -67,7 +67,7 @@ server.listen(3000, async function() {
   let routes = ROUTES_MAP;
   let paths = Object.keys(routes);
 
-  for (routePath of paths) {
+  for (let routePath of paths) {
     let html = await snapshot(browser, routePath);
     let fileName = await persist(html, routePath);
     await inlineCss(fileName);
@@ -75,7 +75,7 @@ server.listen(3000, async function() {
     console.log(colors.blue(`${routePath} => ${fileName}.`));
   }
   console.log(colors.green(`\nRendered ${paths.length} routes.`));
-  
+
   await browser.close();
   process.exit(0);
 });

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -5,6 +5,8 @@ const puppeteer = require('puppeteer');
 const critical = require('critical');
 const colors = require('colors');
 
+process.setMaxListeners(Infinity);
+
 const DIST_PATH = path.join(__dirname, '..', 'dist');
 const HTML_PATH = path.join(__dirname, '..', 'dist', 'index.html');
 const GlimmerRenderer = require(path.join(DIST_PATH, 'ssr-app.js'));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4111,9 +4111,9 @@ es6-map@^0.1.4:
     event-emitter "~0.3.5"
 
 es6-promise@^4.0.3:
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.5.tgz#da6d0d5692efb461e082c14817fe2427d8f5d054"
-  integrity sha512-n6wvpdE43VFtJq+lUDYDBFUwV8TZbuGXLV4D6wKafg13ldznKsyEvatubnmUe31zcvelSzOHF+XbaT+Bl9ObDg==
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.6.tgz#b685edd8258886365ea62b57d30de28fadcd974f"
+  integrity sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==
 
 es6-promisify@^5.0.0:
   version "5.0.0"
@@ -7144,9 +7144,9 @@ mime@^1.2.11:
   integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
 
 mime@^2.0.3:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.0.tgz#e051fd881358585f3279df333fe694da0bcffdd6"
-  integrity sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.1.tgz#19eb7357bebbda37df585b14038347721558c715"
+  integrity sha512-VRUfmQO0rCd3hKwBymAn3kxYzBHr3I/wdVMywgG3HhXOwrCQgN84ZagpdTm2tZ4TNtwsSmyJWYO88mb5XvzGqQ==
 
 mimic-fn@^1.0.0:
   version "1.2.0"
@@ -8162,10 +8162,10 @@ puppeteer@1.10.0:
     rimraf "^2.6.1"
     ws "^5.1.1"
 
-puppeteer@^1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.11.0.tgz#63cdbe12b07275cd6e0b94bce41f3fcb20305770"
-  integrity sha512-iG4iMOHixc2EpzqRV+pv7o3GgmU2dNYEMkvKwSaQO/vMZURakwSOn/EYJ6OIRFYOque1qorzIBvrytPIQB3YzQ==
+puppeteer@^1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.14.0.tgz#828c1926b307200d5fc8289b99df4e13e962d339"
+  integrity sha512-SayS2wUX/8LF8Yo2Rkpc5nkAu4Jg3qu+OLTDSOZtisVQMB2Z5vjlY2TdPi/5CgZKiZroYIiyUN3sRX63El9iaw==
   dependencies:
     debug "^4.1.0"
     extract-zip "^1.6.6"
@@ -10244,7 +10244,14 @@ ws@^5.1.1:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^6.1.0, ws@~6.1.0:
+ws@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
+  integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
+  dependencies:
+    async-limiter "~1.0.0"
+
+ws@~6.1.0:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.2.tgz#3cc7462e98792f0ac679424148903ded3b9c3ad8"
   integrity sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==


### PR DESCRIPTION
This should fix the prerenderer, mainly by un-limiting the number of event listeners and not pre-rendering concurrently but sequentually which doesn't work with critical apparently.

This also runs `yarn build` on CI so we can be sure we don't break the pre-rendering.