### PR TITLE
performance improvements

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -55,13 +55,14 @@ class SimplabsApp extends GlimmerApp {
 
   cssTree() {
     let resetCss = fs.readFileSync(path.join(this.project.root, 'vendor', 'css', 'reset.css'));
+    let fontsCss = fs.readFileSync(path.join(this.project.root, 'vendor', 'css', 'fonts.css'));
     let baselineCss = fs.readFileSync(path.join(this.project.root, 'src', 'ui', 'styles', 'baseline.css'));
 
     let cssTree = Funnel(super.cssTree(...arguments), {
       include: ['app.css'],
     });
 
-    cssTree = Map(cssTree, content => [resetCss, baselineCss, content].join(''));
+    cssTree = Map(cssTree, content => [resetCss, fontsCss, baselineCss, content].join(''));
 
     if (this.options.minifyCSS.enabled) {
       cssTree = new BroccoliCleanCss(cssTree);

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -51,9 +51,11 @@ async function inlineCss(fileName) {
 function buildShoeboxBundlePreloads(html) {
   let dom = new jsdom.JSDOM(html);
   let bundleNodes = Array.from(dom.window.document.querySelectorAll('[data-shoebox-bundle]'));
-  return bundleNodes.map((node) => {
-    return `<link rel="preload" href="${node.getAttribute('src')}" as="script">`;
-  }).join('\n');
+  return bundleNodes
+    .map(node => {
+      return `<link rel="preload" href="${node.getAttribute('src')}" as="script">`;
+    })
+    .join('\n');
 }
 
 const renderer = new GlimmerRenderer();
@@ -63,8 +65,7 @@ server.get('*', async function(req, res, next) {
     let origin = `${req.protocol}://${req.headers.host}`;
     let { body, title } = await renderer.render(origin, req.url);
     let shoeboxBundlePreloads = buildShoeboxBundlePreloads(body);
-    let html = HTML
-      .replace('<div id="app"></div>', body)
+    let html = HTML.replace('<div id="app"></div>', body)
       .replace(/<title>[^<]*<\/title>/, `<title>${title}</title>`)
       .replace('<link', `${shoeboxBundlePreloads}\n<link`);
     res.send(html);

--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -4,6 +4,7 @@ const express = require('express');
 const puppeteer = require('puppeteer');
 const critical = require('critical');
 const colors = require('colors');
+const jsdom = require('jsdom');
 
 process.setMaxListeners(Infinity);
 
@@ -47,13 +48,25 @@ async function inlineCss(fileName) {
   await fs.writeFile(fileName, result.toString('utf8'));
 }
 
+function buildShoeboxBundlePreloads(html) {
+  let dom = new jsdom.JSDOM(html);
+  let bundleNodes = Array.from(dom.window.document.querySelectorAll('[data-shoebox-bundle]'));
+  return bundleNodes.map((node) => {
+    return `<link rel="preload" href="${node.getAttribute('src')}" as="script">`;
+  }).join('\n');
+}
+
 const renderer = new GlimmerRenderer();
 let server = express();
 server.get('*', async function(req, res, next) {
   if (req.headers.accept && req.headers.accept.includes('text/html')) {
     let origin = `${req.protocol}://${req.headers.host}`;
     let { body, title } = await renderer.render(origin, req.url);
-    let html = HTML.replace('<div id="app"></div>', body).replace(/<title>[^<]*<\/title>/, `<title>${title}</title>`);
+    let shoeboxBundlePreloads = buildShoeboxBundlePreloads(body);
+    let html = HTML
+      .replace('<div id="app"></div>', body)
+      .replace(/<title>[^<]*<\/title>/, `<title>${title}</title>`)
+      .replace('<link', `${shoeboxBundlePreloads}\n<link`);
     res.send(html);
   } else {
     next();

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -9,6 +9,8 @@
 
     {{content-for "head"}}
 
+    <link rel="preload" href="{{rootURL}}app.js" as="script">
+
     <link rel="stylesheet" href="{{rootURL}}app.css">
     <link href="https://fonts.googleapis.com/css?family=Nunito+Sans:300,400,700,900" rel="stylesheet">
 

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -12,7 +12,6 @@
     <link rel="preload" href="{{rootURL}}app.js" as="script">
 
     <link rel="stylesheet" href="{{rootURL}}app.css">
-    <link href="https://fonts.googleapis.com/css?family=Nunito+Sans:300,400,700" rel="stylesheet">
 
     {{content-for "head-footer"}}
   </head>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -12,7 +12,7 @@
     <link rel="preload" href="{{rootURL}}app.js" as="script">
 
     <link rel="stylesheet" href="{{rootURL}}app.css">
-    <link href="https://fonts.googleapis.com/css?family=Nunito+Sans:300,400,700,900" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Nunito+Sans:300,400,700" rel="stylesheet">
 
     {{content-for "head-footer"}}
   </head>

--- a/src/ui/styles/blocks/screen.block.css
+++ b/src/ui/styles/blocks/screen.block.css
@@ -29,6 +29,7 @@
   --vertical-spacing: 4em;
 
   font-family: 'Nunito Sans', sans-serif;
+  font-display: fallback;
   color: var(--color-muted);
   overflow: hidden;
 }

--- a/src/ui/styles/blocks/typography.block.css
+++ b/src/ui/styles/blocks/typography.block.css
@@ -47,7 +47,7 @@
   color: var(--color-text);
   font-size: 2.5rem;
   line-height: 1.25;
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .small-text {
@@ -103,6 +103,6 @@
 .tag {
   text-decoration: none;
   display: inline-block;
-  font-weight: 600;
+  font-weight: 700;
   color: var(--color-link);
 }

--- a/vendor/css/fonts.css
+++ b/vendor/css/fonts.css
@@ -1,11 +1,3 @@
-/* vietnamese */
-@font-face {
-  font-family: 'Nunito Sans';
-  font-style: normal;
-  font-weight: 300;
-  src: local('Nunito Sans Light'), local('NunitoSans-Light'), url(https://fonts.gstatic.com/s/nunitosans/v4/pe03MImSLYBIv1o4X1M8cc8WAc5iU1ECVZl_86Y.woff2) format('woff2');
-  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
-}
 /* latin-ext */
 @font-face {
   font-family: 'Nunito Sans';
@@ -22,14 +14,6 @@
   src: local('Nunito Sans Light'), local('NunitoSans-Light'), url(https://fonts.gstatic.com/s/nunitosans/v4/pe03MImSLYBIv1o4X1M8cc8WAc5tU1ECVZl_.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
-/* vietnamese */
-@font-face {
-  font-family: 'Nunito Sans';
-  font-style: normal;
-  font-weight: 400;
-  src: local('Nunito Sans Regular'), local('NunitoSans-Regular'), url(https://fonts.gstatic.com/s/nunitosans/v4/pe0qMImSLYBIv1o4X1M8cceyI9tAcVwob5A.woff2) format('woff2');
-  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
-}
 /* latin-ext */
 @font-face {
   font-family: 'Nunito Sans';
@@ -45,14 +29,6 @@
   font-weight: 400;
   src: local('Nunito Sans Regular'), local('NunitoSans-Regular'), url(https://fonts.gstatic.com/s/nunitosans/v4/pe0qMImSLYBIv1o4X1M8cce9I9tAcVwo.woff2) format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
-}
-/* vietnamese */
-@font-face {
-  font-family: 'Nunito Sans';
-  font-style: normal;
-  font-weight: 700;
-  src: local('Nunito Sans Bold'), local('NunitoSans-Bold'), url(https://fonts.gstatic.com/s/nunitosans/v4/pe03MImSLYBIv1o4X1M8cc8GBs5iU1ECVZl_86Y.woff2) format('woff2');
-  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
 @font-face {

--- a/vendor/css/fonts.css
+++ b/vendor/css/fonts.css
@@ -1,0 +1,72 @@
+/* vietnamese */
+@font-face {
+  font-family: 'Nunito Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Nunito Sans Light'), local('NunitoSans-Light'), url(https://fonts.gstatic.com/s/nunitosans/v4/pe03MImSLYBIv1o4X1M8cc8WAc5iU1ECVZl_86Y.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Nunito Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Nunito Sans Light'), local('NunitoSans-Light'), url(https://fonts.gstatic.com/s/nunitosans/v4/pe03MImSLYBIv1o4X1M8cc8WAc5jU1ECVZl_86Y.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Nunito Sans';
+  font-style: normal;
+  font-weight: 300;
+  src: local('Nunito Sans Light'), local('NunitoSans-Light'), url(https://fonts.gstatic.com/s/nunitosans/v4/pe03MImSLYBIv1o4X1M8cc8WAc5tU1ECVZl_.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Nunito Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Nunito Sans Regular'), local('NunitoSans-Regular'), url(https://fonts.gstatic.com/s/nunitosans/v4/pe0qMImSLYBIv1o4X1M8cceyI9tAcVwob5A.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Nunito Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Nunito Sans Regular'), local('NunitoSans-Regular'), url(https://fonts.gstatic.com/s/nunitosans/v4/pe0qMImSLYBIv1o4X1M8ccezI9tAcVwob5A.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Nunito Sans';
+  font-style: normal;
+  font-weight: 400;
+  src: local('Nunito Sans Regular'), local('NunitoSans-Regular'), url(https://fonts.gstatic.com/s/nunitosans/v4/pe0qMImSLYBIv1o4X1M8cce9I9tAcVwo.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+/* vietnamese */
+@font-face {
+  font-family: 'Nunito Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Nunito Sans Bold'), local('NunitoSans-Bold'), url(https://fonts.gstatic.com/s/nunitosans/v4/pe03MImSLYBIv1o4X1M8cc8GBs5iU1ECVZl_86Y.woff2) format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+1EA0-1EF9, U+20AB;
+}
+/* latin-ext */
+@font-face {
+  font-family: 'Nunito Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Nunito Sans Bold'), local('NunitoSans-Bold'), url(https://fonts.gstatic.com/s/nunitosans/v4/pe03MImSLYBIv1o4X1M8cc8GBs5jU1ECVZl_86Y.woff2) format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+/* latin */
+@font-face {
+  font-family: 'Nunito Sans';
+  font-style: normal;
+  font-weight: 700;
+  src: local('Nunito Sans Bold'), local('NunitoSans-Bold'), url(https://fonts.gstatic.com/s/nunitosans/v4/pe03MImSLYBIv1o4X1M8cc8GBs5tU1ECVZl_.woff2) format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}


### PR DESCRIPTION
This implements a number of performance improvenents.

* preloading all required scripts
* dropping 1 font weight, reducing to 3 (I'm not sure this is in line with what the intentions of the font system were so happy to change this differently)
* inlining the google fonts CSS
* using `font-display: fallback;` so font painting doesn't block anything
* dropping vietnamese characters from the font - pretty sure that's safe for now ;)