### PR TITLE
redirect old workshop domains to tutoring page

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -229,6 +229,52 @@
   from="/blog/2019/05/10/may-monthly-update.html"
   to="/blog/2019/05/10/may-monthly-update/"
 
+# redirect old workshop pages
+
+[[redirects]]
+  from="https://elixir-phoenix-workshop.simplabs.com/*"
+  to="https://simplabs.com/services/tutoring/"
+
+[[redirects]]
+  from="https://elixir-workshops.simplabs.com/*"
+  to="https://simplabs.com/services/tutoring/"
+
+[[redirects]]
+  from="https://ember-basics-workshop.simplabs.com/*"
+  to="https://simplabs.com/services/tutoring/"
+
+[[redirects]]
+  from="https://ember-pro-workshop.simplabs.com/*"
+  to="https://simplabs.com/services/tutoring/"
+
+[[redirects]]
+  from="https://ember-workshop.simplabs.com/*"
+  to="https://simplabs.com/services/tutoring/"
+
+[[redirects]]
+  from="https://ember-workshops.simplabs.com/*"
+  to="https://simplabs.com/services/tutoring/"
+
+[[redirects]]
+  from="https://phoenix-workshops.simplabs.com/*"
+  to="https://simplabs.com/services/tutoring/"
+
+[[redirects]]
+  from="https://progressive-web-apps-workshop.simplabs.com/*"
+  to="https://simplabs.com/services/tutoring/"
+
+[[redirects]]
+  from="https://typescript-fundamentals-workshop.simplabs.com/*"
+  to="https://simplabs.com/services/tutoring/"
+
+[[redirects]]
+  from="https://web-performance-workshop.simplabs.com/*"
+  to="https://simplabs.com/services/tutoring/"
+
+[[redirects]]
+  from="https://phoenix-workshops.simplabs.com/*"
+  to="https://simplabs.com/services/tutoring/"
+
 # handle 404 errors
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
This redirects the old workshop domains to the tutoring page:

* elixir-phoenix-workshop.simplabs.com
* elixir-phoenix-workshops.simplabs.com
* elixir-workshops.simplabs.com
* ember-basics-workshop.simplabs.com
* ember-pro-workshop.simplabs.com
* ember-workshop.simplabs.com
* ember-workshops.simplabs.com
* phoenix-workshops.simplabs.com
* progressive-web-apps-workshop.simplabs
* typescript-fundamentals-workshop.simplabs.com
* web-performance-workshop.simplabs.com

closes #616