### PR TITLE
Improve ArrowLink hover performance in Safari

### DIFF
--- a/src/ui/components/ArrowLink/stylesheet.css
+++ b/src/ui/components/ArrowLink/stylesheet.css
@@ -1,6 +1,7 @@
 :scope {
   block-name: ArrowLink;
   text-align: right;
+  pointer-events: none;
 }
 
 .link {
@@ -11,6 +12,7 @@
   font-size: 3rem;
   line-height: 1.5;
   text-decoration: none;
+  pointer-events: all;
 }
 
 .link:hover {
@@ -24,11 +26,13 @@
   right: 0;
   width: 5rem;
   height: 5rem;
-  transition: right 0.2s ease-out;
+  transition: transform 0.2s;
+  transform: translate(0);
+  pointer-events: none;
 }
 
 :scope:hover .svg {
-  right: -0.5rem;
+  transform: translate(0.5rem);
 }
 
 .arrow {

--- a/src/ui/components/ShapeAcross/stylesheet.css
+++ b/src/ui/components/ShapeAcross/stylesheet.css
@@ -9,7 +9,15 @@
   position: relative;
   z-index: 0;
   grid-column: 1/-1;
-  margin-bottom: 12rem;
+
+  margin-top: -34vw;
+  margin-bottom: calc(-17vw + 12rem);
+  padding-top: 34vw;
+  padding-bottom: 17vw;
+  pointer-events: none;
+  overflow: hidden;
+  transform: translateZ(0);
+  will-change: transform;
 }
 
 .shapes {
@@ -18,6 +26,7 @@
   height: 100vw;
   margin-top: -34vw;
   margin-bottom: -17vw;
+  overflow: hidden;
 }
 
 .bottom {
@@ -68,8 +77,9 @@
 
 .trailing-svg {
   left: calc(100vw + 30rem);
-  top: -50rem;
-  width: 100vw;
+  top: -10rem;
+  width: 70vw;
+  height: auto;
 }
 
 @media (max-width: 887px) {

--- a/src/ui/components/ShapeAcross/stylesheet.css
+++ b/src/ui/components/ShapeAcross/stylesheet.css
@@ -67,19 +67,19 @@
 .trailing-svg {
   position: absolute;
   fill: var(--shape-color);
+  height: auto;
 }
 
 .leading-svg {
   right: calc(80vw + 65rem);
-  bottom: -50rem;
+  bottom: -25rem;
   width: 100vw;
 }
 
 .trailing-svg {
-  left: calc(100vw + 30rem);
+  left: calc(96vw + 30rem);
   top: -10rem;
-  width: 70vw;
-  height: auto;
+  width: 90vw;
 }
 
 @media (max-width: 887px) {
@@ -90,7 +90,13 @@
     margin-top: 0;
   }
 
+  .leading-svg {
+    display: none;
+  }
+
   .trailing-svg {
-    left: calc(100vw + 25rem);
+    left: calc(64vw + 25rem);
+    width: 90vw;
+    top: 0rem;
   }
 }

--- a/src/ui/components/ShapeAcross/template.hbs
+++ b/src/ui/components/ShapeAcross/template.hbs
@@ -4,13 +4,13 @@
       <div class="bottom-clip">
         <img src="{{@src}}" alt="" class="bottom-image" />
       </div>
-      <svg class="bottom-svg" width="3620" height="1240" viewBox="0 0 3620 1240" xmlns="http://www.w3.org/2000/svg">
+      <svg class="bottom-svg" width="362" height="124" viewBox="0 0 362 124" xmlns="http://www.w3.org/2000/svg">
         <defs>
-          <path d="M554.423 0H1800v579.904L1245.577 900H0V320.096L554.423 0z" id="{{this.shapeId}}"></path>
+          <path d="M55.4423 0H180v57.9904L124.5577 90H0V32.0096L55.4423 0z" id="{{this.shapeId}}"></path>
           <mask id="{{this.maskId}}">
             <rect x="0" y="0" width="100%" height="100%" fill="white"></rect>
-            <use x="310" y="330" fill-rule="evenodd" xlink:href="#{{this.shapeId}}" fill="black"></use>
-            <use x="2108" y="10" fill-rule="evenodd" xlink:href="#{{this.shapeId}}" fill="black"></use>
+            <use x="31" y="33" fill-rule="evenodd" xlink:href="#{{this.shapeId}}" fill="black"></use>
+            <use x="210.8" y="1" fill-rule="evenodd" xlink:href="#{{this.shapeId}}" fill="black"></use>
           </mask>
         </defs>
         <rect x="0" y="0" width="100%" height="100%" fill="white" mask="url(#{{this.maskId}})"></rect>
@@ -18,9 +18,9 @@
     </div>
     <svg
       class="leading-svg"
-      width="1800"
-      height="900"
-      viewBox="0 0 1800 900"
+      width="180"
+      height="90"
+      viewBox="0 0 180 90"
       xmlns="http://www.w3.org/2000/svg"
       xmlns:xlink="http://www.w3.org/1999/xlink"
     >
@@ -28,9 +28,9 @@
     </svg>
     <svg
       class="trailing-svg"
-      width="1800"
-      height="900"
-      viewBox="0 0 1800 900"
+      width="180"
+      height="90"
+      viewBox="0 0 180 90"
       xmlns="http://www.w3.org/2000/svg"
       xmlns:xlink="http://www.w3.org/1999/xlink"
     >

--- a/src/ui/components/ShapeDecorative/stylesheet.css
+++ b/src/ui/components/ShapeDecorative/stylesheet.css
@@ -87,10 +87,10 @@
   position: absolute;
   background: var(--shape-color) 90% 100% no-repeat;
   background-size: 123rem auto;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+  top: 1%;
+  left: 1%;
+  width: 98%;
+  height: 98%;
   overflow: hidden;
 }
 


### PR DESCRIPTION
- Use transform for SVG in ArrowLink
- Resize SVG for ShapeAcross
- Add overflow:hidden to ShapeAcross

Closes #622