### PR TITLE
run commands correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "lint:ts": "tslint -c tslint.json 'src/**/*.ts' -t codeFrame",
     "lint:js": "eslint . --cache",
     "lint:hbs": "prettier --check --parser glimmer '**/*.hbs'",
-    "lint": "yarn run lint:ts & yarn run lint:js & yarn run lint:hbs",
+    "lint": "yarn run lint:ts; yarn run lint:js; yarn run lint:hbs",
     "format:ts": "tslint --fix -c tslint.json 'src/**/*.ts'",
     "format:js": "eslint --fix . --cache",
     "format:hbs": "prettier --write --parser glimmer '**/*.hbs'",
-    "format": "yarn run format:ts & yarn run format:js & yarn format:hbs"
+    "format": "yarn run format:ts; yarn run format:js; yarn format:hbs"
   },
   "devDependencies": {
     "@css-blocks/ember-cli": "^0.20.0-beta.7",


### PR DESCRIPTION
This fixes the way the `yarn lint` and `yarn format` tasks run. Previously they were actually run in the background as opposed to being run sequentually 🤦‍♂️ 