### PR TITLE
Add components for recent posts

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -14,6 +14,7 @@ const glob = require('glob');
 const commonjs = require('rollup-plugin-commonjs');
 const resolve = require('rollup-plugin-node-resolve');
 const collectPosts = require('./lib/generate-blog-components/lib/collect-posts');
+const _ = require('lodash');
 
 function findAllComponents() {
   let routes = require('./config/routes-map')();
@@ -25,13 +26,19 @@ function findAllComponents() {
     return acc;
   }, []);
 
+  let recentContentComponents = _.chain(collectPosts(path.join(__dirname, '_posts')).posts)
+    .map('meta.topic')
+    .uniq()
+    .map(topic => `RecentPosts${_.capitalize(topic)}`)
+    .value();
+
   let staticComponents = glob
     .sync('*/', {
       cwd: path.join(__dirname, 'src/ui/components'),
     })
     .map(component => component.replace(/\/$/, ''));
 
-  let allComponents = routedComponents.concat(staticComponents);
+  let allComponents = routedComponents.concat(staticComponents).concat(recentContentComponents);
   return [...new Set(allComponents)];
 }
 

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -125,6 +125,13 @@ class SimplabsApp extends GlimmerApp {
     });
     mainSiteTree = mainSiteNonTalksTree;
 
+    let [recentContentTree, mainSiteNonRecentTree] = this._splitBundle(mainSiteTree, {
+      componentPrefix: 'Recent',
+      file: 'recent.js',
+      moduleName: '__recent__',
+    });
+    mainSiteTree = mainSiteNonRecentTree;
+
     let appTree = super.package(mainSiteTree);
     let mainTree = new MergeTrees([
       appTree,
@@ -132,6 +139,7 @@ class SimplabsApp extends GlimmerApp {
       calendarTree,
       playbookTree,
       talksTree,
+      recentContentTree,
       blogTree,
       ...blogPostTrees,
       ...blogAuthorTrees,

--- a/lib/generate-blog-components/index.js
+++ b/lib/generate-blog-components/index.js
@@ -32,16 +32,25 @@ module.exports = {
     if (type === 'src') {
       let { posts, authors } = collectPosts(path.join(__dirname, '..', '..', '_posts'));
       this._templates = prepareTemplates(path.join(__dirname, 'lib', 'files'));
+
+      let blogStartPageTree = this._writeStartPageComponentTree(posts);
+
       let blogPostTrees = posts.map(post => {
         let related = findRelatedPost(post, posts);
         return this._writePostComponentTree(post, related);
       });
+
       let blogAuthorTrees = authors.map(author => {
         return this._writeAuthorComponentTree(author);
       });
-      let blogStartPageTree = this._writeStartPageComponentTree(posts);
 
-      return mergeTrees([tree, blogStartPageTree, ...blogPostTrees, ...blogAuthorTrees]);
+      let recentPostsByTopic = collectRecentPosts(posts);
+      let recentPostsTrees = _.reduce(recentPostsByTopic, (acc, posts, topic) => {
+        acc.push(this._writeRecentPostsComponentTree(topic, posts));
+        return acc;
+      }, []);
+
+      return mergeTrees([tree, blogStartPageTree, ...blogPostTrees, ...blogAuthorTrees, ...recentPostsTrees]);
     } else {
       return tree;
     }
@@ -119,6 +128,34 @@ module.exports = {
     let componentCssBlock = this._templates.author.stylesheet(data);
     trees.push(writeFile(`/src/ui/components/${author.componentName}/stylesheet.css`, componentCssBlock));
 
+    return mergeTrees(trees);
+  },
+
+  _writeRecentPostsComponentTree(topic, posts) {
+    let trees = [];
+    let componentName = `RecentPosts${_.capitalize(topic)}`;
+    let data = {
+      topic,
+      posts: posts.map(post => {
+        return {
+          date: dateformat(post.meta.date, 'mmmm d, yyyy'),
+          title: post.meta.title,
+          teaserImage: post.meta['teaser-image'],
+          author: {
+            name: post.meta.author,
+          },
+        }
+      }),
+    };
+    let componentTemplate = this._templates['recent-posts'].template(data);
+    trees.push(writeFile(`/src/ui/components/${componentName}/template.hbs`, componentTemplate));
+
+    data = {
+      componentName,
+    };
+    let componentCssBlock = this._templates['recent-posts'].stylesheet(data);
+    trees.push(writeFile(`/src/ui/components/${componentName}/stylesheet.css`, componentCssBlock));
+    
     return mergeTrees(trees);
   },
 
@@ -206,4 +243,10 @@ function findRelatedPost(post, posts) {
     .reverse()
     .first()
     .value();
+}
+
+function collectRecentPosts(posts) {
+  return _.chain(posts).groupBy('meta.topic').mapValues(posts => {
+    return _.chain(posts).sortBy('meta.date').reverse().take(3).value()
+  }).value();
 }

--- a/lib/generate-blog-components/index.js
+++ b/lib/generate-blog-components/index.js
@@ -144,9 +144,11 @@ module.exports = {
         return {
           date: dateformat(post.meta.date, 'mmmm d, yyyy'),
           title: post.meta.title,
+          path: `/blog/${post.queryPath}`,
           teaserImage: post.meta['teaser-image'],
           author: {
             name: post.meta.author,
+            twitter: post.meta.twitter,
           },
         };
       }),

--- a/lib/generate-blog-components/index.js
+++ b/lib/generate-blog-components/index.js
@@ -45,10 +45,14 @@ module.exports = {
       });
 
       let recentPostsByTopic = collectRecentPosts(posts);
-      let recentPostsTrees = _.reduce(recentPostsByTopic, (acc, posts, topic) => {
-        acc.push(this._writeRecentPostsComponentTree(topic, posts));
-        return acc;
-      }, []);
+      let recentPostsTrees = _.reduce(
+        recentPostsByTopic,
+        (acc, posts, topic) => {
+          acc.push(this._writeRecentPostsComponentTree(topic, posts));
+          return acc;
+        },
+        [],
+      );
 
       return mergeTrees([tree, blogStartPageTree, ...blogPostTrees, ...blogAuthorTrees, ...recentPostsTrees]);
     } else {
@@ -144,7 +148,7 @@ module.exports = {
           author: {
             name: post.meta.author,
           },
-        }
+        };
       }),
     };
     let componentTemplate = this._templates['recent-posts'].template(data);
