### PR TITLE
add missing data-internal

### DIFF
--- a/lib/generate-blog/lib/files/recent-posts/template.hbs
+++ b/lib/generate-blog/lib/files/recent-posts/template.hbs
@@ -2,7 +2,7 @@
   {{#each posts}}
     <li class="post">
       <h4 class="typography.headline-3-plain title">
-        <a class="typography.title-link" href="{{path}}">
+        <a class="typography.title-link" href="{{path}}" data-internal>
           {{title}}
         </a>
       </h4>


### PR DESCRIPTION
The link to the post from the title of a recent post (as e.g. shown on `/expertise/ember`) is currently missing the `data-internal` attribute which means clicking it will result in a refresh as opposed to a client-side route change.