### PR TITLE
trigger deployment from travis cron build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,9 @@ jobs:
     - stage: test
       name: "Percy"
       script: yarn build && yarn percy
+    - stage: deploy
+      name: "Trigger deployment"
+      script: "[ \"$TRAVIS_EVENT_TYPE\" = cron ] && curl -X POST -d {} $NETLIFY_WEBHOOK"
 
 notifications:
   email: false


### PR DESCRIPTION
We need to redeploy our website every days as at build time we will decide which contents does get included or does not get included (e.g. when [building the calendar](https://github.com/simplabs/simplabs.github.io/blob/master/lib/generate-calendar/lib/components-builder.js#L14)). We don't currently do that though and there is no way to do it with Netlify directly. Netlify does support webhooks though which we can call to trigger a deployment (which should only happen when the build was triggered by cron as whenever we merge into `master`, Netlify will redeploy anyway).

This PR adds just that to the `.travis.yml`.

For context

* `TRAVIS_EVENT_TYPE` will have a value of `cron` for cron build
* `NETLIFY_WEBHOOK` is defined as an env var for travis and contains the webhook URL which we need to keep secret as otherwise **anyone** could trigger redeploys of the page