### PR TITLE
link to talks from footer

### DIFF
--- a/src/ui/components/Footer/template.hbs
+++ b/src/ui/components/Footer/template.hbs
@@ -86,6 +86,11 @@
         </a>
       </li>
       <li class="item">
+        <a href="/talks" class="link" data-internal>
+          Talks
+        </a>
+      </li>
+      <li class="item">
         <a href="http://github.com/simplabs/" class="link" target="_blank">
           Github
         </a>


### PR DESCRIPTION
This adds a link to the talks catalog in the footer, below the link to the calendar

closes #449 