### PR TITLE
Fix active state for menu on narrow screens

### DIFF
--- a/lib/global-css/css/menu.css
+++ b/lib/global-css/css/menu.css
@@ -22,6 +22,7 @@
     border: 0;
     background: transparent;
     transition: none;
+    text-decoration: none;
   }
 
   #toggle:checked + [data-menu] svg {

--- a/src/ui/components/Header/stylesheet.css
+++ b/src/ui/components/Header/stylesheet.css
@@ -135,8 +135,9 @@
     width: 100%;
   }
 
-  .nav:after {
+  .nav:before {
     position: absolute;
+    bottom: -50vw;
     display: block;
     width: 100%;
     height: 50vw;
@@ -145,6 +146,7 @@
     background-image: url("data:image/svg+xml,%3Csvg width='320' height='148' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='%23007df6' d='M0 0h320v10L240.5 148 0 10z' fill-rule='evenodd'/%3E%3C/svg%3E");
     background-size: cover;
     content: '';
+    clear: both;
   }
 
   .nav-item,
@@ -155,8 +157,11 @@
     transform: translate(-50%);
   }
 
-  .work-with-us {
+  .nav:after {
     float: none;
+    clear: both;
+    display: block;
+    content: '';
   }
 
   .nav-item,


### PR DESCRIPTION
- Fix underline for Contact button
- Disable text-decoration for nav items for small screens

I tried disabling the hover for the active item only, but it looked weird so I decided to drop them for the whole menu, most devices will never use them anyway.

Closes #618
