### PR TITLE
fix blog routes

### DIFF
--- a/_posts/2013-06-15-authentication-in-emberjs.md
+++ b/_posts/2013-06-15-authentication-in-emberjs.md
@@ -7,9 +7,9 @@ bio: "Founding Director of simplabs, author of Ember Simple Auth"
 topic: ember
 ---
 
-**Update:**_I released an Ember.js plugin that makes it very easy to implement an authentication system as described in this post: [Ember.SimpleAuth](/blog/2013-10-09-embersimpleauth)._
+**Update:**_I released an Ember.js plugin that makes it very easy to implement an authentication system as described in this post: [Ember.SimpleAuth](/blog/2013/10/09/embersimpleauth)._
 
-**Update:** _After I wrote this I found out that it’s actually not the best approach to implement authentication in Ember.js… There are some things missing and some other things can be done in a much simpler way. [I wrote a summary of the (better) authentication mechanism we moved to.](/blog/2013-08-08-better-authentication-in-emberjs "(better) authnetication with ember.js")_
+**Update:** _After I wrote this I found out that it’s actually not the best approach to implement authentication in Ember.js… There are some things missing and some other things can be done in a much simpler way. [I wrote a summary of the (better) authentication mechanism we moved to.](/blog/2013/08/08/better-authentication-in-emberjs "(better) authnetication with ember.js")_
 
 _I’m using the latest (as of mid June 2013) [ember](https://github.com/emberjs/ember.js)/[ember-data](https://github.com/emberjs/data)/[handlebars](https://github.com/wycats/handlebars.js) code directly from the respective github repositories in this example._
 

--- a/_posts/2013-08-08-better-authentication-in-emberjs.md
+++ b/_posts/2013-08-08-better-authentication-in-emberjs.md
@@ -7,7 +7,7 @@ bio: "Founding Director of simplabs, author of Ember Simple Auth"
 topic: ember
 ---
 
-**Update:**_I released an Ember.js plugin that makes it very easy to implement an authentication system as described in this post: [Ember.SimpleAuth](/blog/2013-06-15-authentication-in-emberjs)._
+**Update:**_I released an Ember.js plugin that makes it very easy to implement an authentication system as described in this post: [Ember.SimpleAuth](/blog/2013/06/15/authentication-in-emberjs)._
 
 When we started our first [ember.js](http://emberjs.com) project in June 2013, one of the first things we implemented was authentication. Now, almost 2 months later, **it has become clear that our initial approach was not really the best and had some shortcomings. So I implemented a better authentication** (mostly based on the embercasts on authentication).
 

--- a/_posts/2013-10-09-embersimpleauth.md
+++ b/_posts/2013-10-09-embersimpleauth.md
@@ -7,9 +7,9 @@ bio: "Founding Director of simplabs, author of Ember Simple Auth"
 topic: ember
 ---
 
-**Update: [Ember.SimpleAuth 0.1.0 has been released!](/blog/2014-01-20-embersimpleauth-010)** The information in this is (partially) outdated.
+**Update: [Ember.SimpleAuth 0.1.0 has been released!](/blog/2014/01/20/embersimpleauth-010)** The information in this is (partially) outdated.
 
-After I wrote 2 [blog](/blog/2013-06-15-authentication-in-emberjs "the initial post") [posts](/blog/2013-08-08-better-authentication-in-emberjs "the second post with a refined implementation") on implementing token based authentication in [Ember.js](http://emberjs.com) applications and got quite some feedback, good suggestions etc., I thought it **would be nice to pack all these ideas in an Ember.js plugin** so everybody could easily integrate that into their applications. Now **I finally managed to release version 0.0.1 of that plugin**: [Ember.SimpleAuth](https://github.com/simplabs/ember-simple-auth).
+After I wrote 2 [blog](/blog/2013/06/15/authentication-in-emberjs "the initial post") [posts](/blog/2013/08/08/better-authentication-in-emberjs "the second post with a refined implementation") on implementing token based authentication in [Ember.js](http://emberjs.com) applications and got quite some feedback, good suggestions etc., I thought it **would be nice to pack all these ideas in an Ember.js plugin** so everybody could easily integrate that into their applications. Now **I finally managed to release version 0.0.1 of that plugin**: [Ember.SimpleAuth](https://github.com/simplabs/ember-simple-auth).
 
 <!--break-->
 

--- a/_posts/2013-10-28-embersimpleauth-implements-rfc-6749-oauth-20.md
+++ b/_posts/2013-10-28-embersimpleauth-implements-rfc-6749-oauth-20.md
@@ -7,7 +7,7 @@ bio: "Founding Director of simplabs, author of Ember Simple Auth"
 topic: ember
 ---
 
-**Update: [Ember.SimpleAuth 0.1.0 has been released!](/blog/2014-01-20-embersimpleauth-010)** The information in this is (partially) outdated.
+**Update: [Ember.SimpleAuth 0.1.0 has been released!](/blog/2014/01/20/embersimpleauth-010)** The information in this is (partially) outdated.
 
 With the [release of Ember.SimpleAuth 0.0.4](https://github.com/simplabs/ember-simple-auth/releases/tag/0.0.4) **the library is compliant with OAuth 2.0** - specifically it implements the _"Resource Owner Password Credentials Grant Type"_ as defined in [RFC 6749](http://tools.ietf.org/html/rfc6749) (thanks [adamlc](https://github.com/adamlc) for the suggestion). While this is only a minor change in terms of functionality and data flow, used headers etc. it makes everyone’s life a lot easier as instead of implementing your own server endpoints you can now utilize [one of several OAuth 2.0 middlewares that already implement the spec](https://github.com/search?q=oauth%20middleware).
 

--- a/_posts/2014-07-25-testing-with-ember-simple-auth-and-ember-cli.md
+++ b/_posts/2014-07-25-testing-with-ember-simple-auth-and-ember-cli.md
@@ -7,7 +7,7 @@ bio: "Founding Director of simplabs, author of Ember Simple Auth"
 topic: ember
 ---
 
-[The last blog post](/blog/2014-06-30-using-ember-simple-auth-with-ember-cli "Using Ember Simple Auth with ember-cli") showed how to use [Ember Simple Auth](https://github.com/simplabs/ember-simple-auth) with [Ember CLI](https://github.com/ember-cli/ember-cli) to implement session handling and authentication. **This post shows how to test that code**.
+[The last blog post](/blog/2014/06/30/using-ember-simple-auth-with-ember-cli "Using Ember Simple Auth with ember-cli") showed how to use [Ember Simple Auth](https://github.com/simplabs/ember-simple-auth) with [Ember CLI](https://github.com/ember-cli/ember-cli) to implement session handling and authentication. **This post shows how to test that code**.
 
 <!--break-->
 

--- a/_posts/2017-01-13-ember-test-selectors.md
+++ b/_posts/2017-01-13-ember-test-selectors.md
@@ -23,7 +23,7 @@ features.
 
 ## Automatic binding of `data-test-*` properties
 
-As you may know from our [previous blog post](/blog/2016-03-04-ember-test-selectors)
+As you may know from our [previous blog post](/blog/2016/03/04/ember-test-selectors)
 on this topic, the goal of this addon is to let you use attributes starting
 with `data-test-` in your templates:
 

--- a/_posts/2017-11-17-ember-test-selectors-road-to-1-0.md
+++ b/_posts/2017-11-17-ember-test-selectors-road-to-1-0.md
@@ -8,7 +8,7 @@ topic: ember
 ---
 
 Back in January we wrote about the
-[latest changes](/blog/2017-01-13-ember-test-selectors)
+[latest changes](/blog/2017/01/13/ember-test-selectors)
 in [`ember-test-selectors`](https://github.com/simplabs/ember-test-selectors)
 and how we implemented them. Since then we adjusted a few things and this blog
 post should give you an idea what has happened so far and what else will happen

--- a/_posts/2018-06-05-ember-component-playground.md
+++ b/_posts/2018-06-05-ember-component-playground.md
@@ -12,7 +12,7 @@ a component playground for our Ember.js application. In this post we will
 discuss how to implement "convention over configuration" for it by automatically
 discovering new components and showing them in the playground.
 
-[previous post]: /blog/2018-01-24-ember-freestyle
+[previous post]: /blog/2018/01/24/ember-freestyle
 [ember-freestyle]: http://ember-freestyle.com/
 
 <!--break-->

--- a/_posts/2018-07-24-from-spa-to-pwa.md
+++ b/_posts/2018-07-24-from-spa-to-pwa.md
@@ -31,7 +31,7 @@ The application is [open source](https://github.com/simplabs/breethe-client)
 and we encourage everyone interested to look through the source for reference.
 To learn more about how we built Breethe with
 [Glimmer.js](http://glimmerjs.com), refer to the
-[previous post in this series](/blog/2018-07-03-building-a-pwa-with-glimmer-js).
+[previous post in this series](/blog/2018/07/03/building-a-pwa-with-glimmer-js).
 None of the contents in this post are specific to Glimmer.js in any way though,
 but all generally applicable to all frontend stacks.
 
@@ -556,7 +556,7 @@ completes in
 ## Outlook
 
 This post and the
-[previous one](/blog/2018-07-03-building-a-pwa-with-glimmer-js) have given
+[previous one](/blog/2018/07/03/building-a-pwa-with-glimmer-js) have given
 an overview of how to write an SPA (in this case with Glimmer.js) and then
 turning that into a [Progressive Web App](http://breethe.app). With Breethe, we
 haven't stopped there though but employed server side rendering to combine the

--- a/_posts/2018-12-10-assert-your-style.md
+++ b/_posts/2018-12-10-assert-your-style.md
@@ -73,7 +73,7 @@ export default Component.extend({
   }),
 });
 ```
- To learn more about the rationale behind `ember-test-selectors`, be sure to also [give this introduction a read](/blog/2017-11-17-ember-test-selectors-road-to-1-0).
+ To learn more about the rationale behind `ember-test-selectors`, be sure to also [give this introduction a read](/blog/2017/11/17/ember-test-selectors-road-to-1-0).
 
 Using the [HTMLElement.style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) API, we can assert if the correct background color has been applied to our component:
 
@@ -137,7 +137,7 @@ module('Integration | Component | simplabs-logo-tile', function(hooks) {
 
 Now we know how we can write style-related tests for our automated test process that assert that the expected styles are applied to elements on the web page.
 
-But there's an even easier way to assert the computed styles of elements in your **QUnit test suite**. Since [v0.8.1](https://twitter.com/simplabs/status/1065913669995978752) of [qunit-dom](/blog/2017-10-24-high-level-assertions-with-qunit-dom) you can make your tests truly ✨
+But there's an even easier way to assert the computed styles of elements in your **QUnit test suite**. Since [v0.8.1](https://twitter.com/simplabs/status/1065913669995978752) of [qunit-dom](/blog/2017/10/24/high-level-assertions-with-qunit-dom) you can make your tests truly ✨
 
 Check it [out](https://github.com/simplabs/qunit-dom):
 

--- a/_posts/2018-12-20-factories-best-practices.md
+++ b/_posts/2018-12-20-factories-best-practices.md
@@ -13,7 +13,7 @@ Writing tests is like drinking beer 🍻. When you first try it, the taste is re
 
 ## AAA
 
-Before I dive into factories, firstly I want to mention AAA: Arrange, Act, Assert. I covered this paradigm over [here](/blog/2017-09-17-magic-test-data), and I still stand by it. It's the most important thing you can do to make your tests straight forward and understandable for others.
+Before I dive into factories, firstly I want to mention AAA: Arrange, Act, Assert. I covered this paradigm over [here](/blog/2017/09/17/magic-test-data), and I still stand by it. It's the most important thing you can do to make your tests straight forward and understandable for others.
 
 ## Factories > Fixtures
 

--- a/_posts/2019-03-13-elixir-umbrella-mox.md
+++ b/_posts/2019-03-13-elixir-umbrella-mox.md
@@ -38,8 +38,8 @@ The server for this application was implemented using an
 [Elixir](https://elixir-lang.org) umbrella application which will be the focus 
 of this post. The client for Breethe was built with
 [Glimmer.js](http://glimmerjs.com), which we discussed in previous posts:
-- [From SPA to PWA](/blog/2018-07-24-from-spa-to-pwa/)
-- [Building a PWA with Glimmer.js](/blog/2018-07-03-building-a-pwa-with-glimmer-js)
+- [From SPA to PWA](/blog/2018/07/24/from-spa-to-pwa/)
+- [Building a PWA with Glimmer.js](/blog/2018/07/03/building-a-pwa-with-glimmer-js)
 
 ## Umbrella applications and separating concerns 
 

--- a/config/routes-map.js
+++ b/config/routes-map.js
@@ -11,7 +11,7 @@ module.exports = function() {
       component: post.componentName,
       title: `${post.meta.title} | Blog`,
       bundle: {
-        asset: `/blog-${post.queryPath}.js`,
+        asset: `/blog/${post.queryPath}.js`,
         module: `__blog-${post.queryPath}__`,
       },
       parentBundle: {
@@ -26,7 +26,7 @@ module.exports = function() {
       component: author.componentName,
       title: `Posts by ${author.name} | Blog`,
       bundle: {
-        asset: `/blog-author-${author.twitter}.js`,
+        asset: `/blog/author-${author.twitter}.js`,
         module: `__blog-author-${author.twitter}__`,
       },
       parentBundle: {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -90,7 +90,7 @@ class SimplabsApp extends GlimmerApp {
     let blogPostTrees = posts.map(post => {
       let [blogPostTree] = this._splitBundle(jsTree, {
         componentPrefix: post.componentName,
-        file: `blog-${post.queryPath}.js`,
+        file: `blog/${post.queryPath}.js`,
         moduleName: `__blog-${post.queryPath}__`,
       });
       return blogPostTree;
@@ -98,7 +98,7 @@ class SimplabsApp extends GlimmerApp {
     let blogAuthorTrees = authors.map(author => {
       let [blogAuthorTree] = this._splitBundle(jsTree, {
         componentPrefix: author.componentName,
-        file: `blog-author-${author.twitter}.js`,
+        file: `blog/author-${author.twitter}.js`,
         moduleName: `__blog-author-${author.twitter}__`,
       });
       return blogAuthorTree;

--- a/lib/generate-blog-components/lib/collect-posts.js
+++ b/lib/generate-blog-components/lib/collect-posts.js
@@ -49,7 +49,7 @@ module.exports = function(folder) {
 };
 
 function buildQueryPath(file) {
-  return path.basename(file, '.md');
+  return path.basename(file, '.md').replace(/(\d+)-(\d+)-(\d+)-(.+)/, '$1/$2/$3/$4');
 }
 
 function buildPostComponentName(file) {


### PR DESCRIPTION
This fixes the blog routes so that we format the date as `2019/05/02/<post-title>` vs. `2019-05-02-<post-title>` and the old routes continue to work.

closes #523 