### PR TITLE
Cleanup button block

### DIFF
--- a/src/ui/components/FormContact/template.hbs
+++ b/src/ui/components/FormContact/template.hbs
@@ -17,7 +17,7 @@
       </a>
     </p>
     <p>
-      <button type="submit" class="button.button">
+      <button type="submit" class="button">
         Send another message
       </button>
     </p>
@@ -70,7 +70,7 @@
       </div>
     {{/if}}
     <p>
-      <button type="submit" class="button.button">
+      <button type="submit" class="button">
         {{#if this.isSubmitting}}
           Sending…
         {{else}}

--- a/src/ui/components/Header/stylesheet.css
+++ b/src/ui/components/Header/stylesheet.css
@@ -104,7 +104,7 @@
 }
 
 .work-with-us {
-  composes: 'button.button';
+  composes: 'button';
 }
 
 @media (max-width: 887px) {

--- a/src/ui/components/PageHomepage/template.hbs
+++ b/src/ui/components/PageHomepage/template.hbs
@@ -24,7 +24,7 @@
       </li>
     </ul>
     <p class="logos-more">
-      <a href="/work" class="button.button" data-internal>
+      <a href="/work" class="button" data-internal>
         Our Work
       </a>
     </p>

--- a/src/ui/components/WorkWithUs/template.hbs
+++ b/src/ui/components/WorkWithUs/template.hbs
@@ -5,7 +5,7 @@
   <p class="typography.lead offset.after-12">
     Talk to one of our experts to find out how we can help you.
   </p>
-  <a class="button.button" href="/contact" data-internal>
+  <a class="button" href="/contact" data-internal>
     Let's discuss your project
   </a>
 </div>

--- a/src/ui/styles/blocks/button.block.css
+++ b/src/ui/styles/blocks/button.block.css
@@ -1,8 +1,6 @@
 :scope {
   block-name: button;
-}
 
-.button {
   display: inline-block;
   padding: calc(1rem - 2px) calc(3rem - 2px);
   flex-shrink: 0;
@@ -18,21 +16,21 @@
   transition: background-position 0.28s ease-in-out, color 0.1s 0.13s ease-in-out;
 }
 
-.button:focus,
-.button:hover {
+:scope:focus,
+:scope:hover {
   background-position: 50% 10%;
   color: var(--color-text-inverted);
   outline: 0;
   text-decoration: none;
 }
 
-.button:disabled {
+:scope:disabled {
   background-position: 0 90%;
   color: var(--color-accent);
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .button {
+  :scope {
     transition: none;
   }
 }


### PR DESCRIPTION
Use the `:scope` directly. Reduces clutter in templates and makes composition easier, as we no longer compose a subclass of a scope.