### PR TITLE
Fix route bundle loading

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -192,6 +192,7 @@ module.exports = function(defaults) {
     },
     fingerprint: {
       exclude: ['ssr-app.js'],
+      replaceExtensions: ['html', 'css', 'js', 'json']
     },
     rollup: {
       plugins: [resolve({ jsnext: true, module: true, main: true }), commonjs()],

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -192,7 +192,7 @@ module.exports = function(defaults) {
     },
     fingerprint: {
       exclude: ['ssr-app.js'],
-      replaceExtensions: ['html', 'css', 'js', 'json']
+      replaceExtensions: ['html', 'css', 'js', 'json'],
     },
     rollup: {
       plugins: [resolve({ jsnext: true, module: true, main: true }), commonjs()],

--- a/lib/inject-routes/index.js
+++ b/lib/inject-routes/index.js
@@ -14,7 +14,7 @@ module.exports = {
 
   treeFor(type) {
     if (type === 'public') {
-      return writeFile(`routes.json`, JSON.stringify(this.routes));
+      return writeFile('routes.json', JSON.stringify(this.routes));
     }
   },
 

--- a/lib/inject-routes/index.js
+++ b/lib/inject-routes/index.js
@@ -1,17 +1,28 @@
 /* eslint-env node */
 'use strict';
 
+const writeFile = require('broccoli-file-creator');
+
 const routesMap = require('../../config/routes-map.js');
 
 module.exports = {
   name: 'inject-routes',
 
+  included() {
+    this.routes = routesMap();
+  },
+
+  treeFor(type) {
+    if (type === 'public') {
+      return writeFile(`routes.json`, JSON.stringify(this.routes));
+    }
+  },
+
   contentFor(type) {
     if (type === 'head-footer') {
-      let routes = routesMap();
       return `
         <script type="application/json" data-test-shoebox data-shoebox-routes>
-          ${JSON.stringify(routes)}
+          ${JSON.stringify(this.routes)}
         </script>
       `;
     } else {

--- a/ssr/ssr-application.ts
+++ b/ssr/ssr-application.ts
@@ -10,7 +10,7 @@ import { TemplateIterator } from '@glimmer/runtime';
 // tslint:disable-next-line:no-var-requires
 const SimpleDOM = require('simple-dom');
 // tslint:disable-next-line:no-var-requires
-const routesMap = require('../config/routes-map');
+const routesMap = require('./routes.json');
 
 import Application, { ApplicationOptions } from '@glimmer/application';
 
@@ -44,7 +44,7 @@ export default class SSRApplication extends Application {
         this.isSSR = true;
         this.route = options.route;
         this.origin = options.origin;
-        this.routesMap = routesMap();
+        this.routesMap = routesMap;
       }
     }
 


### PR DESCRIPTION
This fixes a problem with loading the routes map in the SSR server. The SSR server is currently not aware of the file names in the routes' bundle definitions and would just inject a `<script>` tag with `src="blog.js"` while it should actually be `src="blog-<fingerprint>.js"`. This fixes that by generating a json file that contains the route definitions and that gets fingerprinted during the build. The SSR server then reads that file (as opposed to executing `config/routes-map.js` directly).