### PR TITLE
remove keywords meta tag

### DIFF
--- a/lib/head-data/index.js
+++ b/lib/head-data/index.js
@@ -10,7 +10,6 @@ module.exports = {
   contentFor(type) {
     if (type === 'head') {
       return `
-        <meta name="keywords" content="ember, elixir, consulting, web apps, progressive web apps, software engineering, rest apis, software architecture, software design, training, ui, ux" />
         <meta name="language" content="en" />
         <meta name="content-language" content="en" />
         <meta name="publisher" content="simplabs GmbH" />


### PR DESCRIPTION
The `keywords` meta tag is no longer needed for SEO and since we're using the same keywords for every page here they potentially have a negative impact even as the won't fit the actual content of each page.

closes #649 