### PR TITLE
Ensure legal links are always in a new grid line

### DIFF
--- a/src/ui/components/Footer/stylesheet.css
+++ b/src/ui/components/Footer/stylesheet.css
@@ -23,7 +23,7 @@
 }
 
 .legal {
-  grid-row: 2/3;
+  width: 100%;
   margin-left: -2rem;
   padding-bottom: 3rem;
 }


### PR DESCRIPTION
Fixed bug introduced in #419 and closes #359