### PR TITLE
move loader UI to bottom on mobile

### DIFF
--- a/src/ui/components/Loader/stylesheet.css
+++ b/src/ui/components/Loader/stylesheet.css
@@ -5,8 +5,19 @@
   background: var(--accent-color);
   position: fixed;
   z-index: 1031;
-  top: 0;
   left: 0;
   width: 100%;
   height: 2px;
+}
+
+@media (min-width: 700px) {
+  :scope {
+    top: 0;
+  }
+}
+
+@media (max-width: 699px) {
+  :scope {
+    bottom: 0;
+  }
 }


### PR DESCRIPTION
This moves the loader UI to the bottom of the screen on mobile devices since it could be hidden by the menu at the top. I'm not sure this is a great way to fix this actually though…

close #521