### PR TITLE
Fix (internal) links

### DIFF
--- a/_posts/2013-06-15-authentication-in-emberjs.md
+++ b/_posts/2013-06-15-authentication-in-emberjs.md
@@ -7,9 +7,9 @@ bio: "Founding Director of simplabs, author of Ember Simple Auth"
 topic: ember
 ---
 
-**Update:**_I released an Ember.js plugin that makes it very easy to implement an authentication system as described in this post: [Ember.SimpleAuth](http://simplabs.com/blog/2013/10/09/embersimpleauth.html)._
+**Update:**_I released an Ember.js plugin that makes it very easy to implement an authentication system as described in this post: [Ember.SimpleAuth](/blog/2013-10-09-embersimpleauth)._
 
-**Update:** _After I wrote this I found out that it’s actually not the best approach to implement authentication in Ember.js… There are some things missing and some other things can be done in a much simpler way. [I wrote a summary of the (better) authentication mechanism we moved to.](http://simplabs.com/blog/2013/08/08/better-authentication-in-emberjs.html "(better) authnetication with ember.js")_
+**Update:** _After I wrote this I found out that it’s actually not the best approach to implement authentication in Ember.js… There are some things missing and some other things can be done in a much simpler way. [I wrote a summary of the (better) authentication mechanism we moved to.](/blog/2013-08-08-better-authentication-in-emberjs "(better) authnetication with ember.js")_
 
 _I’m using the latest (as of mid June 2013) [ember](https://github.com/emberjs/ember.js)/[ember-data](https://github.com/emberjs/data)/[handlebars](https://github.com/wycats/handlebars.js) code directly from the respective github repositories in this example._
 

--- a/_posts/2013-08-08-better-authentication-in-emberjs.md
+++ b/_posts/2013-08-08-better-authentication-in-emberjs.md
@@ -7,7 +7,7 @@ bio: "Founding Director of simplabs, author of Ember Simple Auth"
 topic: ember
 ---
 
-**Update:**_I released an Ember.js plugin that makes it very easy to implement an authentication system as described in this post: [Ember.SimpleAuth](http://simplabs.com/blog/2013/06/15/authentication-in-emberjs.html)._
+**Update:**_I released an Ember.js plugin that makes it very easy to implement an authentication system as described in this post: [Ember.SimpleAuth](/blog/2013-06-15-authentication-in-emberjs)._
 
 When we started our first [ember.js](http://emberjs.com) project in June 2013, one of the first things we implemented was authentication. Now, almost 2 months later, **it has become clear that our initial approach was not really the best and had some shortcomings. So I implemented a better authentication** (mostly based on the embercasts on authentication).
 

--- a/_posts/2013-10-09-embersimpleauth.md
+++ b/_posts/2013-10-09-embersimpleauth.md
@@ -7,9 +7,9 @@ bio: "Founding Director of simplabs, author of Ember Simple Auth"
 topic: ember
 ---
 
-**Update: [Ember.SimpleAuth 0.1.0 has been released!](http://simplabs.com/blog/2014/01/20/embersimpleauth-010.html)** The information in this is (partially) outdated.
+**Update: [Ember.SimpleAuth 0.1.0 has been released!](/blog/2014-01-20-embersimpleauth-010)** The information in this is (partially) outdated.
 
-After I wrote 2 [blog](http://simplabs.com/blog/2013/06/15/authentication-in-emberjs.html "the initial post") [posts](http://simplabs.com/blog/2013/08/08/better-authentication-in-emberjs.html "the second post with a refined implementation") on implementing token based authentication in [Ember.js](http://emberjs.com) applications and got quite some feedback, good suggestions etc., I thought it **would be nice to pack all these ideas in an Ember.js plugin** so everybody could easily integrate that into their applications. Now **I finally managed to release version 0.0.1 of that plugin**: [Ember.SimpleAuth](https://github.com/simplabs/ember-simple-auth).
+After I wrote 2 [blog](/blog/2013-06-15-authentication-in-emberjs "the initial post") [posts](/blog/2013-08-08-better-authentication-in-emberjs "the second post with a refined implementation") on implementing token based authentication in [Ember.js](http://emberjs.com) applications and got quite some feedback, good suggestions etc., I thought it **would be nice to pack all these ideas in an Ember.js plugin** so everybody could easily integrate that into their applications. Now **I finally managed to release version 0.0.1 of that plugin**: [Ember.SimpleAuth](https://github.com/simplabs/ember-simple-auth).
 
 <!--break-->
 

--- a/_posts/2013-10-28-embersimpleauth-implements-rfc-6749-oauth-20.md
+++ b/_posts/2013-10-28-embersimpleauth-implements-rfc-6749-oauth-20.md
@@ -7,7 +7,7 @@ bio: "Founding Director of simplabs, author of Ember Simple Auth"
 topic: ember
 ---
 
-**Update: [Ember.SimpleAuth 0.1.0 has been released!](http://simplabs.com/blog/2014/01/20/embersimpleauth-010.html)** The information in this is (partially) outdated.
+**Update: [Ember.SimpleAuth 0.1.0 has been released!](/blog/2014-01-20-embersimpleauth-010)** The information in this is (partially) outdated.
 
 With the [release of Ember.SimpleAuth 0.0.4](https://github.com/simplabs/ember-simple-auth/releases/tag/0.0.4) **the library is compliant with OAuth 2.0** - specifically it implements the _"Resource Owner Password Credentials Grant Type"_ as defined in [RFC 6749](http://tools.ietf.org/html/rfc6749) (thanks [adamlc](https://github.com/adamlc) for the suggestion). While this is only a minor change in terms of functionality and data flow, used headers etc. it makes everyone’s life a lot easier as instead of implementing your own server endpoints you can now utilize [one of several OAuth 2.0 middlewares that already implement the spec](https://github.com/search?q=oauth%20middleware).
 

--- a/_posts/2014-07-25-testing-with-ember-simple-auth-and-ember-cli.md
+++ b/_posts/2014-07-25-testing-with-ember-simple-auth-and-ember-cli.md
@@ -7,7 +7,7 @@ bio: "Founding Director of simplabs, author of Ember Simple Auth"
 topic: ember
 ---
 
-[The last blog post](http://simplabs.com/blog/2014/06/30/using-ember-simple-auth-with-ember-cli.html "Using Ember Simple Auth with ember-cli") showed how to use [Ember Simple Auth](https://github.com/simplabs/ember-simple-auth) with [Ember CLI](https://github.com/ember-cli/ember-cli) to implement session handling and authentication. **This post shows how to test that code**.
+[The last blog post](/blog/2014-06-30-using-ember-simple-auth-with-ember-cli "Using Ember Simple Auth with ember-cli") showed how to use [Ember Simple Auth](https://github.com/simplabs/ember-simple-auth) with [Ember CLI](https://github.com/ember-cli/ember-cli) to implement session handling and authentication. **This post shows how to test that code**.
 
 <!--break-->
 

--- a/_posts/2017-01-13-ember-test-selectors.md
+++ b/_posts/2017-01-13-ember-test-selectors.md
@@ -23,7 +23,7 @@ features.
 
 ## Automatic binding of `data-test-*` properties
 
-As you may know from our [previous blog post](http://simplabs.com/blog/2016/03/04/ember-test-selectors.html)
+As you may know from our [previous blog post](/blog/2016-03–04-ember-test-selectors)
 on this topic, the goal of this addon is to let you use attributes starting
 with `data-test-` in your templates:
 

--- a/_posts/2017-10-24-high-level-assertions-with-qunit-dom.md
+++ b/_posts/2017-10-24-high-level-assertions-with-qunit-dom.md
@@ -236,4 +236,4 @@ Moving the tests to `async/await` and `qunit-dom` makes them a lot more
 readable and easier to understand for new developers and is just a few
 keystrokes away if you're already using Ember.js for your frontend projects.
 If you need help refactoring your tests or even your production code to be
-more structured and understandable feel free to [contact us](https://simplabs.com/contact/).
+more structured and understandable feel free to [contact us](/contact/).

--- a/_posts/2017-11-17-ember-test-selectors-road-to-1-0.md
+++ b/_posts/2017-11-17-ember-test-selectors-road-to-1-0.md
@@ -8,7 +8,7 @@ topic: ember
 ---
 
 Back in January we wrote about the
-[latest changes](https://simplabs.com/blog/2017/01/13/ember-test-selectors.html)
+[latest changes](/blog/2017-01-13-ember-test-selectors)
 in [`ember-test-selectors`](https://github.com/simplabs/ember-test-selectors)
 and how we implemented them. Since then we adjusted a few things and this blog
 post should give you an idea what has happened so far and what else will happen
@@ -230,4 +230,4 @@ likely not be done by the time we release v1.0.0, but will be something for us
 to work on in the next year.
 
 If you have questions on how to best take advantage of test-selectors or how to
-structure your tests in general make sure to [contact us](https://simplabs.com/contact/).
+structure your tests in general make sure to [contact us](/contact/).

--- a/_posts/2018-06-05-ember-component-playground.md
+++ b/_posts/2018-06-05-ember-component-playground.md
@@ -12,7 +12,7 @@ a component playground for our Ember.js application. In this post we will
 discuss how to implement "convention over configuration" for it by automatically
 discovering new components and showing them in the playground.
 
-[previous post]: https://simplabs.com/blog/2018/01/24/ember-freestyle.html
+[previous post]: /blog/2018-01-24-ember-freestyle
 [ember-freestyle]: http://ember-freestyle.com/
 
 <!--break-->

--- a/_posts/2018-07-03-building-a-pwa-with-glimmer-js.md
+++ b/_posts/2018-07-03-building-a-pwa-with-glimmer-js.md
@@ -197,7 +197,7 @@ template like this:
     <ul>
       {{#each locations key="id" as |location|}}
         <li class="result">
-          <a href="/location/{{location.id}}" class="result-link" data-navigo>
+          <a href="/location/{{location.id}}" class="result-link" data-internal>
             {{location.label}}
           </a>
         </li>

--- a/_posts/2018-12-10-assert-your-style.md
+++ b/_posts/2018-12-10-assert-your-style.md
@@ -73,7 +73,7 @@ export default Component.extend({
   }),
 });
 ```
- To learn more about the rationale behind `ember-test-selectors`, be sure to also [give this introduction a read](https://simplabs.com/blog/2017/11/17/ember-test-selectors-road-to-1-0.html).
+ To learn more about the rationale behind `ember-test-selectors`, be sure to also [give this introduction a read](/blog/2017-11-17-ember-test-selectors-road-to-1-0).
 
 Using the [HTMLElement.style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) API, we can assert if the correct background color has been applied to our component:
 
@@ -137,7 +137,7 @@ module('Integration | Component | simplabs-logo-tile', function(hooks) {
 
 Now we know how we can write style-related tests for our automated test process that assert that the expected styles are applied to elements on the web page.
 
-But there's an even easier way to assert the computed styles of elements in your **QUnit test suite**. Since [v0.8.1](https://twitter.com/simplabs/status/1065913669995978752) of [qunit-dom](https://simplabs.com/blog/2017/10/24/high-level-assertions-with-qunit-dom.html) you can make your tests truly ✨
+But there's an even easier way to assert the computed styles of elements in your **QUnit test suite**. Since [v0.8.1](https://twitter.com/simplabs/status/1065913669995978752) of [qunit-dom](/blog/2017-10-24-high-level-assertions-with-qunit-dom) you can make your tests truly ✨
 
 Check it [out](https://github.com/simplabs/qunit-dom):
 
@@ -179,4 +179,4 @@ You can read more about the usage of the `.hasStyle` method in the [API document
 
 There are different ways to assert against inline styles and computed styles in your application and if you're using Ember & QUnit, [qunit-dom](https://github.com/simplabs/qunit-dom) is your best bet to make your style tests easy to write and read.
 
-Questions? Suggestions? [Contact us!](https://simplabs.com/contact/)
+Questions? Suggestions? [Contact us!](/contact/)

--- a/_posts/2018-12-20-factories-best-practices.md
+++ b/_posts/2018-12-20-factories-best-practices.md
@@ -13,7 +13,7 @@ Writing tests is like drinking beer 🍻. When you first try it, the taste is re
 
 ## AAA
 
-Before I dive into factories, firstly I want to mention AAA: Arrange, Act, Assert. I covered this paradigm over [here](https://simplabs.com/blog/2017/09/17/magic-test-data.html), and I still stand by it. It's the most important thing you can do to make your tests straight forward and understandable for others.
+Before I dive into factories, firstly I want to mention AAA: Arrange, Act, Assert. I covered this paradigm over [here](/blog/2017-09-17-magic-test-data), and I still stand by it. It's the most important thing you can do to make your tests straight forward and understandable for others.
 
 ## Factories > Fixtures
 

--- a/_posts/2019-03-07-march-monthly-update.md
+++ b/_posts/2019-03-07-march-monthly-update.md
@@ -32,7 +32,7 @@ Ricardo Mendes will host a [Contributors Workshop](https://emberconf.com/schedul
 
 Also, [Jessica Jordan](https://twitter.com/jjordan_dev) will be giving a talk about [Crafting Web Comics in Ember](https://emberconf.com/speakers.html#jessica-jordan) which promises to be a very fun and informative talk.
 
-If you're attending EmberConf 2019 and would like to speak to us about our work, please [please get in touch.](https://simplabs.com/contact/index.html)
+If you're attending EmberConf 2019 and would like to speak to us about our work, please [please get in touch.](/contact)
 
 #### Ember.js film premiere
 
@@ -44,7 +44,7 @@ The film was premiered at meetups across Europe and we'd like to thank [Honeypot
 
 ## Events
 
-_We're always interested in new speakers for the various meetups we're involved in. If you'd like to give a talk, [please get in touch.](https://simplabs.com/contact/index.html)_
+_We're always interested in new speakers for the various meetups we're involved in. If you'd like to give a talk, [please get in touch.](/contact)_
 
 #### Upcoming events
 

--- a/_posts/2019-03-18-emberconf-update.md
+++ b/_posts/2019-03-18-emberconf-update.md
@@ -33,6 +33,6 @@ Lastly, [Chris Manson](https://twitter.com/real_ate) will be giving a lightning
 talk about [empress-blog](https://github.com/empress/empress-blog).
 
 If you're attending EmberConf 2019 and would like to speak to us about our 
-work, please [get in touch.](https://simplabs.com/contact/index.html)
+work, please [get in touch.](/contact)
 
 See you there!

--- a/_posts/2019-03-29-qonto-project.md
+++ b/_posts/2019-03-29-qonto-project.md
@@ -17,7 +17,7 @@ for freelancers, startups and SMEs."
 
 Qonto reached out to simplabs looking for a combination of added engineering
 power and outside expertise to help their in-house engineers improve, we call
-this [Team Augmentation](https://simplabs.com/team-augmentation/index.html).
+this [Team Augmentation](/services/team-augmentation/).
 
 This method of working sees our technology experts merge with our client's
 in-house engineering teams to share their know-how. simplabs engineers spearhead
@@ -25,7 +25,7 @@ and guide new development initiatives while establishing best practices and
 transferring knowledge to in-house engineers on the job via reviews and pairing
 sessions.
 
-Just as with previous Team Augmentation projects like [trainline](https://simplabs.com/trainline/index.html) this
+Just as with previous Team Augmentation projects like [trainline](/cases/trainline) this
 approach brings "double value for the client" says simlpabs CEO Marco
 Otte-Witte, "short term value is added by the client immediately gaining more
 engineering power, but additional long term value is added through improved

--- a/lib/generate-blog-components/index.js
+++ b/lib/generate-blog-components/index.js
@@ -153,7 +153,7 @@ function htmlizeBody(body) {
     dom.querySelectorAll('td').forEach(td => td.classList.add('table.cell'));
     dom.querySelectorAll('a').forEach(a => {
       if (!a.href.startsWith('http')) {
-        a.dataset.navigo = true;
+        a.dataset.internal = true;
       }
     });
   });

--- a/lib/generate-blog-components/index.js
+++ b/lib/generate-blog-components/index.js
@@ -151,6 +151,11 @@ function htmlizeBody(body) {
     dom.querySelectorAll('table').forEach(table => table.classList.add('table'));
     dom.querySelectorAll('th').forEach(th => th.classList.add('table.header'));
     dom.querySelectorAll('td').forEach(td => td.classList.add('table.cell'));
+    dom.querySelectorAll('a').forEach(a => {
+      if (!a.href.startsWith('http')) {
+        a.dataset.navigo = true;
+      }
+    });
   });
   return encodeCurlies(html);
 }

--- a/lib/generate-blog-components/lib/files/post/component-template.hbs
+++ b/lib/generate-blog-components/lib/files/post/component-template.hbs
@@ -51,7 +51,7 @@
             <p class="card.text">
               simplabs is a Web Engineering Consultancy based in Munich, Germany. We work for clients all over the world, offering Software Engineering, Technology Consulting as well as Individual and Group Training with modern Web Technologies. We specialize in a set of conventions-based tools like Ember.js, Elixir and, Phoenix as well as Ruby on Rails and like to move fast without breaking things.
             </p>
-            <a class="typography.arrow-link" href="/about" data-navigo>
+            <a class="typography.arrow-link" href="/about" data-internal>
               Learn more about Simplabs
             </a>
           </div>
@@ -81,7 +81,7 @@
               <h3 class="typography.headline-2">
                 {{related.title}}
               </h3>
-              <a class="typography.arrow-link" href="{{related.link}}" data-navigo>
+              <a class="typography.arrow-link" href="{{related.link}}" data-internal>
                 Read Post
               </a>
             </div>

--- a/lib/generate-blog-components/lib/files/post/component-template.hbs
+++ b/lib/generate-blog-components/lib/files/post/component-template.hbs
@@ -51,7 +51,7 @@
             <p class="card.text">
               simplabs is a Web Engineering Consultancy based in Munich, Germany. We work for clients all over the world, offering Software Engineering, Technology Consulting as well as Individual and Group Training with modern Web Technologies. We specialize in a set of conventions-based tools like Ember.js, Elixir and, Phoenix as well as Ruby on Rails and like to move fast without breaking things.
             </p>
-            <a class="typography.arrow-link" href="/about">
+            <a class="typography.arrow-link" href="/about" data-navigo>
               Learn more about Simplabs
             </a>
           </div>
@@ -81,7 +81,7 @@
               <h3 class="typography.headline-2">
                 {{related.title}}
               </h3>
-              <a class="typography.arrow-link" href="{{related.link}}">
+              <a class="typography.arrow-link" href="{{related.link}}" data-navigo>
                 Read Post
               </a>
             </div>

--- a/lib/generate-blog-components/lib/files/start-page/component-template.hbs
+++ b/lib/generate-blog-components/lib/files/start-page/component-template.hbs
@@ -19,14 +19,14 @@
               Latest Post
             </p>
             <h2 class="typography.headline-1">
-              <a href="{{latest.path}}" class="typography.title-link" data-navigo>
+              <a href="{{latest.path}}" class="typography.title-link" data-internal>
                 {{latest.title}}
               </a>
             </h2>
             <p class="typography.lead">
               {{{latest.excerpt}}}
             </p>
-            <a href="{{latest.path}}" class="typography.arrow-link" data-navigo>
+            <a href="{{latest.path}}" class="typography.arrow-link" data-internal>
               Read Post
             </a>
           </div>
@@ -49,19 +49,19 @@
               <div class="main-block.content-section">
                 <div class="main-block.content-section-item">
                   <div class="tags">
-                    <a class="tag" href="#" data-navigo>
+                    <a class="tag" href="#" data-internal>
                       #{{topic}}
                     </a>
                   </div>
                   <h3 class="typography.headline-2">
-                    <a class="typography.title-link" href="{{path}}" data-navigo>
+                    <a class="typography.title-link" href="{{path}}" data-internal>
                       {{title}}
                     </a>
                   </h3>
                   <p class="typography.body-text">
                     {{{excerpt}}}
                   </p>
-                  <a href="#" data-navigo>
+                  <a href="#" data-internal>
                     {{author.name}}
                   </a>
                   <p>
@@ -83,7 +83,7 @@
             <p class="card.text">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
             </p>
-            <a class="typography.arrow-link" href="/calendar" data-navigo>
+            <a class="typography.arrow-link" href="/calendar" data-internal>
               View Our Talks
             </a>
           </div>

--- a/lib/generate-blog-components/lib/files/start-page/component-template.hbs
+++ b/lib/generate-blog-components/lib/files/start-page/component-template.hbs
@@ -19,14 +19,14 @@
               Latest Post
             </p>
             <h2 class="typography.headline-1">
-              <a href="{{latest.path}}" class="typography.title-link">
+              <a href="{{latest.path}}" class="typography.title-link" data-navigo>
                 {{latest.title}}
               </a>
             </h2>
             <p class="typography.lead">
               {{{latest.excerpt}}}
             </p>
-            <a href="{{latest.path}}" class="typography.arrow-link">
+            <a href="{{latest.path}}" class="typography.arrow-link" data-navigo>
               Read Post
             </a>
           </div>
@@ -49,19 +49,19 @@
               <div class="main-block.content-section">
                 <div class="main-block.content-section-item">
                   <div class="tags">
-                    <a class="tag" href="#">
+                    <a class="tag" href="#" data-navigo>
                       #{{topic}}
                     </a>
                   </div>
                   <h3 class="typography.headline-2">
-                    <a class="typography.title-link" href="{{path}}">
+                    <a class="typography.title-link" href="{{path}}" data-navigo>
                       {{title}}
                     </a>
                   </h3>
                   <p class="typography.body-text">
                     {{{excerpt}}}
                   </p>
-                  <a href="#">
+                  <a href="#" data-navigo>
                     {{author.name}}
                   </a>
                   <p>
@@ -83,7 +83,7 @@
             <p class="card.text">
               Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
             </p>
-            <a class="typography.arrow-link" href="/calendar">
+            <a class="typography.arrow-link" href="/calendar" data-navigo>
               View Our Talks
             </a>
           </div>

--- a/src/ui/components/About/template.hbs
+++ b/src/ui/components/About/template.hbs
@@ -14,11 +14,11 @@
         </p>
         <p class="typography.lead">
           We have written and reviewed applications for various international clients in the past, covering technology stacks from Ruby on Rails to
-          <a href="/expertise/ember" data-navigo>
+          <a href="/expertise/ember" data-internal>
             Ember.js
           </a>
           and
-          <a href="/expertise/elixir-phoenix" data-navigo>
+          <a href="/expertise/elixir-phoenix" data-internal>
             Elixir/Phoenix
           </a>
           .
@@ -81,7 +81,7 @@
             <p class="card.text">
               We share what we learn with the community via talks at conferences and meetups and on our blog.
             </p>
-            <a class="typography.arrow-link" href="/calendar" data-navigo>
+            <a class="typography.arrow-link" href="/calendar" data-internal>
               View Talks
             </a>
           </div>

--- a/src/ui/components/About/template.hbs
+++ b/src/ui/components/About/template.hbs
@@ -14,11 +14,11 @@
         </p>
         <p class="typography.lead">
           We have written and reviewed applications for various international clients in the past, covering technology stacks from Ruby on Rails to
-          <a href="/expertise/ember">
+          <a href="/expertise/ember" data-navigo>
             Ember.js
           </a>
           and
-          <a href="/expertise/elixir-phoenix">
+          <a href="/expertise/elixir-phoenix" data-navigo>
             Elixir/Phoenix
           </a>
           .
@@ -81,7 +81,7 @@
             <p class="card.text">
               We share what we learn with the community via talks at conferences and meetups and on our blog.
             </p>
-            <a class="typography.arrow-link" href="/calendar">
+            <a class="typography.arrow-link" href="/calendar" data-navigo>
               View Talks
             </a>
           </div>

--- a/src/ui/components/BreetheCaseThumb/template.hbs
+++ b/src/ui/components/BreetheCaseThumb/template.hbs
@@ -16,7 +16,7 @@
       <h3 class="typography.headline-2">
         Air quality data for locations around the world
       </h3>
-      <a class="typography.arrow-link" href="#">
+      <a class="typography.arrow-link" href="#" data-navigo>
         Read Case Study
       </a>
     </div>

--- a/src/ui/components/BreetheCaseThumb/template.hbs
+++ b/src/ui/components/BreetheCaseThumb/template.hbs
@@ -16,7 +16,7 @@
       <h3 class="typography.headline-2">
         Air quality data for locations around the world
       </h3>
-      <a class="typography.arrow-link" href="#" data-navigo>
+      <a class="typography.arrow-link" href="#" data-internal>
         Read Case Study
       </a>
     </div>

--- a/src/ui/components/EmberExpertise/template.hbs
+++ b/src/ui/components/EmberExpertise/template.hbs
@@ -116,7 +116,7 @@
             <p class="card.text">
               EmberFest is a great opportunity to get in touch with the European Ember Community.
             </p>
-            <a class="typography.arrow-link" href="/calendar">
+            <a class="typography.arrow-link" href="/calendar" data-navigo>
               View Our Calendar
             </a>
           </div>
@@ -146,7 +146,7 @@
               <p class="typography.body-text">
                 Every new projects gives us the opportunity to learn and grow our expertise. We share what we learn with the community via talks at conferences and meetups and on our blog.
               </p>
-              <a class="typography.arrow-link" href="/talks">
+              <a class="typography.arrow-link" href="/talks" data-navigo>
                 View Talks
               </a>
             </div>
@@ -160,7 +160,7 @@
               <p class="typography.body-text">
                 We share our experience with Ember.js in our blog.
               </p>
-              <a class="typography.arrow-link" href="/blog">
+              <a class="typography.arrow-link" href="/blog" data-navigo>
                 Read Our Blog
               </a>
             </div>
@@ -181,7 +181,7 @@
             <p class="typography.body-text">
               Ember.js is a project built by an open community and we are an active member of the community. We support the Ember.js Munich and Ember.js Berlin meetups are are co-organizers of EmberFest, the european Ember Community Conference.
             </p>
-            <a class="typography.arrow-link" href="#">
+            <a class="typography.arrow-link" href="#" data-navigo>
               View Our Calendar
             </a>
           </div>

--- a/src/ui/components/EmberExpertise/template.hbs
+++ b/src/ui/components/EmberExpertise/template.hbs
@@ -116,7 +116,7 @@
             <p class="card.text">
               EmberFest is a great opportunity to get in touch with the European Ember Community.
             </p>
-            <a class="typography.arrow-link" href="/calendar" data-navigo>
+            <a class="typography.arrow-link" href="/calendar" data-internal>
               View Our Calendar
             </a>
           </div>
@@ -146,7 +146,7 @@
               <p class="typography.body-text">
                 Every new projects gives us the opportunity to learn and grow our expertise. We share what we learn with the community via talks at conferences and meetups and on our blog.
               </p>
-              <a class="typography.arrow-link" href="/talks" data-navigo>
+              <a class="typography.arrow-link" href="/talks" data-internal>
                 View Talks
               </a>
             </div>
@@ -160,7 +160,7 @@
               <p class="typography.body-text">
                 We share our experience with Ember.js in our blog.
               </p>
-              <a class="typography.arrow-link" href="/blog" data-navigo>
+              <a class="typography.arrow-link" href="/blog" data-internal>
                 Read Our Blog
               </a>
             </div>
@@ -181,7 +181,7 @@
             <p class="typography.body-text">
               Ember.js is a project built by an open community and we are an active member of the community. We support the Ember.js Munich and Ember.js Berlin meetups are are co-organizers of EmberFest, the european Ember Community Conference.
             </p>
-            <a class="typography.arrow-link" href="#" data-navigo>
+            <a class="typography.arrow-link" href="#" data-internal>
               View Our Calendar
             </a>
           </div>

--- a/src/ui/components/ExpeditionCaseStudy/template.hbs
+++ b/src/ui/components/ExpeditionCaseStudy/template.hbs
@@ -45,7 +45,7 @@
                 <p class="typography.body-text">
                   Besides working on the core application, simplabs spearheaded several engineering efforts focused around mobile performance, improved load times, server side rendering and localization.
                 </p>
-                <a class="typography.arrow-link" href="#" data-navigo>
+                <a class="typography.arrow-link" href="#" data-internal>
                   Learn More
                 </a>
               </div>
@@ -84,7 +84,7 @@
             <p class="card.text">
               We value conventions-based frameworks that result in maintainable and well-defined projects which are easy to take over by our clients once we've left.
             </p>
-            <a class="typography.arrow-link" href="#" data-navigo>
+            <a class="typography.arrow-link" href="#" data-internal>
               Learn More
             </a>
           </div>

--- a/src/ui/components/ExpeditionCaseStudy/template.hbs
+++ b/src/ui/components/ExpeditionCaseStudy/template.hbs
@@ -45,7 +45,7 @@
                 <p class="typography.body-text">
                   Besides working on the core application, simplabs spearheaded several engineering efforts focused around mobile performance, improved load times, server side rendering and localization.
                 </p>
-                <a class="typography.arrow-link" href="#">
+                <a class="typography.arrow-link" href="#" data-navigo>
                   Learn More
                 </a>
               </div>
@@ -84,7 +84,7 @@
             <p class="card.text">
               We value conventions-based frameworks that result in maintainable and well-defined projects which are easy to take over by our clients once we've left.
             </p>
-            <a class="typography.arrow-link" href="#">
+            <a class="typography.arrow-link" href="#" data-navigo>
               Learn More
             </a>
           </div>

--- a/src/ui/components/ExpeditionCaseThumb/template.hbs
+++ b/src/ui/components/ExpeditionCaseThumb/template.hbs
@@ -16,7 +16,7 @@
       <h3 class="typography.headline-2">
         Air quality data for locations around the world
       </h3>
-      <a class="typography.arrow-link" href="#">
+      <a class="typography.arrow-link" href="#" data-navigo>
         Read Case Study
       </a>
     </div>

--- a/src/ui/components/ExpeditionCaseThumb/template.hbs
+++ b/src/ui/components/ExpeditionCaseThumb/template.hbs
@@ -16,7 +16,7 @@
       <h3 class="typography.headline-2">
         Air quality data for locations around the world
       </h3>
-      <a class="typography.arrow-link" href="#" data-navigo>
+      <a class="typography.arrow-link" href="#" data-internal>
         Read Case Study
       </a>
     </div>

--- a/src/ui/components/Footer/template.hbs
+++ b/src/ui/components/Footer/template.hbs
@@ -1,6 +1,6 @@
 <div>
   <div class="branding">
-    <a class="logo-wrap" href="/a" data-navigo="">
+    <a class="logo-wrap" href="/a" data-internal="">
       <img class="fluid-image.image" src="/assets/images/neu.svg" alt="simplabs" />
     </a>
     © 2014-2018 simplabs GmbH
@@ -9,13 +9,13 @@
     <strong class="menu-title">
       Services
     </strong>
-    <a href="/services/software-engineering" class="menu-link" data-navigo>
+    <a href="/services/software-engineering" class="menu-link" data-internal>
       Software engineering
     </a>
-    <a href="/services/team-augmentation" class="menu-link" data-navigo>
+    <a href="/services/team-augmentation" class="menu-link" data-internal>
       Team Augmentation
     </a>
-    <a href="/services/training" class="menu-link" data-navigo>
+    <a href="/services/training" class="menu-link" data-internal>
       Training
     </a>
   </nav>
@@ -23,10 +23,10 @@
     <strong class="menu-title">
       Expertise
     </strong>
-    <a href="/expertise/ember" class="menu-link" data-navigo>
+    <a href="/expertise/ember" class="menu-link" data-internal>
       Ember.js
     </a>
-    <a href="/expertise/elixir-phoenix" class="menu-link" data-navigo>
+    <a href="/expertise/elixir-phoenix" class="menu-link" data-internal>
       Elixir & Phoenix
     </a>
   </nav>
@@ -34,16 +34,16 @@
     <strong class="menu-title">
       Work
     </strong>
-    <a href="/cases/trainline" class="menu-link" data-navigo>
+    <a href="/cases/trainline" class="menu-link" data-internal>
       Trainline
     </a>
-    <a href="/cases/expedition" class="menu-link" data-navigo>
+    <a href="/cases/expedition" class="menu-link" data-internal>
       Expedition
     </a>
-    <a href="/expertise/elixir-phoenix" class="menu-link" data-navigo>
+    <a href="/expertise/elixir-phoenix" class="menu-link" data-internal>
       Elixir & Phoenix
     </a>
-    <a href="/expertise/timify" class="menu-link" data-navigo>
+    <a href="/expertise/timify" class="menu-link" data-internal>
       Timify
     </a>
   </nav>
@@ -57,7 +57,7 @@
     <a href="https://twitter.com/simplabs/" class="menu-link" target="_blank">
       Twitter
     </a>
-    <a href="/expertise/timify" class="menu-link" data-navigo>
+    <a href="/expertise/timify" class="menu-link" data-internal>
       Contact
     </a>
   </nav>

--- a/src/ui/components/FullStackService/template.hbs
+++ b/src/ui/components/FullStackService/template.hbs
@@ -12,7 +12,7 @@
           <p class="typography.small-text">
             Andreas Knürr, Timify CEO
           </p>
-          <a class="typography.arrow-link link" href="/work">
+          <a class="typography.arrow-link link" href="/work" data-navigo>
             View Our Work
           </a>
         </div>

--- a/src/ui/components/FullStackService/template.hbs
+++ b/src/ui/components/FullStackService/template.hbs
@@ -12,7 +12,7 @@
           <p class="typography.small-text">
             Andreas Knürr, Timify CEO
           </p>
-          <a class="typography.arrow-link link" href="/work" data-navigo>
+          <a class="typography.arrow-link link" href="/work" data-internal>
             View Our Work
           </a>
         </div>

--- a/src/ui/components/Homepage/template.hbs
+++ b/src/ui/components/Homepage/template.hbs
@@ -52,7 +52,7 @@
               <p class="typography.body-text">
                 We turn our clients' ideas into successful products, working closely with them in short iterations.
               </p>
-              <a class="typography.arrow-link" href="/services/software-engineering" data-navigo>
+              <a class="typography.arrow-link" href="/services/software-engineering" data-internal>
                 Learn More
               </a>
             </div>
@@ -65,7 +65,7 @@
               <p class="typography.body-text">
                 We turn our clients' ideas into successful products, working closely with them in short iterations.
               </p>
-              <a class="typography.arrow-link" href="/services/team-augmentation" data-navigo>
+              <a class="typography.arrow-link" href="/services/team-augmentation" data-internal>
                 Learn More
               </a>
             </div>
@@ -78,7 +78,7 @@
               <p class="typography.body-text">
                 We turn our clients' ideas into successful products, working closely with them in short iterations.
               </p>
-              <a class="typography.arrow-link" href="/services/training" data-navigo>
+              <a class="typography.arrow-link" href="/services/training" data-internal>
                 Learn More
               </a>
             </div>
@@ -98,7 +98,7 @@
             <p class="card.text">
               EmberFest is a great opportunity to get in touch with the European Ember Community.
             </p>
-            <a class="typography.arrow-link" href="/calendar" data-navigo>
+            <a class="typography.arrow-link" href="/calendar" data-internal>
               View Our Calendar
             </a>
           </div>

--- a/src/ui/components/Homepage/template.hbs
+++ b/src/ui/components/Homepage/template.hbs
@@ -52,7 +52,7 @@
               <p class="typography.body-text">
                 We turn our clients' ideas into successful products, working closely with them in short iterations.
               </p>
-              <a class="typography.arrow-link" href="/services/software-engineering">
+              <a class="typography.arrow-link" href="/services/software-engineering" data-navigo>
                 Learn More
               </a>
             </div>
@@ -65,7 +65,7 @@
               <p class="typography.body-text">
                 We turn our clients' ideas into successful products, working closely with them in short iterations.
               </p>
-              <a class="typography.arrow-link" href="/services/team-augmentation">
+              <a class="typography.arrow-link" href="/services/team-augmentation" data-navigo>
                 Learn More
               </a>
             </div>
@@ -78,7 +78,7 @@
               <p class="typography.body-text">
                 We turn our clients' ideas into successful products, working closely with them in short iterations.
               </p>
-              <a class="typography.arrow-link" href="/services/training">
+              <a class="typography.arrow-link" href="/services/training" data-navigo>
                 Learn More
               </a>
             </div>
@@ -98,7 +98,7 @@
             <p class="card.text">
               EmberFest is a great opportunity to get in touch with the European Ember Community.
             </p>
-            <a class="typography.arrow-link" href="/calendar">
+            <a class="typography.arrow-link" href="/calendar" data-navigo>
               View Our Calendar
             </a>
           </div>

--- a/src/ui/components/LeadingExperts/template.hbs
+++ b/src/ui/components/LeadingExperts/template.hbs
@@ -12,7 +12,7 @@
           <h3 class="shape.sub-heading">
             We are Europe’s Leading Ember Experts
           </h3>
-          <a class="typography.arrow-link link" href="/expertise/ember" data-navigo>
+          <a class="typography.arrow-link link" href="/expertise/ember" data-internal>
             Learn More
           </a>
         </div>

--- a/src/ui/components/LeadingExperts/template.hbs
+++ b/src/ui/components/LeadingExperts/template.hbs
@@ -12,7 +12,7 @@
           <h3 class="shape.sub-heading">
             We are Europe’s Leading Ember Experts
           </h3>
-          <a class="typography.arrow-link link" href="/expertise/ember">
+          <a class="typography.arrow-link link" href="/expertise/ember" data-navigo>
             Learn More
           </a>
         </div>

--- a/src/ui/components/Navigation/template.hbs
+++ b/src/ui/components/Navigation/template.hbs
@@ -1,24 +1,24 @@
 <div>
   <div class="navbar-brand">
-    <a href="/" data-navigo>
+    <a href="/" data-internal>
       <img class="fluid-image.image" src="/assets/images/neu.svg" alt="simplabs" />
     </a>
   </div>
   <nav class="navbar-nav">
-    <a href="/services" class="nav-item" data-navigo>
+    <a href="/services" class="nav-item" data-internal>
       Services
     </a>
-    <a href="/work" class="nav-item" data-navigo>
+    <a href="/work" class="nav-item" data-internal>
       Work
     </a>
-    <a href="/about" class="nav-item" data-navigo>
+    <a href="/about" class="nav-item" data-internal>
       About
     </a>
-    <a href="/blog" class="nav-item" data-navigo>
+    <a href="/blog" class="nav-item" data-internal>
       Blog
     </a>
   </nav>
-  <a href="/work-with-us" class="button.button" data-navigo>
+  <a href="/work-with-us" class="button.button" data-internal>
     Work with us
   </a>
 </div>

--- a/src/ui/components/OurProcess/template.hbs
+++ b/src/ui/components/OurProcess/template.hbs
@@ -12,7 +12,7 @@
           <h3 class="shape.sub-heading">
             Our process enables sustainable solutions
           </h3>
-          <a class="typography.arrow-link" href="#" data-navigo>
+          <a class="typography.arrow-link" href="#" data-internal>
             Learn More
           </a>
         </div>

--- a/src/ui/components/OurProcess/template.hbs
+++ b/src/ui/components/OurProcess/template.hbs
@@ -12,7 +12,7 @@
           <h3 class="shape.sub-heading">
             Our process enables sustainable solutions
           </h3>
-          <a class="typography.arrow-link" href="#">
+          <a class="typography.arrow-link" href="#" data-navigo>
             Learn More
           </a>
         </div>

--- a/src/ui/components/Services/template.hbs
+++ b/src/ui/components/Services/template.hbs
@@ -21,7 +21,7 @@
               <p class="typography.body-text">
                 We turn ideas into successful products, working closely with our clients in short iterations. Our solutions are well architected and easy to maintain and extend by our clients once they are ready to take over themselves.
               </p>
-              <a href="/services/software-engineering" class="typography.arrow-link">
+              <a href="/services/software-engineering" class="typography.arrow-link" data-navigo>
                 Learn More
               </a>
             </div>
@@ -34,7 +34,7 @@
               <p class="typography.body-text">
                 Not all engineering teams have the experience or confidence to make big decisions and complete large scale projects on time and budget. Our technology experts step in and merge with our clients' in-house engineering teams, spearhead development initiatives, establish best practices and install a smooth engineering process to get their projects across the finish line.
               </p>
-              <a href="/services/team-augmentation" class="typography.arrow-link">
+              <a href="/services/team-augmentation" class="typography.arrow-link" data-navigo>
                 Learn More
               </a>
             </div>
@@ -51,7 +51,7 @@
               <p class="typography.body-text">
                 From introductory workshops on frameworks like Ember.js or Phoenix to advanced classes on distributed systems design, authentication, deployment or scalability, we set up customized training sessions that suit the needs of our clients and their teams.
               </p>
-              <a href="/service" class="typography.arrow-link">
+              <a href="/service" class="typography.arrow-link" data-navigo>
                 Learn More
               </a>
             </div>
@@ -73,7 +73,7 @@
             <p class="card.text">
               Our process is simple and client-focused. Get an insight on how we work to deliver ambitious software solutions.
             </p>
-            <a class="typography.arrow-link" href="/playbook">
+            <a class="typography.arrow-link" href="/playbook" data-navigo>
               Read our Playbook
             </a>
           </div>

--- a/src/ui/components/Services/template.hbs
+++ b/src/ui/components/Services/template.hbs
@@ -21,7 +21,7 @@
               <p class="typography.body-text">
                 We turn ideas into successful products, working closely with our clients in short iterations. Our solutions are well architected and easy to maintain and extend by our clients once they are ready to take over themselves.
               </p>
-              <a href="/services/software-engineering" class="typography.arrow-link" data-navigo>
+              <a href="/services/software-engineering" class="typography.arrow-link" data-internal>
                 Learn More
               </a>
             </div>
@@ -34,7 +34,7 @@
               <p class="typography.body-text">
                 Not all engineering teams have the experience or confidence to make big decisions and complete large scale projects on time and budget. Our technology experts step in and merge with our clients' in-house engineering teams, spearhead development initiatives, establish best practices and install a smooth engineering process to get their projects across the finish line.
               </p>
-              <a href="/services/team-augmentation" class="typography.arrow-link" data-navigo>
+              <a href="/services/team-augmentation" class="typography.arrow-link" data-internal>
                 Learn More
               </a>
             </div>
@@ -51,7 +51,7 @@
               <p class="typography.body-text">
                 From introductory workshops on frameworks like Ember.js or Phoenix to advanced classes on distributed systems design, authentication, deployment or scalability, we set up customized training sessions that suit the needs of our clients and their teams.
               </p>
-              <a href="/service" class="typography.arrow-link" data-navigo>
+              <a href="/service" class="typography.arrow-link" data-internal>
                 Learn More
               </a>
             </div>
@@ -73,7 +73,7 @@
             <p class="card.text">
               Our process is simple and client-focused. Get an insight on how we work to deliver ambitious software solutions.
             </p>
-            <a class="typography.arrow-link" href="/playbook" data-navigo>
+            <a class="typography.arrow-link" href="/playbook" data-internal>
               Read our Playbook
             </a>
           </div>

--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -47,7 +47,7 @@ export default class Simplabs extends Component {
       document.addEventListener('click', (event: Event) => {
         const target = event.target as HTMLElement;
       
-        if (target.tagName === 'A' && target.dataset.navigo !== undefined) {
+        if (target.tagName === 'A' && target.dataset.internal !== undefined) {
           event.preventDefault();
           this.router.navigate(target.getAttribute('href'));
         }

--- a/src/ui/components/SoftwareEngineering/template.hbs
+++ b/src/ui/components/SoftwareEngineering/template.hbs
@@ -127,7 +127,7 @@
             <p class="typography.body-text">
               Get an overview on the actions and steps we take to consistently achieve high productivity and quality.
             </p>
-            <a class="typography.arrow-link" href="#">
+            <a class="typography.arrow-link" href="#" data-navigo>
               Read our Playbook
             </a>
           </div>

--- a/src/ui/components/SoftwareEngineering/template.hbs
+++ b/src/ui/components/SoftwareEngineering/template.hbs
@@ -127,7 +127,7 @@
             <p class="typography.body-text">
               Get an overview on the actions and steps we take to consistently achieve high productivity and quality.
             </p>
-            <a class="typography.arrow-link" href="#" data-navigo>
+            <a class="typography.arrow-link" href="#" data-internal>
               Read our Playbook
             </a>
           </div>

--- a/src/ui/components/TeamAugmentation/template.hbs
+++ b/src/ui/components/TeamAugmentation/template.hbs
@@ -136,7 +136,7 @@
             <p class="typography.body-text">
               Get an overview on the actions and steps we take to consistently achieve high productivity and quality.
             </p>
-            <a class="typography.arrow-link" href="#" data-navigo>
+            <a class="typography.arrow-link" href="#" data-internal>
               Read our Playbook
             </a>
           </div>

--- a/src/ui/components/TeamAugmentation/template.hbs
+++ b/src/ui/components/TeamAugmentation/template.hbs
@@ -136,7 +136,7 @@
             <p class="typography.body-text">
               Get an overview on the actions and steps we take to consistently achieve high productivity and quality.
             </p>
-            <a class="typography.arrow-link" href="#">
+            <a class="typography.arrow-link" href="#" data-navigo>
               Read our Playbook
             </a>
           </div>

--- a/src/ui/components/TrainlineCaseStudy/template.hbs
+++ b/src/ui/components/TrainlineCaseStudy/template.hbs
@@ -45,7 +45,7 @@
                 <p class="typography.body-text">
                   Besides working on the core application, simplabs spearheaded several engineering efforts focused around mobile performance, improved load times, server side rendering and localization.
                 </p>
-                <a class="typography.arrow-link" href="#" data-navigo>
+                <a class="typography.arrow-link" href="#" data-internal>
                   Learn More
                 </a>
               </div>
@@ -84,7 +84,7 @@
             <p class="card.text">
               We value conventions-based frameworks that result in maintainable and well-defined projects which are easy to take over by our clients once we've left.
             </p>
-            <a class="typography.arrow-link" href="#" data-navigo>
+            <a class="typography.arrow-link" href="#" data-internal>
               Learn More
             </a>
           </div>

--- a/src/ui/components/TrainlineCaseStudy/template.hbs
+++ b/src/ui/components/TrainlineCaseStudy/template.hbs
@@ -45,7 +45,7 @@
                 <p class="typography.body-text">
                   Besides working on the core application, simplabs spearheaded several engineering efforts focused around mobile performance, improved load times, server side rendering and localization.
                 </p>
-                <a class="typography.arrow-link" href="#">
+                <a class="typography.arrow-link" href="#" data-navigo>
                   Learn More
                 </a>
               </div>
@@ -84,7 +84,7 @@
             <p class="card.text">
               We value conventions-based frameworks that result in maintainable and well-defined projects which are easy to take over by our clients once we've left.
             </p>
-            <a class="typography.arrow-link" href="#">
+            <a class="typography.arrow-link" href="#" data-navigo>
               Learn More
             </a>
           </div>

--- a/src/ui/components/TrainlineCaseThumb/template.hbs
+++ b/src/ui/components/TrainlineCaseThumb/template.hbs
@@ -16,7 +16,7 @@
       <h3 class="typography.headline-2">
         Leveraging Trainline's full market potential
       </h3>
-      <a class="typography.arrow-link" href="/cases/trainline" data-navigo>
+      <a class="typography.arrow-link" href="/cases/trainline" data-internal>
         Read Case Study
       </a>
     </div>

--- a/src/ui/components/TrainlineCaseThumb/template.hbs
+++ b/src/ui/components/TrainlineCaseThumb/template.hbs
@@ -16,7 +16,7 @@
       <h3 class="typography.headline-2">
         Leveraging Trainline's full market potential
       </h3>
-      <a class="typography.arrow-link" href="/cases/trainline">
+      <a class="typography.arrow-link" href="/cases/trainline" data-navigo>
         Read Case Study
       </a>
     </div>

--- a/src/ui/components/Work/template.hbs
+++ b/src/ui/components/Work/template.hbs
@@ -31,7 +31,7 @@
                 <p class="typography.body-text">
                   Trainline is Europe’s leading independent rail and coach platform. We worked with them to deliver a high-performance mobile web app, along with an improved engineering process, enabling Trainline to achieve their business goals for years to come.
                 </p>
-                <a href="#" class="typography.arrow-link" data-navigo>
+                <a href="#" class="typography.arrow-link" data-internal>
                   Read Case Study
                 </a>
                 <div class="main-block.body-image">
@@ -52,7 +52,7 @@
                 <p class="typography.body-text">
                   When Timify decided it was time to re-engineer their existing product, they trusted us to bring them into the future. We added engineering capacity and technology expertise to Timify's internal team and helped to build a solid foundation that enabled them to iterate fast and launch on-schedule, without sacrificing quality.
                 </p>
-                <a href="#" class="typography.arrow-link" data-navigo>
+                <a href="#" class="typography.arrow-link" data-internal>
                   Read Case Study
                 </a>
                 <div class="main-block.body-image">
@@ -70,7 +70,7 @@
                 <h3 class="typography.headline-2">
                   A modern UI for an open-source router firmware
                 </h3>
-                <a href="#" class="typography.arrow-link" data-navigo>
+                <a href="#" class="typography.arrow-link" data-internal>
                   Read Case Study
                 </a>
               </div>
@@ -81,7 +81,7 @@
                 <h3 class="typography.headline-2">
                   An online travel magazine for global citizens
                 </h3>
-                <a href="#" class="typography.arrow-link" data-navigo>
+                <a href="#" class="typography.arrow-link" data-internal>
                   Read Case Study
                 </a>
               </div>

--- a/src/ui/components/Work/template.hbs
+++ b/src/ui/components/Work/template.hbs
@@ -31,7 +31,7 @@
                 <p class="typography.body-text">
                   Trainline is Europe’s leading independent rail and coach platform. We worked with them to deliver a high-performance mobile web app, along with an improved engineering process, enabling Trainline to achieve their business goals for years to come.
                 </p>
-                <a href="#" class="typography.arrow-link">
+                <a href="#" class="typography.arrow-link" data-navigo>
                   Read Case Study
                 </a>
                 <div class="main-block.body-image">
@@ -52,7 +52,7 @@
                 <p class="typography.body-text">
                   When Timify decided it was time to re-engineer their existing product, they trusted us to bring them into the future. We added engineering capacity and technology expertise to Timify's internal team and helped to build a solid foundation that enabled them to iterate fast and launch on-schedule, without sacrificing quality.
                 </p>
-                <a href="#" class="typography.arrow-link">
+                <a href="#" class="typography.arrow-link" data-navigo>
                   Read Case Study
                 </a>
                 <div class="main-block.body-image">
@@ -70,7 +70,7 @@
                 <h3 class="typography.headline-2">
                   A modern UI for an open-source router firmware
                 </h3>
-                <a href="#" class="typography.arrow-link">
+                <a href="#" class="typography.arrow-link" data-navigo>
                   Read Case Study
                 </a>
               </div>
@@ -81,7 +81,7 @@
                 <h3 class="typography.headline-2">
                   An online travel magazine for global citizens
                 </h3>
-                <a href="#" class="typography.arrow-link">
+                <a href="#" class="typography.arrow-link" data-navigo>
                   Read Case Study
                 </a>
               </div>

--- a/src/ui/components/WorkWithUs/template.hbs
+++ b/src/ui/components/WorkWithUs/template.hbs
@@ -7,7 +7,7 @@
   <p class="typography.lead" state:typography.offset>
     Talk to one of our technology experts to find out how we can help you.
   </p>
-  <a class="button.button" href="#">
+  <a class="button.button" href="#" data-navigo>
     Let's discuss your project
   </a>
 </div>

--- a/src/ui/components/WorkWithUs/template.hbs
+++ b/src/ui/components/WorkWithUs/template.hbs
@@ -7,7 +7,7 @@
   <p class="typography.lead" state:typography.offset>
     Talk to one of our technology experts to find out how we can help you.
   </p>
-  <a class="button.button" href="#" data-navigo>
+  <a class="button.button" href="#" data-internal>
     Let's discuss your project
   </a>
 </div>


### PR DESCRIPTION
This fixes internal links by:

* adding missing `data-navigo` attributes to templates
* making absolute links in blog posts relative
* adding `data-navigo` attributes to internal links in blog posts automatically

This also renames `data-navigo` to `data-internal` as the fact that we're (currently) using navigo is an implementation detail that we don't need to expose everywhere in the app.