### PR TITLE
Fix sitemap problems

### DIFF
--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -45,7 +45,7 @@ function generateSitemap(routes) {
       <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   `;
 
-  let paths = Object.keys(routes);
+  let paths = Object.keys(routes).filter(path => path !== '/404');
   for (let path of paths) {
     sitemap += `
       <url>

--- a/package.json
+++ b/package.json
@@ -101,8 +101,7 @@
       "lib/head-data",
       "lib/routes",
       "lib/sentry",
-      "lib/service-workers",
-      "lib/sitemap"
+      "lib/service-workers"
     ]
   },
   "prettier": {


### PR DESCRIPTION
* removes reference to the old `sitemap` in-repo-addon
* filters `/404` from the routes added to the sitemap

closes #601 