### PR TITLE
Disable serviceworker in development mode

### DIFF
--- a/lib/service-workers/index.js
+++ b/lib/service-workers/index.js
@@ -29,6 +29,10 @@ module.exports = {
   },
 
   contentFor(type) {
+    if (process.env.EMBER_ENV === 'development') {
+      return '';
+    }
+
     if (type === 'body-footer') {
       return `
         <script>
@@ -40,6 +44,8 @@ module.exports = {
         </script>
       `;
     }
+
+    return '';
   },
 
   postprocessTree(type, appTree) {


### PR DESCRIPTION
I got stumped by the service worker on iOS more than once so I propose we disable it for good while in development. This change ensures it's only added to the DOM if the environment is set to production.