### PR TITLE
assert presence of break marker in blog posts

### DIFF
--- a/lib/generate-blog/lib/components-builder.js
+++ b/lib/generate-blog/lib/components-builder.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const assert = require('assert');
+
 const dateformat = require('dateformat');
 const marked = require('marked');
 const _ = require('lodash');
@@ -10,6 +12,8 @@ const htmlizeMarkdown = require('../../markdown-content/htmlize-markdown');
 const BaseComponentsBuilder = require('../../component-generation/base-components-builder');
 
 const Renderer = new marked.Renderer();
+
+const BREAK_MARKER = '<!--break-->';
 
 Renderer.code = function(code, language) {
   let highlighted = code;
@@ -115,6 +119,11 @@ module.exports = class ComponentsBuilder extends BaseComponentsBuilder {
   }
 
   _preparePostTemplateData(post) {
+    assert(
+      post.content.includes(BREAK_MARKER),
+      `Post "${post.meta.title}" does not contain break marker! Add "${BREAK_MARKER}" after the teaser.`,
+    );
+
     return {
       title: post.meta.title,
       excerpt: htmlizeExcerpt(post.content),
@@ -177,5 +186,5 @@ function htmlizeExcerpt(content) {
 }
 
 function splitPostContent(content) {
-  return content.split('<!--break-->');
+  return content.split(BREAK_MARKER);
 }


### PR DESCRIPTION
This asserts the presence of the break marker (`<!--break-->`) that separates the teaser from the main content in blog posts so we show a better error message if it is missing.

closes #632 