### PR TITLE
split markdown *after* htmlifying content

### DIFF
--- a/lib/generate-blog/lib/collect-posts.js
+++ b/lib/generate-blog/lib/collect-posts.js
@@ -17,14 +17,13 @@ module.exports = function(folder) {
     .map(file => {
       let queryPath = buildQueryPath(file);
       let componentName = buildPostComponentName(file);
-      let [meta, excerpt, content] = separateMeta(file);
+      let [meta, content] = separateMeta(file);
       meta.date = new Date(path.basename(file).substring(0, 10));
 
       return {
         queryPath,
         componentName,
         meta,
-        excerpt,
         content,
       };
     });

--- a/lib/generate-blog/lib/components-builder.js
+++ b/lib/generate-blog/lib/components-builder.js
@@ -117,7 +117,7 @@ module.exports = class ComponentsBuilder extends BaseComponentsBuilder {
   _preparePostTemplateData(post) {
     return {
       title: post.meta.title,
-      excerpt: htmlizeExcerpt(post.excerpt),
+      excerpt: htmlizeExcerpt(post.content),
       body: htmlizeBody(post.content),
       date: dateformat(post.meta.date, 'mmmm d, yyyy'),
       path: `/blog/${post.queryPath}`,
@@ -154,8 +154,8 @@ function encodeCurlies(content) {
   return content.replace(/\{\{/gm, '&#123;&#123;').replace(/\}\}/gm, '&#125;&#125;');
 }
 
-function htmlizeBody(body) {
-  let html = htmlizeMarkdown(body, { renderer: Renderer }, dom => {
+function htmlizeBody(content) {
+  let html = htmlizeMarkdown(content, { renderer: Renderer }, dom => {
     dom.querySelectorAll('p > img').forEach(img => {
       let paragraph = img.parentElement;
       img.classList.add('main-block.image-centered');
@@ -166,15 +166,21 @@ function htmlizeBody(body) {
       paragraph.parentElement.removeChild(paragraph);
     });
   });
-  return encodeCurlies(html);
+  let [, body] = splitPostContent(html);
+  return encodeCurlies(body);
 }
 
-function htmlizeExcerpt(excerpt) {
-  let html = htmlizeMarkdown(excerpt, { renderer: Renderer }, dom => {
+function htmlizeExcerpt(content) {
+  let html = htmlizeMarkdown(content, { renderer: Renderer }, dom => {
     dom.querySelectorAll('p').forEach(p => {
       p.classList.remove('typography.body-text');
       p.classList.add('typography.lead');
     });
   });
-  return encodeCurlies(html);
+  let [excerpt] = splitPostContent(html);
+  return encodeCurlies(excerpt);
+}
+
+function splitPostContent(content) {
+  return content.split('<!--break-->');
 }

--- a/lib/generate-blog/lib/feed-builder.js
+++ b/lib/generate-blog/lib/feed-builder.js
@@ -51,8 +51,8 @@ function generateFeed(posts) {
 
   for (let post of posts) {
     let url = `https://simplabs.com/blog/${post.queryPath}`;
-    let excerpt = htmlize(post.excerpt);
     let content = htmlize(post.content);
+    let [excerpt] = content.split('&lt;!--break--&gt;');
     feed += `
       <entry>
         <title>${post.meta.title}</title>

--- a/lib/markdown-content/separate-meta.js
+++ b/lib/markdown-content/separate-meta.js
@@ -7,9 +7,9 @@ const frontMatter = require('front-matter');
 module.exports = function separateMeta(file) {
   let content = fs.readFileSync(file).toString();
   let data = frontMatter(content);
-  let [excerpt, body] = data.body.split('<!--break-->');
+  let body = data.body;
 
   let meta = data.attributes;
 
-  return [meta, excerpt, body];
+  return [meta, body];
 };


### PR DESCRIPTION
This changes how we handled post excerpts. When splitting first and then htmlifying the markdown, links that use the style `[title]` with a `[title](url)` entry at the bottom of the markdown file don't work because the latter is not part of the excerpt. Now we simply htmlify the complete content and then cut the excerpt out of that afterwards so that the link gets properly replaced.

closes #567 