### PR TITLE
scroll to top after route changes

### DIFF
--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -76,6 +76,7 @@ export default class Simplabs extends Component {
         if (target.tagName === 'A' && target.dataset.internal !== undefined) {
           event.preventDefault();
           this.router.navigate(target.getAttribute('href'));
+          window.scrollTo(0, 0);
         }
       });
     }


### PR DESCRIPTION
…so we don't go to the bottom of the target route.