### PR TITLE
Use found element instead of event target when handling internal links

### DIFF
--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -144,7 +144,7 @@ export default class Simplabs extends Component {
 
           if (link && link.dataset.internal !== undefined) {
             event.preventDefault();
-            this.router.navigate(target.getAttribute('href'));
+            this.router.navigate(link.getAttribute('href'));
           }
         }
       });


### PR DESCRIPTION
This fixes the navigation for linked images in blog posts, see #639.