### PR TITLE
scroll to top when clicking link to current route

### DIFF
--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -53,6 +53,9 @@ export default class Simplabs extends Component {
           if (!this.appState.isSSR) {
             window.scrollTo(0, 0);
           }
+        },
+        already: () => {
+          window.scrollTo(0, 0);
         }
       };
       if (bundle && !this.appState.isSSR) {


### PR DESCRIPTION
…because that's better than just nothing happening which is the current behavior.