### PR TITLE
Enable tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import App from './main';
 
 const containerElement = document.getElementById('app');
 const hasSSRBody = !!document.querySelector('[data-has-ssr-response]');
-const app = new App({ hasSSRBody, element: containerElement });
+const app = new App({ hasSSRBody: !!hasSSRBody, element: containerElement });
 
 setPropertyDidChange(() => {
   app.scheduleRerender();

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,14 +4,14 @@ import moduleMap from '../config/module-map';
 import resolverConfiguration from '../config/resolver-configuration';
 
 export default class App extends Application {
-  constructor({ hasSSRBody = false, element }) {
+  constructor(options = { hasSSRBody: false, element: null }) {
     let moduleRegistry = new BasicModuleRegistry(moduleMap);
     let resolver = new Resolver(resolverConfiguration, moduleRegistry);
 
-    const BuilderType = hasSSRBody ? RehydratingBuilder : DOMBuilder;
+    const BuilderType = options.hasSSRBody ? RehydratingBuilder : DOMBuilder;
 
     super({
-      builder: new BuilderType({ element, nextSibling: null }),
+      builder: new BuilderType({ element: options.element, nextSibling: null }),
       loader: new RuntimeCompilerLoader(resolver),
       renderer: new SyncRenderer(),
       resolver,

--- a/src/ui/components/ArrowLink/component-test.ts
+++ b/src/ui/components/ArrowLink/component-test.ts
@@ -1,5 +1,6 @@
 import hbs from '@glimmer/inline-precompile';
-import { render, setupRenderingTest } from '@glimmer/test-helpers';
+import { render } from '@glimmer/test-helpers';
+import { setupRenderingTest } from '../../../utils/test-helpers/setup-rendering-test';
 
 const { module, test } = QUnit;
 
@@ -9,6 +10,6 @@ module('Component: ArrowLink', function(hooks) {
   test('it renders', async function(assert) {
     await render(hbs`<ArrowLink />`);
 
-    assert.ok(this.containerElement.querySelector('div'));
+    assert.ok(this.containerElement.querySelector('a'));
   });
 });

--- a/src/ui/components/Card/component-test.ts
+++ b/src/ui/components/Card/component-test.ts
@@ -8,26 +8,8 @@ module('Component: Card', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    /*
-     * You may pass data into the component through arguments set on the
-     * `testContext`
-     *
-     * For example:
-     *
-     * ```
-     * this.foo = { foo: '123' };
-     *
-     * await render(hbs`<Card @foo={{this.foo}} />`)
-     *
-     * // or
-     *
-     * this.foo = 'bar';
-     * await render(hbs`<p>{{this.foo}}</p>`);
-     *
-     * assert.dom('p').text('bar');
-     * ```
-     */
     await render(hbs`<Card />`);
-    assert.ok(this.containerElement.querySelector('div'));
+
+    assert.ok(this.containerElement.querySelector('figure'));
   });
 });

--- a/src/ui/components/Footer/component-test.ts
+++ b/src/ui/components/Footer/component-test.ts
@@ -1,5 +1,6 @@
 import hbs from '@glimmer/inline-precompile';
-import { render, setupRenderingTest } from '@glimmer/test-helpers';
+import { render } from '@glimmer/test-helpers';
+import { setupRenderingTest } from '../../../utils/test-helpers/setup-rendering-test';
 
 const { module, test } = QUnit;
 

--- a/src/ui/components/Header/component-test.ts
+++ b/src/ui/components/Header/component-test.ts
@@ -1,5 +1,6 @@
 import hbs from '@glimmer/inline-precompile';
-import { render, setupRenderingTest } from '@glimmer/test-helpers';
+import { render } from '@glimmer/test-helpers';
+import { setupRenderingTest } from '../../../utils/test-helpers/setup-rendering-test';
 
 const { module, test } = QUnit;
 

--- a/src/ui/components/Loader/component-test.ts
+++ b/src/ui/components/Loader/component-test.ts
@@ -1,5 +1,6 @@
 import hbs from '@glimmer/inline-precompile';
-import { render, setupRenderingTest } from '@glimmer/test-helpers';
+import { render } from '@glimmer/test-helpers';
+import { setupRenderingTest } from '../../../utils/test-helpers/setup-rendering-test';
 
 const { module, test } = QUnit;
 

--- a/src/ui/components/PageAbout/component-test.ts
+++ b/src/ui/components/PageAbout/component-test.ts
@@ -8,7 +8,7 @@ module('Component: PageAbout', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    await render(hbs`<About />`);
+    await render(hbs`<PageAbout />`);
 
     assert.ok(this.containerElement.querySelector('div'));
   });

--- a/src/ui/components/PageCaseDdWrt/component-test.ts
+++ b/src/ui/components/PageCaseDdWrt/component-test.ts
@@ -1,5 +1,6 @@
 import hbs from '@glimmer/inline-precompile';
-import { render, setupRenderingTest } from '@glimmer/test-helpers';
+import { render } from '@glimmer/test-helpers';
+import { setupRenderingTest } from '../../../utils/test-helpers/setup-rendering-test';
 
 const { module, test } = QUnit;
 

--- a/src/ui/components/PageCaseStudyExpedition/component-test.ts
+++ b/src/ui/components/PageCaseStudyExpedition/component-test.ts
@@ -8,7 +8,7 @@ module('Component: PageCaseStudyExpedition', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    await render(hbs`<CaseStudy />`);
+    await render(hbs`<PageCaseStudyExpedition />`);
 
     assert.ok(this.containerElement.querySelector('div'));
   });

--- a/src/ui/components/PageCaseStudyTrainline/component-test.ts
+++ b/src/ui/components/PageCaseStudyTrainline/component-test.ts
@@ -8,7 +8,7 @@ module('Component: PageCaseStudyTrainline', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    await render(hbs`<CaseStudy />`);
+    await render(hbs`<PageCaseStudyTrainline />`);
 
     assert.ok(this.containerElement.querySelector('div'));
   });

--- a/src/ui/components/PageTraining/component-test.ts
+++ b/src/ui/components/PageTraining/component-test.ts
@@ -1,5 +1,6 @@
 import hbs from '@glimmer/inline-precompile';
-import { render, setupRenderingTest } from '@glimmer/test-helpers';
+import { render } from '@glimmer/test-helpers';
+import { setupRenderingTest } from '../../../utils/test-helpers/setup-rendering-test';
 
 const { module, test } = QUnit;
 

--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -172,6 +172,8 @@ export default class Simplabs extends Component {
     let script = document.querySelector('[data-shoebox-routes]');
     if (script) {
       return JSON.parse(script.innerText);
+    } else {
+      return {};
     }
   }
 }

