### PR TITLE
handle bundle-loading errors gracefully

### DIFF
--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -81,10 +81,17 @@ export default class Simplabs extends Component {
         }
       };
       if (bundle && !this.appState.isSSR) {
-        options.before = async done => {
-          await this._loadBundle(bundle, parentBundle);
-          this._registerBundle(bundle);
-          done();
+        options.before = async (done, params) => {
+          try {
+            await this._loadBundle(bundle, parentBundle);
+            this._registerBundle(bundle);
+            done();
+          } catch(e) {
+            if (window.Sentry) {
+              window.Sentry.captureException(e);
+            }
+            window.location = path;
+          }
         };
       }
       this.router.on(


### PR DESCRIPTION
…so that people are not stuck not being able to go to a particular route. Instead, when loading the bundle for a route fails, we simply force the browser to refresh on the target route.