### PR TITLE
reset loader progress when loading starts

### DIFF
--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -127,6 +127,7 @@ export default class Simplabs extends Component {
 
   private _startLoader() {
     this.isLoading = true;
+    this.loadingProgress = 0;
     this.loadingProgressInterval = window.setInterval(
       () => (this.loadingProgress = Math.min(this.loadingProgress + 10, 100)),
       150,


### PR DESCRIPTION
This fixes a small bug with the loader - when lazy-loading 1 bundle, the loader ends up at 100% progress but when lazy-loading another bundle afterwards, progress is not reset and the loader just remains at 100% until loading finishes.

This resets the progress back to 0 whenever the loader animation is started.