### PR TITLE
Generate sitemap.xml during build

### DIFF
--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -6,7 +6,7 @@ const writeFile = require('broccoli-file-creator');
 const routesMap = require('../../config/routes-map.js');
 
 module.exports = {
-  name: 'inject-routes',
+  name: 'routes',
 
   included() {
     this.routes = routesMap();

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const writeFile = require('broccoli-file-creator');
+const MergeTrees = require('broccoli-merge-trees');
 
 const routesMap = require('../../config/routes-map.js');
 
@@ -14,7 +15,10 @@ module.exports = {
 
   treeFor(type) {
     if (type === 'public') {
-      return writeFile('routes.json', JSON.stringify(this.routes));
+      return new MergeTrees([
+        writeFile('routes.json', JSON.stringify(this.routes)),
+        writeFile('sitemap.xml', generateSitemap(this.routes)),
+      ]);
     }
   },
 
@@ -34,3 +38,23 @@ module.exports = {
     return true;
   },
 };
+
+function generateSitemap(routes) {
+  let sitemap = `
+    <?xml version="1.0" encoding="UTF-8"?>
+      <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  `;
+
+  let paths = Object.keys(routes);
+  for (let path of paths) {
+    sitemap += `
+      <url>
+        <loc>https://simplabs.com${path}</loc>
+      </url>
+    `;
+  }
+
+  sitemap += `</urlset>`;
+
+  return sitemap.replace(/^\s+|\s+$/g, '');
+}

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -54,7 +54,7 @@ function generateSitemap(routes) {
     `;
   }
 
-  sitemap += `</urlset>`;
+  sitemap += '</urlset>';
 
   return sitemap.replace(/^\s+|\s+$/g, '');
 }

--- a/lib/routes/package.json
+++ b/lib/routes/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "inject-routes",
+  "name": "routes",
   "keywords": [
     "ember-addon"
   ],

--- a/package.json
+++ b/package.json
@@ -92,9 +92,10 @@
       "lib/generate-calendar",
       "lib/generate-talks-archive",
       "lib/google-analytics",
-      "lib/inject-routes",
+      "lib/routes",
       "lib/sentry",
-      "lib/service-workers"
+      "lib/service-workers",
+      "lib/sitemap"
     ]
   },
   "prettier": {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,4 @@
 # http://www.robotstxt.org
 User-agent: *
 Disallow:
+Sitemap: https://simplabs.com/sitemap.xml


### PR DESCRIPTION
This extends the _"routes"_ (previously _"inject-routes"_) in-repo-addon so that it generates a `sitemap.xml` during the build.

closes #531