### PR TITLE
Disable Google Analytics in development mode

### DIFF
--- a/lib/google-analytics/index.js
+++ b/lib/google-analytics/index.js
@@ -8,6 +8,10 @@ module.exports = {
   },
 
   contentFor(type) {
+    if (process.env.EMBER_ENV === 'development') {
+      return '';
+    }
+
     if (type === 'body-footer') {
       return `
         <script async src="https://www.googletagmanager.com/gtag/js?id=UA-53237918-1"></script>
@@ -18,8 +22,8 @@ module.exports = {
           gtag('config', 'UA-53237918-1');
         </script>
       `;
-    } else {
-      return '';
     }
+
+    return '';
   },
 };


### PR DESCRIPTION
Looking into the addons, I found that we're collecting Google Analytics data even in development. While we can easily filter those visits there, I think it's much easier to just not send them at all. 