### PR TITLE
Fix ArrowLink styles

### DIFF
--- a/src/ui/components/ArrowLink/stylesheet.css
+++ b/src/ui/components/ArrowLink/stylesheet.css
@@ -1,9 +1,9 @@
 :scope {
+  block-name: ArrowLink;
   text-align: right;
 }
 
 .link {
-  block-name: ArrowLink;
   position: relative;
   display: inline-block;
   padding: 1.5rem 7rem 1.5rem 0;


### PR DESCRIPTION
The `block-name` was previously defined inside a class in the block vs. in `:scope` where it is supposed to be. That also leads to the `block-name` being included in the generated CSS.