### PR TITLE
prevent replacement of `app.js` and `app.css` with fingerprinted filenames

### DIFF
--- a/lib/markdown-content/htmlize-markdown.js
+++ b/lib/markdown-content/htmlize-markdown.js
@@ -5,6 +5,7 @@ const marked = require('marked');
 const jsdom = require('jsdom');
 
 module.exports = function htmlizeMarkdown(source, options = {}, callback = null) {
+  source = preventBundleFingerprintReplacement(source);
   let html = marked(source, options);
   html = manipulateDom(html, dom => {
     dom.querySelectorAll('a').forEach(a => {
@@ -26,4 +27,15 @@ function manipulateDom(html, callback) {
   let dom = new jsdom.JSDOM(html);
   callback(dom.window.document);
   return dom.window.document.body.innerHTML;
+}
+
+// During a production build, references to app.js and app.css will be replaced
+// with their fingerprinted versions in the entire website. Of course we do not
+// actually want mentions of these filenames in blog posts to be replaced so
+// we're replacing any mentions of these files with a version that includes a
+// non-visible whitespace so they won't match the regex that
+// broccoli-asset-rewrite uses but will still look correct to the reader. See
+// https://github.com/simplabs/simplabs.github.io/issues/630 for reference.
+function preventBundleFingerprintReplacement(source) {
+  return source.replace(/app\.js/g, 'app\u200b.js').replace(/app\.css/g, 'app\u200b.css');
 }


### PR DESCRIPTION
The fingerprint replacement also replaces all occurences of `app.js` and `app.css` in the blog posts. That's not what we want of course as it

* makes the content harder to read
* means that **every** deployment will also change the blog bundle even if no new blog post released - that will invalidate the bundle if everyone's caches as well

As I'm not aware of a better solution, I'm simplabs inserting a non-visible whitespace into occurences of the respective file names so that e.g. `app.js` becomes `app<non-visible whitespace>.js` which should prevent the replacing. As nobody is likely to copy/paste these file names anyway that should be a good-enough solution.

closes #630 