### PR TITLE
redirect old blog subdomain to new blog

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -20,6 +20,11 @@
   from="/ember/"
   to="/expertise/ember/"
 
+# redirect old blog subdomain
+[[redirects]]
+  from="https://log.simplabs.com/*"
+  to="https://simplabs.com/blog/"
+
 # redirect old blog routes
 [[redirects]]
   from="/blog/2013/06/15/authentication-in-emberjs.html"


### PR DESCRIPTION
This redirects all traffic going to the old blog subdomain log.simplabs.com to the new blog simplabs.com/blog.

closes #617 