### PR TITLE
inject critical css for multiple viewport sizes

### DIFF
--- a/scripts/prerender.js
+++ b/scripts/prerender.js
@@ -42,8 +42,16 @@ async function inlineCss(fileName) {
     base: DIST_PATH,
     folder: './',
     html: input,
-    width: 1300,
-    height: 900,
+    dimensions: [
+      {
+        height: 667,
+        width: 375,
+      },
+      {
+        height: 900,
+        width: 1200,
+      },
+    ],
   });
   await fs.writeFile(fileName, result.toString('utf8'));
 }


### PR DESCRIPTION
This changes the pre-renderer so that it injects critical CSS for multiple viewport sizes. It currently uses only 2 different viewport sizes but once we find out what the relevant breakpoints are during #357 we can update the script.

closes #455 