### PR TITLE
fix domain redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -22,7 +22,7 @@
 
 # redirect old blog subdomain
 [[redirects]]
-  from="https://log.simplabs.com/*"
+  from="https://log.simplabs.com*"
   to="https://simplabs.com/blog/"
 
 # redirect old blog routes
@@ -237,47 +237,47 @@
 # redirect old workshop pages
 
 [[redirects]]
-  from="https://elixir-phoenix-workshop.simplabs.com/*"
+  from="https://elixir-phoenix-workshop.simplabs.com*"
   to="https://simplabs.com/services/tutoring/"
 
 [[redirects]]
-  from="https://elixir-workshops.simplabs.com/*"
+  from="https://elixir-workshops.simplabs.com*"
   to="https://simplabs.com/services/tutoring/"
 
 [[redirects]]
-  from="https://ember-basics-workshop.simplabs.com/*"
+  from="https://ember-basics-workshop.simplabs.com*"
   to="https://simplabs.com/services/tutoring/"
 
 [[redirects]]
-  from="https://ember-pro-workshop.simplabs.com/*"
+  from="https://ember-pro-workshop.simplabs.com*"
   to="https://simplabs.com/services/tutoring/"
 
 [[redirects]]
-  from="https://ember-workshop.simplabs.com/*"
+  from="https://ember-workshop.simplabs.com*"
   to="https://simplabs.com/services/tutoring/"
 
 [[redirects]]
-  from="https://ember-workshops.simplabs.com/*"
+  from="https://ember-workshops.simplabs.com*"
   to="https://simplabs.com/services/tutoring/"
 
 [[redirects]]
-  from="https://phoenix-workshops.simplabs.com/*"
+  from="https://phoenix-workshops.simplabs.com*"
   to="https://simplabs.com/services/tutoring/"
 
 [[redirects]]
-  from="https://progressive-web-apps-workshop.simplabs.com/*"
+  from="https://progressive-web-apps-workshop.simplabs.com*"
   to="https://simplabs.com/services/tutoring/"
 
 [[redirects]]
-  from="https://typescript-fundamentals-workshop.simplabs.com/*"
+  from="https://typescript-fundamentals-workshop.simplabs.com*"
   to="https://simplabs.com/services/tutoring/"
 
 [[redirects]]
-  from="https://web-performance-workshop.simplabs.com/*"
+  from="https://web-performance-workshop.simplabs.com*"
   to="https://simplabs.com/services/tutoring/"
 
 [[redirects]]
-  from="https://phoenix-workshops.simplabs.com/*"
+  from="https://phoenix-workshops.simplabs.com*"
   to="https://simplabs.com/services/tutoring/"
 
 # handle 404 errors


### PR DESCRIPTION
#628 and #629 didn't quite work as expected as the configuration added with them seems to **require** a path after the domain, e.g. `https://log.simplabs.com/path` redirects to `https://simplabs.com/blog/` correctly while `https://log.simplabs.com` (with no path) doesn't. As there's no way to really test this (or at least I'm not aware of one), I'm **assuming** this fixes it.

closes #616 
closes #617 