### PR TITLE
split playbook into separate bundle

### DIFF
--- a/config/routes-map.js
+++ b/config/routes-map.js
@@ -58,7 +58,11 @@ module.exports = function() {
       title: 'Imprint',
       bundle: { asset: '/legal.js', module: '__legal__' },
     },
-    '/playbook': { component: 'PagePlaybook', title: 'Playbook' },
+    '/playbook': {
+      component: 'PagePlaybook',
+      title: 'Playbook',
+      bundle: { asset: '/playbook.js', module: '__playbook__' },
+    },
     '/privacy': {
       component: 'PageLegalPrivacy',
       title: 'Privacy Policy',

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -111,8 +111,23 @@ class SimplabsApp extends GlimmerApp {
     });
     mainSiteTree = mainSiteNonLegalTree;
 
+    let [playbookTree, mainSiteNonPlaybookTree] = this._splitBundle(mainSiteTree, {
+      componentPrefix: 'PagePlaybook',
+      file: 'playbook.js',
+      moduleName: '__playbook__',
+    });
+    mainSiteTree = mainSiteNonPlaybookTree;
+
     let appTree = super.package(mainSiteTree);
-    let mainTree = new MergeTrees([appTree, legalTree, calendarTree, blogTree, ...blogPostTrees, ...blogAuthorTrees]);
+    let mainTree = new MergeTrees([
+      appTree,
+      legalTree,
+      calendarTree,
+      playbookTree,
+      blogTree,
+      ...blogPostTrees,
+      ...blogAuthorTrees,
+    ]);
 
     if (process.env.PRERENDER) {
       let ssrTree = this._packageSSR();


### PR DESCRIPTION
…so we don't grow the main bundle as the playbook receives more and more content over time and also we don't invalidate the main bundle in everyone's cache each time the playbook updates.