@@ -155,7 +159,7 @@ module.exports = {
     };
     let componentCssBlock = this._templates['recent-posts'].stylesheet(data);
     trees.push(writeFile(`/src/ui/components/${componentName}/stylesheet.css`, componentCssBlock));
-    
+
     return mergeTrees(trees);
   },
 
@@ -246,7 +250,14 @@ function findRelatedPost(post, posts) {
 }
 
 function collectRecentPosts(posts) {
-  return _.chain(posts).groupBy('meta.topic').mapValues(posts => {
-    return _.chain(posts).sortBy('meta.date').reverse().take(3).value()
-  }).value();
+  return _.chain(posts)
+    .groupBy('meta.topic')
+    .mapValues(posts => {
+      return _.chain(posts)
+        .sortBy('meta.date')
+        .reverse()
+        .take(3)
+        .value();
+    })
+    .value();
 }

--- a/lib/generate-blog-components/lib/files/recent-posts/stylesheet.hbs
+++ b/lib/generate-blog-components/lib/files/recent-posts/stylesheet.hbs
@@ -3,3 +3,32 @@
 :scope {
   block-name: {{componentName}};
 }
+
+.post + .post {
+  margin-top: 8rem;
+}
+
+.title {
+  margin-bottom: 2rem;
+}
+
+.media {
+  position: relative;
+  padding-left: 8rem;
+}
+
+.image {
+  display: block;
+  position: absolute;
+  left: 0;
+  width: 6rem;
+  height: 6rem;
+  border-radius: 3rem;
+  overflow: hidden;
+}
+
+.author,
+.date {
+  display: block;
+  line-height: 3rem;
+}

--- a/lib/generate-blog-components/lib/files/recent-posts/stylesheet.hbs
+++ b/lib/generate-blog-components/lib/files/recent-posts/stylesheet.hbs
@@ -1,0 +1,3 @@
+:scope {
+  block-name: {{componentName}};
+}

--- a/lib/generate-blog-components/lib/files/recent-posts/stylesheet.hbs
+++ b/lib/generate-blog-components/lib/files/recent-posts/stylesheet.hbs
@@ -1,3 +1,5 @@
+@block typography from "../../styles/blocks/typography.block.css";
+
 :scope {
   block-name: {{componentName}};
 }

