### PR TITLE
redirect old blog routes to new ones

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,3 +14,212 @@
   from = "/*"
   to = "/404/index.html"
   status = 404
+
+# redirect old blog routes
+[[redirects]]
+  from="/blog/2013/06/15/authentication-in-emberjs.html"
+  to="/blog/2013/06/15/authentication-in-emberjs/"
+
+[[redirects]]
+  from="/blog/2013/06/27/excellent-172.html"
+  to="/blog/2013/06/27/excellent-172/"
+
+[[redirects]]
+  from="/blog/2013/06/28/excellent-200.html"
+  to="/blog/2013/06/28/excellent-200/"
+
+[[redirects]]
+  from="/blog/2013/08/08/better-authentication-in-emberjs.html"
+  to="/blog/2013/08/08/better-authentication-in-emberjs/"
+
+[[redirects]]
+  from="/blog/2013/10/09/embersimpleauth.html"
+  to="/blog/2013/10/09/embersimpleauth/"
+
+[[redirects]]
+  from="/blog/2013/10/28/embersimpleauth-implements-rfc-6749-oauth-20.html"
+  to="/blog/2013/10/28/embersimpleauth-implements-rfc-6749-oauth-20/"
+
+[[redirects]]
+  from="/blog/2014/01/20/embersimpleauth-010.html"
+  to="/blog/2014/01/20/embersimpleauth-010/"
+
+[[redirects]]
+  from="/blog/2014/03/11/embersimpleauth-020.html"
+  to="/blog/2014/03/11/embersimpleauth-020/"
+
+[[redirects]]
+  from="/blog/2014/04/06/embersimpleauth-021.html"
+  to="/blog/2014/04/06/embersimpleauth-021/"
+
+[[redirects]]
+  from="/blog/2014/04/10/embersimpleauth-030.html"
+  to="/blog/2014/04/10/embersimpleauth-030/"
+
+[[redirects]]
+  from="/blog/2014/04/24/embersimpleauth-needs-a-logo.html"
+  to="/blog/2014/04/24/embersimpleauth-needs-a-logo/"
+
+[[redirects]]
+  from="/blog/2014/06/30/using-ember-simple-auth-with-ember-cli.html"
+  to="/blog/2014/06/30/using-ember-simple-auth-with-ember-cli/"
+
+[[redirects]]
+  from="/blog/2014/07/25/testing-with-ember-simple-auth-and-ember-cli.html"
+  to="/blog/2014/07/25/testing-with-ember-simple-auth-and-ember-cli/"
+
+[[redirects]]
+  from="/blog/2014/10/15/the-most-important-command-when-working-with-xcode-6.html"
+  to="/blog/2014/10/15/the-most-important-command-when-working-with-xcode-6/"
+
+[[redirects]]
+  from="/blog/2015/06/03/emberjs-workshop-in-munich.html"
+  to="/blog/2015/06/03/emberjs-workshop-in-munich/"
+
+[[redirects]]
+  from="/blog/2015/07/29/ember-simple-auth-10-a-first-look.html"
+  to="/blog/2015/07/29/ember-simple-auth-10-a-first-look/"
+
+[[redirects]]
+  from="/blog/2015/08/07/rails-api-auth.html"
+  to="/blog/2015/08/07/rails-api-auth/"
+
+[[redirects]]
+  from="/blog/2015/11/27/updating-to-ember-simple-auth-1.0.html"
+  to="/blog/2015/11/27/updating-to-ember-simple-auth-1.0/"
+
+[[redirects]]
+  from="/blog/2015/12/3/ember-cli-deploy-notifications.html"
+  to="/blog/2015/12/3/ember-cli-deploy-notifications/"
+
+[[redirects]]
+  from="/blog/2016/03/04/ember-test-selectors.html"
+  to="/blog/2016/03/04/ember-test-selectors/"
+
+[[redirects]]
+  from="/blog/2016/12/06/out-of-the-box-fastboot-support-in-ember-simple-auth.html"
+  to="/blog/2016/12/06/out-of-the-box-fastboot-support-in-ember-simple-auth/"
+
+[[redirects]]
+  from="/blog/2017/01/13/ember-test-selectors.html"
+  to="/blog/2017/01/13/ember-test-selectors/"
+
+[[redirects]]
+  from="/blog/2017/02/01/class-based-computed-properties.html"
+  to="/blog/2017/02/01/class-based-computed-properties/"
+
+[[redirects]]
+  from="/blog/2017/02/13/npm-libs-in-ember-cli.html"
+  to="/blog/2017/02/13/npm-libs-in-ember-cli/"
+
+[[redirects]]
+  from="/blog/2017/03/21/on-computed-properties-vs-helpers.html"
+  to="/blog/2017/03/21/on-computed-properties-vs-helpers/"
+
+[[redirects]]
+  from="/blog/2017/08/28/creating-web-components-with-glimmer.html"
+  to="/blog/2017/08/28/creating-web-components-with-glimmer/"
+
+[[redirects]]
+  from="/blog/2017/09/17/magic-test-data.html"
+  to="/blog/2017/09/17/magic-test-data/"
+
+[[redirects]]
+  from="/blog/2017/10/24/high-level-assertions-with-qunit-dom.html"
+  to="/blog/2017/10/24/high-level-assertions-with-qunit-dom/"
+
+[[redirects]]
+  from="/blog/2017/11/17/ember-test-selectors-road-to-1-0.html"
+  to="/blog/2017/11/17/ember-test-selectors-road-to-1-0/"
+
+[[redirects]]
+  from="/blog/2017/12/04/enginification.html"
+  to="/blog/2017/12/04/enginification/"
+
+[[redirects]]
+  from="/blog/2018/01/24/ember-freestyle.html"
+  to="/blog/2018/01/24/ember-freestyle/"
+
+[[redirects]]
+  from="/blog/2018/02/14/handling-webhooks-in-phoenix.html"
+  to="/blog/2018/02/14/handling-webhooks-in-phoenix/"
+
+[[redirects]]
+  from="/blog/2018/05/30/a-little-encouragement-goes-a-long-way-in-2018.html"
+  to="/blog/2018/05/30/a-little-encouragement-goes-a-long-way-in-2018/"
+
+[[redirects]]
+  from="/blog/2018/06/05/ember-component-playground.html"
+  to="/blog/2018/06/05/ember-component-playground/"
+
+[[redirects]]
+  from="/blog/2018/06/11/actix.html"
+  to="/blog/2018/06/11/actix/"
+
+[[redirects]]
+  from="/blog/2018/06/18/intl-polyfill-loading.html"
+  to="/blog/2018/06/18/intl-polyfill-loading/"
+
+[[redirects]]
+  from="/blog/2018/06/27/actix-tcp-client.html"
+  to="/blog/2018/06/27/actix-tcp-client/"
+
+[[redirects]]
+  from="/blog/2018/07/03/building-a-pwa-with-glimmer-js.html"
+  to="/blog/2018/07/03/building-a-pwa-with-glimmer-js/"
+
+[[redirects]]
+  from="/blog/2018/07/24/from-spa-to-pwa.html"
+  to="/blog/2018/07/24/from-spa-to-pwa/"
+
+[[redirects]]
+  from="/blog/2018/11/27/open-source-maintenance.html"
+  to="/blog/2018/11/27/open-source-maintenance/"
+
+[[redirects]]
+  from="/blog/2018/12/10/assert-your-style.html"
+  to="/blog/2018/12/10/assert-your-style/"
+
+[[redirects]]
+  from="/blog/2018/12/20/factories-best-practices.html"
+  to="/blog/2018/12/20/factories-best-practices/"
+
+[[redirects]]
+  from="/blog/2019/02/08/ember-js-film-release.html"
+  to="/blog/2019/02/08/ember-js-film-release/"
+
+[[redirects]]
+  from="/blog/2019/02/11/ember-js-film-berlin.html"
+  to="/blog/2019/02/11/ember-js-film-berlin/"
+
+[[redirects]]
+  from="/blog/2019/03/07/march-monthly-update.html"
+  to="/blog/2019/03/07/march-monthly-update/"
+
+[[redirects]]
+  from="/blog/2019/03/13/elixir-umbrella-mox.html"
+  to="/blog/2019/03/13/elixir-umbrella-mox/"
+
+[[redirects]]
+  from="/blog/2019/03/18/emberconf-update.html"
+  to="/blog/2019/03/18/emberconf-update/"
+
+[[redirects]]
+  from="/blog/2019/03/29/qonto-project.html"
+  to="/blog/2019/03/29/qonto-project/"
+
+[[redirects]]
+  from="/blog/2019/04/05/april-monthly-update.html"
+  to="/blog/2019/04/05/april-monthly-update/"
+
+[[redirects]]
+  from="/blog/2019/04/05/spas-pwas-and-ssr.html"
+  to="/blog/2019/04/05/spas-pwas-and-ssr/"
+
+[[redirects]]
+  from="/blog/2019/04/24/dependency-updates-for-gitlab.html"
+  to="/blog/2019/04/24/dependency-updates-for-gitlab/"
+
+[[redirects]]
+  from="/blog/2019/05/10/may-monthly-update.html"
+  to="/blog/2019/05/10/may-monthly-update/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,11 +10,6 @@
   SENTRY_DSN = "https://5d8e23a02a1841f5837b96ef76423c8b@sentry.io/1456103"
   SENTRY_ENV = "deploy-preview"
 
-[[redirects]]
-  from = "/*"
-  to = "/404/index.html"
-  status = 404
-
 # redirect old blog routes
 [[redirects]]
   from="/blog/2013/06/15/authentication-in-emberjs.html"
@@ -223,3 +218,9 @@
 [[redirects]]
   from="/blog/2019/05/10/may-monthly-update.html"
   to="/blog/2019/05/10/may-monthly-update/"
+
+# handle 404 errors
+[[redirects]]
+  from = "/*"
+  to = "/404/index.html"
+  status = 404


### PR DESCRIPTION
This adds redirects from the old blog routes (e.g. `/blog/2013/06/15/authentication-in-emberjs.html`) to the new ones (e.g. `/blog/2013/06/15/authentication-in-emberjs/`) so we don't 404 for old posts.