### PR TITLE
improve service worker build time

### DIFF
--- a/lib/service-workers/lib/worker-builder.js
+++ b/lib/service-workers/lib/worker-builder.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const fs = require('fs-extra');
 
-const BroccoliPlugin = require('broccoli-plugin');
+const BroccoliPlugin = require('broccoli-caching-writer');
 const walkSync = require('walk-sync');
 const Rollup = require('rollup');
 const commonjs = require('rollup-plugin-commonjs');


### PR DESCRIPTION
This switches the service worker builder plugin from the standard `broccoli-plugin` base class to `broccoli-caching-writer` which should enable better caching and a faster build.