### PR TITLE
improve scroll behavior on navigation

### DIFF
--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -48,7 +48,12 @@ export default class Simplabs extends Component {
     Object.keys(this.appState.routesMap).forEach((path) => {
       let { component, title = '', bundle, parentBundle } = this.appState.routesMap[path];
       let options: INavigoHooks = {
-        after: () => this._setPageTitle(title),
+        after: () => {
+          this._setPageTitle(title);
+          if (!this.appState.isSSR) {
+            window.scrollTo(0, 0);
+          }
+        }
       };
       if (bundle && !this.appState.isSSR) {
         options.before = async done => {
@@ -89,7 +94,6 @@ export default class Simplabs extends Component {
           if (link && link.dataset.internal !== undefined) {
             event.preventDefault();
             this.router.navigate(target.getAttribute('href'));
-            window.scrollTo(0, 0);
           }
         }
       });


### PR DESCRIPTION
We are currently scrolling to top when the navigation is triggered instead of when it completes. The problem here is that the navigation might potentially have to wait until it can perform if a JS bundle has to be loaded which makes this strange for the user as we scroll to the top before navigation actually occured. This changes it so that we only scroll after we have transitioned to the new page.