### PR TITLE
Reduce percy load

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -1,3 +1,0 @@
-version: 1
-static-snapshots:
-  ignore-files: 'bare-index.html'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ addons:
 cache:
   yarn: true
 
+branches:
+  only: 
+    - master
+
 env:
   global:
     # See https://git.io/vdao3 for details.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format:js": "eslint --fix . --cache",
     "format:hbs": "prettier --write --parser glimmer '**/*.hbs'",
     "format": "yarn run format:ts; yarn run format:js; yarn format:hbs",
-    "percy": "percy snapshot dist"
+    "percy": "percy exec -- node scripts/percy.js"
   },
   "devDependencies": {
     "@babel/core": "^7.4.5",
@@ -33,6 +33,7 @@
     "@glimmer/resolver": "^0.4.3",
     "@glimmer/ssr": "^0.13.0",
     "@glimmer/test-helpers": "^0.31.1",
+    "@percy/script": "^1.0.0",
     "@types/navigo": "^7.0.1",
     "@types/qunit": "^2.0.31",
     "broccoli-asset-rev": "^2.5.0",

--- a/scripts/percy.js
+++ b/scripts/percy.js
@@ -11,17 +11,13 @@ const ROUTES_MAP = require('../config/routes-map')();
 let routes = ROUTES_MAP;
 let paths = Object.keys(routes);
 
-let nonBlogPostsPaths = paths
-  .filter(path => !path.startsWith('/blog/20'));
+let nonBlogPostsPaths = paths.filter(path => !path.startsWith('/blog/20'));
 let latestBlogPostsPaths = paths
   .filter(path => path.startsWith('/blog/20'))
   .sort()
   .slice(-5);
 
-let snapshotPaths = [
-  ...nonBlogPostsPaths,
-  ...latestBlogPostsPaths
-];
+let snapshotPaths = [...nonBlogPostsPaths, ...latestBlogPostsPaths];
 
 let server = express();
 server.use(express.static(DIST_PATH));

--- a/scripts/percy.js
+++ b/scripts/percy.js
@@ -1,0 +1,38 @@
+const path = require('path');
+
+const PercyScript = require('@percy/script');
+const express = require('express');
+
+process.setMaxListeners(Infinity);
+
+const DIST_PATH = path.join(__dirname, '..', 'dist');
+const ROUTES_MAP = require('../config/routes-map')();
+
+let routes = ROUTES_MAP;
+let paths = Object.keys(routes);
+
+let nonBlogPostsPaths = paths
+  .filter(path => !path.startsWith('/blog/20'));
+let latestBlogPostsPaths = paths
+  .filter(path => path.startsWith('/blog/20'))
+  .sort()
+  .slice(-5);
+
+let snapshotPaths = [
+  ...nonBlogPostsPaths,
+  ...latestBlogPostsPaths
+];
+
+let server = express();
+server.use(express.static(DIST_PATH));
+
+server.listen(3000, async function() {
+  await PercyScript.run(async (page, percySnapshot) => {
+    for (let path of snapshotPaths) {
+      await page.goto(`http://localhost:3000${path}`);
+      await percySnapshot(path);
+    }
+  });
+
+  process.exit(0);
+});

--- a/scripts/percy.js
+++ b/scripts/percy.js
@@ -11,13 +11,14 @@ const ROUTES_MAP = require('../config/routes-map')();
 let routes = ROUTES_MAP;
 let paths = Object.keys(routes);
 
-let nonBlogPostsPaths = paths.filter(path => !path.startsWith('/blog/20'));
+let nonBlogPaths = paths.filter(path => !path.startsWith('/blog'));
 let latestBlogPostsPaths = paths
   .filter(path => path.startsWith('/blog/20'))
   .sort()
   .slice(-5);
+let sampleBlogAuthorsPaths = paths.filter(path => path.startsWith('/blog/author')).slice(-2);
 
-let snapshotPaths = [...nonBlogPostsPaths, ...latestBlogPostsPaths];
+let snapshotPaths = [...nonBlogPaths, ...latestBlogPostsPaths, ...sampleBlogAuthorsPaths, '/blog'];
 
 let server = express();
 server.use(express.static(DIST_PATH));

--- a/scripts/percy.js
+++ b/scripts/percy.js
@@ -30,6 +30,7 @@ server.listen(3000, async function() {
   await PercyScript.run(async (page, percySnapshot) => {
     for (let path of snapshotPaths) {
       await page.goto(`http://localhost:3000${path}`);
+      await page.waitFor('[data-cookie-banner]');
       await percySnapshot(path);
     }
   });

--- a/src/ui/components/CookieBanner/stylesheet.css
+++ b/src/ui/components/CookieBanner/stylesheet.css
@@ -21,12 +21,6 @@
   }
 }
 
-@media only percy {
-  :scope {
-    display: none;
-  }
-}
-
 .message {
   text-align: right;
   padding: 1.5rem 2rem;

--- a/src/ui/components/CookieBanner/stylesheet.css
+++ b/src/ui/components/CookieBanner/stylesheet.css
@@ -21,6 +21,12 @@
   }
 }
 
