### PR TITLE
add basic metadata

### DIFF
--- a/lib/head-data/index.js
+++ b/lib/head-data/index.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+  name: require('./package').name,
+
+  isDevelopingAddon() {
+    return true;
+  },
+
+  contentFor(type) {
+    if (type === 'head') {
+      return `
+        <meta name="keywords" content="ember, elixir, consulting, web apps, progressive web apps, software engineering, rest apis, software architecture, software design, training, ui, ux" />
+        <meta name="language" content="en" />
+        <meta name="content-language" content="en" />
+        <meta name="publisher" content="simplabs GmbH" />
+        <link type="application/atom+xml" rel="alternate" href="https://simplabs.com/feed.xml" title="simplabs Blog" />
+      `;
+    } else {
+      return '';
+    }
+  },
+};

--- a/lib/head-data/package.json
+++ b/lib/head-data/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "head-data",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
       "lib/generate-calendar",
       "lib/generate-talks-archive",
       "lib/google-analytics",
+      "lib/head-data",
       "lib/routes",
       "lib/sentry",
       "lib/service-workers",


### PR DESCRIPTION
This adds basic metadata to the document head. This just mimics what we had for the old page - SEO needs to be looked at in more detail still after this (see #539).

closes #528