### PR TITLE
navigate for clicks on elements inside links

### DIFF
--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -90,8 +90,9 @@ export default class Simplabs extends Component {
     if (!this.appState.isSSR) {
       document.addEventListener('click', (event: Event) => {
         let target = event.target as HTMLElement;
+        let link = findLinkParent(target);
 
-        if (target.tagName === 'A' && target.dataset.internal !== undefined) {
+        if (link && link.dataset.internal !== undefined) {
           event.preventDefault();
           this.router.navigate(target.getAttribute('href'));
           window.scrollTo(0, 0);
@@ -180,4 +181,15 @@ export default class Simplabs extends Component {
 
 function formatPageTitle(title) {
   return `${title ? `${title} | ` : ''}simplabs`;
+}
+
+function findLinkParent(target) {
+  let element = target;
+  while (element && element !== document) {
+    if (element.matches('a')) {
+      return element;
+    }
+    element = element.parentElement;
+  }
+  return null;
 }


### PR DESCRIPTION
This fixes navigation when the user clicks on elements **inside** of a link. Currently, we only navigate correctly when the clicked element itself is a link while we actually want to navigate for clicks on elements **inside** of links as well (e.g. the image in the main navigation).