### PR TITLE
use the same playbook card everywhere

### DIFF
--- a/src/ui/components/PageCaseStudyTrainline/template.hbs
+++ b/src/ui/components/PageCaseStudyTrainline/template.hbs
@@ -63,14 +63,7 @@
         </div>
       </div>
       <div class="main-block.sidebar vertical-offset">
-        <Card @title="Learn about our iterations based approach" @src="/assets/images/card/playbook.svg">
-          <p class="typography.body-text">
-            We maintain a lean process that supports the team rather than stand in its way. Find out more about how we work to deliver ambitious software solutions for our clients.
-          </p>
-          <ArrowLink @href="/playbook">
-            Learn more
-          </ArrowLink>
-        </Card>
+        <CardPlaybook />
       </div>
     </div>
   </div>


### PR DESCRIPTION
This replaces the playbook teaser on the trainline case study with the one we use on all other pages.