### PR TITLE
Set labels for travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,18 +31,25 @@ install:
 jobs:
   include:
     - stage: test
+      name: Tests
       script: yarn test
     - stage: test
+      name: "Lint - TypeScript"
       script: yarn lint:ts
     - stage: test
+      name: "Lint - JavaScript"
       script: yarn lint:js
     - stage: test
+      name: "Lint - Handlebars"
       script: yarn lint:hbs
     - stage: test
+      name: "Lint - CSS"
       script: yarn lint:css
     - stage: test
+      name: "Crawler"
       script: yarn build && yarn crawl
     - stage: test
+      name: "Percy"
       script: yarn build && yarn percy
 
 notifications:


### PR DESCRIPTION
This sets labels for the Travis CI jobs for an easier overview of what succeeded/failed on CI.