### PR TITLE
Split blog bundle from main app bundle

### DIFF
--- a/config/routes-map.js
+++ b/config/routes-map.js
@@ -14,8 +14,8 @@ module.exports = function() {
         module: `__blog-${post.queryPath}__`,
       },
       parentBundle: {
-        asset: '/blog.js'
-      }
+        asset: '/blog.js',
+      },
     };
     return acc;
   }, {});

--- a/config/routes-map.js
+++ b/config/routes-map.js
@@ -7,7 +7,16 @@ const collectPosts = require('../lib/generate-blog-components/lib/collect-posts'
 module.exports = function() {
   let blogPosts = collectPosts(path.join(__dirname, '..', '_posts'));
   let blogPostRoutes = blogPosts.reduce((acc, post) => {
-    acc[`/blog/${post.queryPath}`] = { component: post.componentName, bundle: 'blog' };
+    acc[`/blog/${post.queryPath}`] = {
+      component: post.componentName,
+      bundle: {
+        asset: `/blog-${post.queryPath}.js`,
+        module: `__blog-${post.queryPath}__`,
+      },
+      parentBundle: {
+        asset: '/blog.js'
+      }
+    };
     return acc;
   }, {});
 
@@ -26,7 +35,7 @@ module.exports = function() {
     '/calendar': { component: 'Calendar' },
     '/playbook': { component: 'Playbook' },
     '/contact': { component: 'Contact' },
-    '/blog': { component: 'Blog', bundle: 'blog' },
+    '/blog': { component: 'Blog', bundle: { asset: '/blog.js', module: '__blog__' } },
   };
 
   return routes;

--- a/config/routes-map.js
+++ b/config/routes-map.js
@@ -7,7 +7,7 @@ const collectPosts = require('../lib/generate-blog-components/lib/collect-posts'
 module.exports = function() {
   let blogPosts = collectPosts(path.join(__dirname, '..', '_posts'));
   let blogPostRoutes = blogPosts.reduce((acc, post) => {
-    acc[`/blog/${post.queryPath}`] = { component: post.componentName };
+    acc[`/blog/${post.queryPath}`] = { component: post.componentName, bundle: 'blog' };
     return acc;
   }, {});
 
@@ -26,7 +26,7 @@ module.exports = function() {
     '/calendar': { component: 'Calendar' },
     '/playbook': { component: 'Playbook' },
     '/contact': { component: 'Contact' },
-    '/blog': { component: 'Blog' },
+    '/blog': { component: 'Blog', bundle: 'blog' },
   };
 
   return routes;

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -140,7 +140,7 @@ class SimplabsApp extends GlimmerApp {
         input: 'config/module-map.js',
         output: {
           file: 'blog.js',
-          name: 'blog',
+          name: '__blog__',
           format: 'umd',
           sourcemap: this.options.sourcemaps.enabled,
         },

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -139,8 +139,8 @@ class SimplabsApp extends GlimmerApp {
       rollup: {
         input: 'config/module-map.js',
         output: {
-          file: 'blog-content.js',
-          name: 'blog-content',
+          file: 'blog.js',
+          name: 'blog',
           format: 'umd',
           sourcemap: this.options.sourcemaps.enabled,
         },

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -13,8 +13,6 @@ const typescript = require('broccoli-typescript-compiler').default;
 const glob = require('glob');
 const commonjs = require('rollup-plugin-commonjs');
 const resolve = require('rollup-plugin-node-resolve');
-const BroccoliDebug = require('broccoli-debug');
-const replace = require('broccoli-string-replace');
 
 function findAllComponents() {
   let routes = require('./config/routes-map')();
@@ -97,7 +95,7 @@ class SimplabsApp extends GlimmerApp {
     mainSiteTree = new MergeTrees([mainSiteTree, mainSiteModuleMap], { overwrite: true });
 
     let blogTree = new Funnel(tree, {
-      exclude: ['src/ui/components/!(Blog)*']
+      exclude: ['src/ui/components/!(Blog)*'],
     });
     let blogJsTree = new Funnel(blogTree, {
       exclude: ['src/ui/components/**/*.hbs'],

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -73,7 +73,6 @@ class SimplabsApp extends GlimmerApp {
 
   package(jsTree) {
     let [mainSiteTree, blogTree] = this._splitBlogTree(jsTree);
-    blogTree = new BroccoliDebug(blogTree, 'simplabs:blog');
     let appTree = super.package(mainSiteTree);
     let blogContentTree = this._packageBlog(blogTree);
     let mainTree = new MergeTrees([appTree, blogContentTree]);
@@ -141,15 +140,10 @@ class SimplabsApp extends GlimmerApp {
       rollup: {
         input: 'config/module-map.js',
         output: {
-          file: 'blog.js',
-          format: 'cjs',
-        },
-        onwarn(warning) {
-          if (warning.code === 'THIS_IS_UNDEFINED') {
-            return;
-          }
-          // eslint-disable-next-line no-console
-          console.log('Rollup warning: ', warning.message);
+          file: 'blog-content.js',
+          name: 'blog-content',
+          format: 'umd',
+          sourcemap: this.options.sourcemaps.enabled,
         },
         plugins: [resolve({ jsnext: true, module: true, main: true }), commonjs()],
       },

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -71,7 +71,7 @@ class SimplabsApp extends GlimmerApp {
   }
 
   package(jsTree) {
-    let [mainSiteTree, blogTree] = this._splitBundle(jsTree, {
+    let [blogTree, mainSiteTree] = this._splitBundle(jsTree, {
       componentPrefix: 'Blog',
       file: 'blog.js',
       moduleName: '__blog__',
@@ -79,7 +79,7 @@ class SimplabsApp extends GlimmerApp {
 
     let blogPosts = collectPosts(path.join(__dirname, '_posts'));
     let blogPostTrees = blogPosts.map(post => {
-      let [_, blogPostTree] = this._splitBundle(jsTree, {
+      let [blogPostTree] = this._splitBundle(jsTree, {
         componentPrefix: post.componentName,
         file: `blog-${post.queryPath}.js`,
         moduleName: `__blog-${post.queryPath}__`,
@@ -145,7 +145,7 @@ class SimplabsApp extends GlimmerApp {
     bundleTree = new MergeTrees([bundleTree, bundleModuleMap], { overwrite: true });
     bundleTree = this._packageSplitBundle(bundleTree, bundle);
 
-    return [mainBundleTree, bundleTree];
+    return [bundleTree, mainBundleTree];
   }
 
   _packageSplitBundle(bundleTree, bundle) {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -96,10 +96,9 @@ class SimplabsApp extends GlimmerApp {
     let mainSiteModuleMap = this.buildResolutionMap(mainSiteJsTree);
     mainSiteTree = new MergeTrees([mainSiteTree, mainSiteModuleMap], { overwrite: true });
 
-    tree = new BroccoliDebug(tree, 'simplabs:in-tree');
-    let blogTree = new BroccoliDebug(new Funnel(tree, {
+    let blogTree = new Funnel(tree, {
       exclude: ['src/ui/components/!(Blog)*']
-    }), 'simplabs:blog-before');
+    });
     let blogJsTree = new Funnel(blogTree, {
       exclude: ['src/ui/components/**/*.hbs'],
     });

--- a/lib/generate-blog-components/lib/files/post/component-css-block.hbs
+++ b/lib/generate-blog-components/lib/files/post/component-css-block.hbs
@@ -15,9 +15,6 @@
 {{componentName}}
 ;
   extends: blog-post;
-  --accent-color: #007df6;
-  --shape-decoration-position-right: -92em;
-  --shape-decoration-position-top: -20em;
 }
 
 .related-background {

--- a/lib/generate-blog-components/lib/files/post/component-css-block.hbs
+++ b/lib/generate-blog-components/lib/files/post/component-css-block.hbs
@@ -20,7 +20,7 @@
   --shape-decoration-position-top: -20em;
 }
 
-.background {
+.related-background {
 {{#if relatedTeaserBackground}}
   background:{{relatedTeaserBackground}};
 {{/if}}

--- a/lib/generate-blog-components/lib/files/post/component-template.hbs
+++ b/lib/generate-blog-components/lib/files/post/component-template.hbs
@@ -63,7 +63,7 @@
       {{#if related}}
         <div class="shape.wrap">
           <div class="shape-left">
-            <div class="shape-left.background background">
+            <div class="shape-left.background related-background">
               {{#if related.teaserImage}}
                 <div class="shape-left.content">
                   <div class="shape.content-image">
@@ -87,7 +87,7 @@
             </div>
           </div>
           <div class="shape-decoration">
-            <div class="shape-decoration.background background"></div>
+            <div class="shape-decoration.background related-background"></div>
           </div>
         </div>
       {{/if}}

--- a/lib/inject-routes/package.json
+++ b/lib/inject-routes/package.json
@@ -2,5 +2,8 @@
   "name": "inject-routes",
   "keywords": [
     "ember-addon"
-  ]
+  ],
+  "ember-addon": {
+    "before": "broccoli-asset-rev"
+  }
 }

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -52,10 +52,9 @@ let server = express();
 server.get('*', async function(req, res, next) {
   if (req.headers.accept && req.headers.accept.includes('text/html')) {
     let origin = `${req.protocol}://${req.headers.host}`;
-    let app = await renderer.render(origin, req.url);
-    let body = `<div id="app">${app}</div>`;
-    body = HTML.replace('<div id="app"></div>', body);
-    res.send(body);
+    let body = await renderer.render(origin, req.url);
+    let html = HTML.replace('<div id="app"></div>', body);
+    res.send(html);
   } else {
     next();
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,19 +13,29 @@ setPropertyDidChange(() => {
 
 app.registerInitializer({
   initialize(registry) {
+    function registerBundle(module) {
+      let content = window[module] || {};
+      Object.keys(content).forEach((key) => {
+        if (!registry._resolver.registry._entries[key]) {
+          registry._resolver.registry._entries[key] = content[key];
+        }
+      });
+    }
+
     class LazyRegistration {
       public static create() {
-        return new LazyRegistration(registry);
+        return new LazyRegistration();
       }
 
-      constructor(theRegistry) {
-        this.registry = theRegistry;
-      }
-
-      public register(key, content) {
-        this.registry._resolver.registry._entries[key] = content;
+      public registerBundle(module) {
+        registerBundle(module);
       }
     }
+
+    document.querySelectorAll('[data-shoebox]').forEach((shoebox) => {
+      let module = shoebox.dataset.shoeboxBundle;
+      registerBundle(module);
+    });
 
     registry.register(
       `utils:/${app.rootName}/lazy-registration/main`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,14 @@ setPropertyDidChange(() => {
 
 app.registerInitializer({
   initialize(registry) {
+    window.__lazyRegister__ = function(key, content) {
+      registry._resolver.registry._entries[key] = content;
+    };
+  }
+});
+
+app.registerInitializer({
+  initialize(registry) {
     registry._resolver.registry._entries[
       `helper:/${app.rootName}/components/-css-blocks-classnames`
     ] = classnames;

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,10 +4,9 @@ import moduleMap from '../config/module-map';
 import resolverConfiguration from '../config/resolver-configuration';
 
 export default class App extends Application {
-  constructor({ hasSSRBody = false }) {
+  constructor({ hasSSRBody = false, element }) {
     let moduleRegistry = new BasicModuleRegistry(moduleMap);
     let resolver = new Resolver(resolverConfiguration, moduleRegistry);
-    const element = document.body;
 
     const BuilderType = hasSSRBody ? RehydratingBuilder : DOMBuilder;
 

--- a/src/ui/components/Loader/component.ts
+++ b/src/ui/components/Loader/component.ts
@@ -1,0 +1,8 @@
+import Component, { tracked } from '@glimmer/component';
+
+export default class Loader extends Component {
+  @tracked
+  get translation() {
+    return 100 - this.args.progress;
+  }
+}

--- a/src/ui/components/Loader/stylesheet.css
+++ b/src/ui/components/Loader/stylesheet.css
@@ -1,0 +1,12 @@
+:scope {
+  block-name: loader;
+  --accent-color: #007DF6;
+  transition: all 200ms ease 0s;
+  background: var(--accent-color);
+  position: fixed;
+  z-index: 1031;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+}

--- a/src/ui/components/Loader/template.hbs
+++ b/src/ui/components/Loader/template.hbs
@@ -1,0 +1,1 @@
+<div role="bar" style="transform: translate3d(-{{this.translation}}%, 0px, 0px);"></div>

--- a/src/ui/components/Navigation/template.hbs
+++ b/src/ui/components/Navigation/template.hbs
@@ -14,7 +14,7 @@
     <a href="/about" class="nav-item" data-internal>
       About
     </a>
-    <a href="/blog" class="nav-item" data-internal>
+    <a href="/blog" class="nav-item" data-internal data-bundle="blog">
       Blog
     </a>
   </nav>

--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -50,7 +50,7 @@ export default class Simplabs extends Component {
       if (bundle && !this.appState.isSSR) {
         options.before = async (done) => {
           await this._loadBundle(bundle, parentBundle);
-          this._registerContent(bundle);
+          this._registerBundle(bundle);
           done();
         };
       }
@@ -101,11 +101,8 @@ export default class Simplabs extends Component {
     });
   }
 
-  private _registerContent(bundle) {
-    let content = window[bundle.module] || {};
-    Object.keys(content).forEach((key) => {
-      this.lazyRegistration.register(key, content[key]);
-    });
+  private _registerBundle(bundle) {
+    this.lazyRegistration.registerBundle(bundle.module);
   }
 
   private _startLoader() {
@@ -122,6 +119,8 @@ export default class Simplabs extends Component {
   private _injectBundle(bundle) {
     let script = this.document.createElement('script');
     script.setAttribute('src', bundle.asset);
+    script.setAttribute('data-shoebox', true);
+    script.setAttribute('data-shoebox-bundle', bundle.module);
     this.document.body.appendChild(script);
   }
 }

--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -41,8 +41,16 @@ export default class Simplabs extends Component {
     this.router = new Navigo(this.appState.origin);
 
     Object.keys(this.routesMap).forEach((path) => {
-      let { component } = this.routesMap[path];
-      this.router.on(path, () => this.activeComponent = component);
+      let { component, bundle } = this.routesMap[path];
+      let options = {};
+      if (bundle) {
+        options.before = async (done) => {
+          await this._loadBundle(bundle);
+          this._registerContent(bundle);
+          done();
+        };
+      }
+      this.router.on(path, () => this.activeComponent = component, options);
     });
     this.router.resolve(this.appState.route);
   }
@@ -54,12 +62,6 @@ export default class Simplabs extends Component {
       
         if (target.tagName === 'A' && target.dataset.internal !== undefined) {
           event.preventDefault();
-
-          let bundle = target.dataset.bundle as String;
-          if (bundle !== undefined) {
-            await this._loadBundle(bundle);
-            this._registerContent(bundle);
-          }
           this.router.navigate(target.getAttribute('href'));
         }
       });

--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -20,6 +20,12 @@ export default class Simplabs extends Component {
   @tracked
   private activeComponent: string = null;
 
+  @tracked
+  private isLoading: boolean = false;
+
+  @tracked
+  private loadingProgress: number = 0;
+
   constructor(options) {
     super(options);
 
@@ -71,7 +77,10 @@ export default class Simplabs extends Component {
       }
 
       let script = document.createElement('script');
-      script.onload = resolve;
+      script.onload = () => {
+        this._stopLoader();
+        resolve();
+      };
       script.onerror = function(error) {
         if (this.parentNode) {
           this.parentNode.removeChild(this);
@@ -80,8 +89,8 @@ export default class Simplabs extends Component {
       };
       script.src = bundle.asset;
       script.async = false;
-      
       document.head.appendChild(script);
+      this._startLoader();
     });
   }
 
@@ -90,5 +99,16 @@ export default class Simplabs extends Component {
     Object.keys(content).forEach((key) => {
       window.__lazyRegister__(key, content[key])
     });
+  }
+
+  private _startLoader() {
+    this.isLoading = true;
+    this._loadingProgressInterval = window.setInterval(() => this.loadingProgress = Math.min(this.loadingProgress + 10, 100), 150);
+  }
+
+  private _stopLoader() {
+    window.clearInterval(this._loadingProgressInterval);
+    this.loadingProgress = 100;
+    window.setTimeout(() => this.isLoading = false, 150);
   }
 }

--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -39,6 +39,7 @@ export default class Simplabs extends Component {
 
     this._setupRouting();
     this._bindInternalLinks();
+    this._restoreActiveComponentState();
   }
 
   private _setupRouting() {
@@ -55,10 +56,13 @@ export default class Simplabs extends Component {
         };
       }
       this.router.on(path, () => {
-        if (bundle && this.appState.isSSR) {
-          this._injectBundle(bundle);
-        }
         this.activeComponent = component;
+        if (this.appState.isSSR) {
+          if (bundle) {
+            this._injectBundle(bundle);
+          }
+          this._injectActiveComponentState();
+        }
       }, options);
     });
     this.router.resolve(this.appState.route);
@@ -122,5 +126,21 @@ export default class Simplabs extends Component {
     script.setAttribute('data-shoebox', true);
     script.setAttribute('data-shoebox-bundle', bundle.module);
     this.document.body.appendChild(script);
+  }
+
+  private _injectActiveComponentState() {
+    let script = this.document.createElement('script');
+    script.setAttribute('data-shoebox', true);
+    script.setAttribute('data-shoebox-active-component', this.activeComponent);
+    this.document.body.appendChild(script);
+  }
+
+  private _restoreActiveComponentState() {
+    if (!this.appState.isSSR) {
+      let script = document.querySelector('[data-shoebox-active-component]');
+      if (script) {
+        this.activeComponent = script.dataset.shoeboxActiveComponent;
+      }
+    }
   }
 }

--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -22,7 +22,7 @@ export default class Simplabs extends Component {
   private appState: IAppState;
 
   @tracked
-  private activeComponent: string;
+  private activeComponent: string = null;
 
   constructor(options) {
     super(options);

--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -66,7 +66,7 @@ export default class Simplabs extends Component {
 
   private _bindInternalLinks() {
     if (!this.appState.isSSR) {
-      document.addEventListener('click', async (event: Event) => {
+      document.addEventListener('click', (event: Event) => {
         let target = event.target as HTMLElement;
 
         if (target.tagName === 'A' && target.dataset.internal !== undefined) {

--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -1,4 +1,5 @@
 import Component, { tracked } from '@glimmer/component';
+import { getOwner } from '@glimmer/di';
 import Navigo from 'navigo';
 
 interface IRoutesMap {
@@ -54,8 +55,10 @@ export default class Simplabs extends Component {
         if (target.tagName === 'A' && target.dataset.internal !== undefined) {
           event.preventDefault();
 
-          if (target.dataset.bundle !== undefined) {
-            await this._loadBundle(target.dataset.bundle);
+          let bundle = target.dataset.bundle as String;
+          if (bundle !== undefined) {
+            await this._loadBundle(bundle);
+            this._registerContent(bundle);
           }
           this.router.navigate(target.getAttribute('href'));
         }
@@ -82,6 +85,13 @@ export default class Simplabs extends Component {
       script.async = false;
       
       document.head.appendChild(script);
+    });
+  }
+
+  private _registerContent(bundle) {
+    let content = window[`__${bundle}__`] || {};
+    Object.keys(content).forEach((key) => {
+      window.__lazyRegister__(key, content[key])
     });
   }
 }

--- a/src/ui/components/Simplabs/template.hbs
+++ b/src/ui/components/Simplabs/template.hbs
@@ -1,4 +1,7 @@
 <div data-has-ssr-response={{appState.isSSR}}>
+  {{#if this.isLoading}}
+    <Loader @progress={{this.loadingProgress}} />
+  {{/if}}
   {{#if activeComponent}}
     {{component activeComponent}}
   {{/if}}

--- a/src/ui/lazy-registration.d.ts
+++ b/src/ui/lazy-registration.d.ts
@@ -1,0 +1,3 @@
+interface ILazyRegistration {
+  register(key: string, content: any)
+}

--- a/src/ui/styles/blocks/blog-post.block.css
+++ b/src/ui/styles/blocks/blog-post.block.css
@@ -3,6 +3,9 @@
 :scope {
   block-name: blog-post;
   extends: screen;
+  --accent-color: #007df6;
+  --shape-decoration-position-right: -92em;
+  --shape-decoration-position-top: -20em;
 }
 
 .logo {

--- a/ssr/index.ts
+++ b/ssr/index.ts
@@ -23,6 +23,7 @@ export default class GlimmerRenderer {
 
     const mountEl = document.createElement('div');
     mountEl.setAttribute('id', 'app');
+    document.body.appendChild(mountEl);
     let renderer = new SyncRenderer();
     let builder = new SerializingBuilder({ element: document.body as any as Element, nextSibling: null });
 

--- a/ssr/ssr-application.ts
+++ b/ssr/ssr-application.ts
@@ -76,7 +76,13 @@ export default class SSRApplication extends Application {
         );
         registry.registerInjection(
           `component:/${rootName}/components/Simplabs`,
-          'appState', `app-state:/${rootName}/main/main`
+          'appState',
+          `app-state:/${rootName}/main/main`
+        );
+        registry.registerInjection(
+          `component:/${rootName}/components/Simplabs`,
+          'document',
+          `document:/${rootName}/main/main`
         );
         registry.register(
           `component-manager:/${rootName}/component-managers/main`,
@@ -121,6 +127,6 @@ export default class SSRApplication extends Application {
       throw err;
     }
 
-    return this.serializer.serializeChildren(this.element);
+    return this.serializer.serializeChildren(this.document.body);
   }
 }


### PR DESCRIPTION
The blog bundle is relatively big and we shouldn't load it for everyone but only when it's needed. This PR does just that - it splits all of the blog components and templates into a separate `blog.js` and only loads that when required.

### TODO

- [x] split each blog post into its own bundle and load only that when going to the particular page
- [x] when starting the app on the `/blog` route in dev mode, there's an error
- [x] the blog bundles don't get fingerprinted correctly in the source code in production so that the requests go to the non-fingerprinted assets
- [x] show a loader while the bundle is lazily loading
- [x] the pre-rendered pages do not include the lazily inserted script tags

closes #273 