--- a/lib/generate-blog-components/lib/files/recent-posts/template.hbs
+++ b/lib/generate-blog-components/lib/files/recent-posts/template.hbs
@@ -1,0 +1,6 @@
+<div>
+  recent posts for {{topic}}
+  {{#each posts}}
+    {{title}} by {{author.name}}
+  {{/each}}
+</div>

--- a/lib/generate-blog-components/lib/files/recent-posts/template.hbs
+++ b/lib/generate-blog-components/lib/files/recent-posts/template.hbs
@@ -1,15 +1,26 @@
-<div>
+<ul>
   {{#each posts}}
-    <h4 class="typography.headline-3-plain">{{title}}</h4>
-    <img src="/assets/images/authors/{{author.twitter}}.jpg" />
-    <p class="typography.small-text">
-      {{author.name}}
-    </p>
-    <p class="typography.small-text">
-      {{date}}
-    </p>
-    <ArrowLink @href="{{path}}">
-      Read Post
-    </ArrowLink>
+    <li class="post">
+      <h4 class="typography.headline-3-plain title">
+        <a class="typography.title-link" href="{{path}}">
+          {{title}}
+        </a>
+      </h4>
+
+      <div class="media">
+        <img class="image" src="/assets/images/authors/{{author.twitter}}.jpg" />
+        <p>
+          <span class="author">
+            {{author.name}}
+          </span>
+          <span class="date">
+            {{date}}
+          </span>
+        </p>
+      </div>
+      <ArrowLink @href="{{path}}">
+        Read Post
+      </ArrowLink>
+    </li>
   {{/each}}
-</div>
+</ul>

--- a/lib/generate-blog-components/lib/files/recent-posts/template.hbs
+++ b/lib/generate-blog-components/lib/files/recent-posts/template.hbs
@@ -1,6 +1,15 @@
 <div>
-  recent posts for {{topic}}
   {{#each posts}}
-    {{title}} by {{author.name}}
+    <h4 class="typography.headline-3-plain">{{title}}</h4>
+    <img src="/assets/images/authors/{{author.twitter}}.jpg" />
+    <p class="typography.small-text">
+      {{author.name}}
+    </p>
+    <p class="typography.small-text">
+      {{date}}
+    </p>
+    <ArrowLink @href="{{path}}">
+      Read Post
+    </ArrowLink>
   {{/each}}
 </div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,8 @@ app.registerInitializer({
       registerBundle(module);
     });
 
+    registerBundle('__recent__');
+
     registry.register(
       `utils:/${app.rootName}/lazy-registration/main`,
       LazyRegistration

--- a/src/ui/components/PageElixirExpertise/template.hbs
+++ b/src/ui/components/PageElixirExpertise/template.hbs
@@ -66,6 +66,17 @@
           </div>
         </div>
       </div>
+      <div class="main-block.sidebar">
+        <div class="card">
+          <p class="typography.small-text">
+            From our Blog
+          </p>
+          <div class="card.image">
+            <img class="fluid-image.image" src="/assets/images/card/elixir.svg" />
+          </div>
+          <RecentPostsElixir />
+        </div>
+      </div>
     </div>
   </div>
   <WorkWithUs />

--- a/src/ui/components/PageEmberExpertise/template.hbs
+++ b/src/ui/components/PageEmberExpertise/template.hbs
@@ -154,6 +154,17 @@
           <!--item-->
         </div>
       </div>
+      <div class="main-block.sidebar">
+        <div class="card">
+          <p class="typography.small-text">
+            From our Blog
+          </p>
+          <div class="card.image">
+            <img class="fluid-image.image" src="/assets/images/card/ember.svg" />
+          </div>
+          <RecentPostsEmber />
+        </div>
+      </div>
     </div>
   </div>
   <ClientsGrid @title="We are trusted by companies that bet on Ember" @only="trainline,qonto,cardstack" />

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -9,6 +9,7 @@
 
     {{content-for "head"}}
 
+    <link rel="preload" href="{{rootURL}}recent.js" as="script">
     <link rel="preload" href="{{rootURL}}app.js" as="script">
 
     <link rel="stylesheet" href="{{rootURL}}app.css">
@@ -19,7 +20,10 @@
     {{content-for "body"}}
 
     <div id="app"></div>
+
     {{content-for "body-pre-app-bundle"}}
+
+    <script src="{{rootURL}}recent.js"></script>
     <script src="{{rootURL}}app.js"></script>
 
     {{content-for "body-footer"}}


### PR DESCRIPTION
This adds components for recent posts (e.g. `RecentPostsEmber`, `RecentPostsElixir` etc.). These components are bundled separately so that we don't invalidate cached `app.js` files when publishing new blog posts. We can use similar techniques if we later want to have components for recent talks etc. as well.

closes #452 

### TODO

- [x] this needs design
- [x] the CSS needs to be updated so that author names and images are rendered correctly.