### PR TITLE
Fix css-blocks states

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -122,6 +122,9 @@ module.exports = function(defaults) {
     fingerprint: {
       exclude: ['ssr-app.js'],
     },
+    rollup: {
+      plugins: [resolve({ jsnext: true, module: true, main: true }), commonjs()],
+    },
   });
 
   return app.toTree();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import { classnames } from '@css-blocks/glimmer/dist/cjs/src/helpers/classnames';
+import { concat } from '@css-blocks/glimmer/dist/cjs/src/helpers/concat';
 import { ComponentManager, setPropertyDidChange } from '@glimmer/component';
 import App from './main';
 
@@ -7,6 +9,17 @@ const app = new App({ hasSSRBody });
 
 setPropertyDidChange(() => {
   app.scheduleRerender();
+});
+
+app.registerInitializer({
+  initialize(registry) {
+    registry._resolver.registry._entries[
+      `helper:/${app.rootName}/components/-css-blocks-classnames`
+    ] = classnames;
+    registry._resolver.registry._entries[
+      `helper:/${app.rootName}/components/-css-blocks-concat`
+    ] = concat;
+  }
 });
 
 app.registerInitializer({


### PR DESCRIPTION
css-blocks doesn't currently register its helpers correctly in Glimmer.js apps (it does in Ember.js apps) - see linkedin/css-blocks#195. This registers the helpers manually (based on https://github.com/linkedin/css-blocks/issues/195#issuecomment-426799214) which is pretty hacky but should be possible to remove once the underlying problem in `@css-blocks/glimmer` has been fixed.