### PR TITLE
replace timify logo with qonto logo on homepage

### DIFF
--- a/src/ui/components/PageHomepage/template.hbs
+++ b/src/ui/components/PageHomepage/template.hbs
@@ -37,7 +37,7 @@
         <img src="/assets/images/logos/experteer.svg" />
       </li>
       <li class="logos-logo">
-        <img src="/assets/images/logos/timify.svg" />
+        <img src="/assets/images/logos/qonto.svg" />
       </li>
     </ul>
     <p class="logos-more">


### PR DESCRIPTION
as I think Qonto is better known/more interesting due to the fact that they are a FinTech etc.