--- a/src/utils/test-helpers/setup-rendering-test.ts
+++ b/src/utils/test-helpers/setup-rendering-test.ts
@@ -1,15 +1,20 @@
 import { classnames } from '@css-blocks/glimmer/dist/cjs/src/helpers/classnames';
+import { concat } from '@css-blocks/glimmer/dist/cjs/src/helpers/concat';
 import { setupRenderingTest as originalSetupRenderingTest } from '@glimmer/test-helpers';
 
 export const setupRenderingTest = function(hooks) {
   originalSetupRenderingTest(hooks);
 
   hooks.beforeEach(function beforeEach() {
+    let rootName = this.app.rootName;
     this.app.registerInitializer({
       initialize(registry) {
         registry._resolver.registry._entries[
-          `helper:/glimmer-pdp-viewer/components/-css-blocks-classnames`
+          `helper:/${rootName}/components/-css-blocks-classnames`
         ] = classnames;
+        registry._resolver.registry._entries[
+          `helper:/${rootName}/components/-css-blocks-concat`
+        ] = concat;
       }
     });
   });

--- a/testem.json
+++ b/testem.json
@@ -1,7 +1,5 @@
 {
-  "framework": "qunit",
-  "src_files": ["src/**/*"],
-  "serve_files": ["index.js"],
+  "test_page": "tests/index.html",
   "disable_watching": true,
   "launch_in_ci": ["Chrome"],
   "launch_in_dev": ["Chrome"],

--- a/tests/index.html
+++ b/tests/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>simplabs</title>
+    <title>Simplabs</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 


### PR DESCRIPTION
Apparently the way that tests are discovered/run in Glimmer has changed which just silently failed for us as our test suite still passed because it simply didn't run any tests. See also simplabs/breethe-client#210

This enables the tests again and also fixes an error that had actually made them all fail which we didn't recognize though as the tests never ran.