+@media only percy {
+  :scope {
+    display: none;
+  }
+}
+
 .message {
   text-align: right;
   padding: 1.5rem 2rem;

--- a/src/ui/components/CookieBanner/template.hbs
+++ b/src/ui/components/CookieBanner/template.hbs
@@ -1,4 +1,4 @@
-<div>
+<div data-cookie-banner>
   <p class="message">
     This website uses cookies;
     <a href="/privacy/" class="link" date-internal>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1826,6 +1826,46 @@
   dependencies:
     typescript-collections "^1.2.5"
 
+"@percy/agent@~0":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@percy/agent/-/agent-0.7.2.tgz#29884ec6c7562b379c331cefc977496b06e52efc"
+  integrity sha512-0z5Kp6YOA+g7mOxsNI0DeKfUZMtqgf76okBhgsQoycvM0yHQ6e/XrG7B7j3KeNSL8gt6N+XkP62xipqIRsmAKQ==
+  dependencies:
+    "@oclif/command" "1.5.14"
+    "@oclif/config" "^1"
+    "@oclif/plugin-help" "^2"
+    "@oclif/plugin-not-found" "^1.2"
+    "@types/express" "^4.16.0"
+    "@types/js-yaml" "^3.11.2"
+    "@types/puppeteer" "^1.6.0"
+    axios "^0.18.1"
+    body-parser "^1.18.3"
+    colors "^1.3.2"
+    cors "^2.8.4"
+    cross-spawn "^6.0.5"
+    express "^4.16.3"
+    generic-pool "^3.7.1"
+    globby "^9.2.0"
+    js-yaml "^3.13.1"
+    percy-client "^3.0.3"
+    puppeteer "^1.13.0"
+    retry-axios "^1.0.1"
+    winston "^2.0.0"
+
+"@percy/puppeteer@^1.0.7":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@percy/puppeteer/-/puppeteer-1.0.8.tgz#9ce4359f885e446bea12bfaa99e746ff38755b03"
+  integrity sha512-YTR5scNNANchsP4iUurXYHVaBg3XPJBMmnfgHwJD9/SnSMjPvSEr7uN4cPGKH78rWibl/js8FFggedkK5+7fQA==
+  dependencies:
+    "@percy/agent" "~0"
+
+"@percy/script@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@percy/script/-/script-1.0.0.tgz#66cbaa995f9a3398fc7379f207d0f23fdb7ac81d"
+  integrity sha512-iPd7NTvich3+u+CPEvjsM0+fC559Uiw9MU9CyVcjIdhyJ+fW9XCLv98xh3/X8i2xh3XsuIYdEgoF2qPE07tfJA==
+  dependencies:
+    "@percy/puppeteer" "^1.0.7"
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"


### PR DESCRIPTION
This reduces the load that we put on Percy and the load that Percy puts on us by:

* Instead of screenshotting **all** of the blog archive we only screenshot the index page, the last 5 posts and 2 sample author pages now. This dramatically reduces the number of screenshots so that we are less likely to burn through our screenshots limit that Percy sets for our plan super fast and also make reviewing easier as there are just less screenshots to review per build. Also the index page, last 5 blog posts and 2 authors should be a good enough representation of the blog in general so that we should be able to find any visual regressions that affect the blog.
* We now wait for the cookie banner to be present before making the screenshot. That removes the flakyness that was caused previously by the screenshot banner sometimes being present and sometimes not when the screenshot was taken (due to the fact that it is added after the initial render with a delay that lead to a race condition). Contrary to what #603 says, I found this the better approach than hiding the banner to Percy as that's more intrusive and also this way we get a more complete render of the page as (most of) our users will actually see it.
* I configured travis so that it doesn't do 2 builds per PR - one for the branch and one for the branch merged into `master`. We really only care for the latter and by only running 1 build per PR vs. 2, we reduce the number of Percy screenshots by 50%.

closes #603