### PR TITLE
don't treat absolute links as internal

### DIFF
--- a/lib/markdown-content/htmlize-markdown.js
+++ b/lib/markdown-content/htmlize-markdown.js
@@ -18,9 +18,9 @@ module.exports = function htmlizeMarkdown(source, options = {}, callback = null)
     dom.querySelectorAll('th').forEach(th => th.classList.add('table.header'));
     dom.querySelectorAll('td').forEach(td => td.classList.add('table.cell'));
     dom.querySelectorAll('a').forEach(a => {
-      if (a.href.startsWith('/') || a.href.startsWith('https://simplabs.com')) {
+      if (a.href.startsWith('/')) {
         a.dataset.internal = true;
-      } else {
+      } else if (!a.href.startsWith('https://simplabs.com')) {
         a.target = '_blank';
         a.rel = 'noopener';
       }

--- a/src/ui/components/ArrowLink/component-test.ts
+++ b/src/ui/components/ArrowLink/component-test.ts
@@ -19,10 +19,10 @@ module('Component: ArrowLink', function(hooks) {
     assert.ok(this.containerElement.querySelector('a').dataset.internal !== undefined);
   });
 
-  test('it adds a "data-internal" attribute for absolute internal links', async function(assert) {
+  test('it does not add a "data-internal" attribute for absolute internal links', async function(assert) {
     await render(hbs`<ArrowLink @href="https://simplabs.com/link" />`);
 
-    assert.ok(this.containerElement.querySelector('a').dataset.internal !== undefined);
+    assert.ok(this.containerElement.querySelector('a').dataset.internal === undefined);
   });
 
   test('it does not add a "data-internal" attribute for external links', async function(assert) {
@@ -37,7 +37,7 @@ module('Component: ArrowLink', function(hooks) {
     assert.notOk(this.containerElement.querySelector('a').target);
   });
 
-  test('it does not add a "target" attribute for relative internal links', async function(assert) {
+  test('it does not add a "target" attribute for absolute internal links', async function(assert) {
     await render(hbs`<ArrowLink @href="https://simplabs.com/link" />`);
 
     assert.notOk(this.containerElement.querySelector('a').target);

--- a/src/ui/components/ArrowLink/component.ts
+++ b/src/ui/components/ArrowLink/component.ts
@@ -3,21 +3,28 @@ import Component, { tracked } from '@glimmer/component';
 export default class ArrowLink extends Component {
   @tracked
   get isInternal() {
-    const href = this.args.href || '';
+    let href = this.args.href || '';
 
-    return Boolean(href.substring(0, 1) === '/' || href.match(/^https?:\/\/simplabs.com/));
+    return Boolean(href.substring(0, 1) === '/';
+  }
+
+  @tracked
+  get isSimplabs() {
+    let href = this.args.href || '';
+
+    return this.isInternal || href.match(/^https?:\/\/simplabs.com/));
   }
 
   @tracked
   get target() {
-    if (!this.isInternal) {
+    if (!this.isSimplabs) {
       return '_blank';
     }
   }
 
   @tracked
   get rel() {
-    if (!this.isInternal) {
+    if (!this.isSimplabs) {
       return 'noopener';
     }
   }


### PR DESCRIPTION
Handling absolute links as internal can lead to situations where we end up with URLs like this:

https://deploy-preview-550--objective-northcutt-37494c.netlify.com/blog/2018/12/20/factories-best-practiceshttps://simplabs.com/blog/2017/09/17/magic-test-data/

Navigo simply appends the absolute URL to the current URL in this case which obviously doesn't work. We should never have any absolute links in anything anyway really though - we'll handle making all links absolute in `feed.xml` in the code that generates that.