### PR TITLE
show white background for mobile menu trigger

### DIFF
--- a/lib/global-css/css/menu.css
+++ b/lib/global-css/css/menu.css
@@ -40,5 +40,6 @@
 
   #toggle:checked + [data-menu] label[for='toggle'] {
     --color: var(--color-text-inverted);
+    --color-background: var(--color-accent);
   }
 }

--- a/src/ui/components/Header/stylesheet.css
+++ b/src/ui/components/Header/stylesheet.css
@@ -81,10 +81,13 @@
   padding: 0;
   cursor: pointer;
   border: 2px solid var(--color);
+  outline: 1rem solid var(--color-background);
+  background: var(--color-background);
   border-width: 2px 0;
   overflow: hidden;
   text-indent: 999rem;
   white-space: nowrap;
+  transition: all 0.275s;
 }
 
 .toggler:after {
@@ -96,6 +99,7 @@
   background: var(--color);
   content: '';
   transform: translate(0, -1px);
+  transition: all 0.275s;
 }
 
 .nav {


### PR DESCRIPTION
This adds a white background to the mobile menu trigger so that it correctly shows even if displayed above an element that has the button's primary color.

closes #620 