### PR TITLE
Better handling of title tag and related meta tags

### DIFF
--- a/config/routes-map.js
+++ b/config/routes-map.js
@@ -8,7 +8,6 @@ module.exports = function() {
   let blogPostRoutes = posts.reduce((acc, post) => {
     acc[`/blog/${post.queryPath}`] = {
       component: post.componentName,
-      title: `${post.meta.title} | Blog`,
       bundle: {
         asset: `/blog/${post.queryPath}.js`,
         module: `__blog-${post.queryPath}__`,
@@ -23,7 +22,6 @@ module.exports = function() {
   let blogAuthorsRoutes = authors.reduce((acc, author) => {
     acc[`/blog/author/${author.twitter}`] = {
       component: author.componentName,
-      title: `Posts by ${author.name} | Blog`,
       bundle: {
         asset: `/blog/author-${author.twitter}.js`,
         module: `__blog-author-${author.twitter}__`,
@@ -39,46 +37,41 @@ module.exports = function() {
     ...blogPostRoutes,
     ...blogAuthorsRoutes,
     '/': { component: 'PageHomepage' },
-    '/404': { component: 'Page404', title: 'Not found' },
-    '/blog': { component: 'PageBlog', title: 'Blog', bundle: { asset: '/blog.js', module: '__blog__' } },
+    '/404': { component: 'Page404' },
+    '/blog': { component: 'PageBlog', bundle: { asset: '/blog.js', module: '__blog__' } },
     '/calendar': {
       component: 'PageCalendar',
-      title: 'Calendar',
       bundle: { asset: '/calendar.js', module: '__calendar__' },
     },
-    '/cases/ddwrt': { component: 'PageCaseDdWrt', title: 'DD-WRT NXT | Work' },
-    '/cases/expedition': { component: 'PageCaseStudyExpedition', title: 'Expedition | Work' },
-    '/cases/timify': { component: 'PageCaseStudyTimify', title: 'Timify | Work' },
-    '/cases/trainline': { component: 'PageCaseStudyTrainline', title: 'Trainline | Work' },
-    '/contact': { component: 'PageContact', title: 'Contact' },
-    '/expertise/ember': { component: 'PageEmberExpertise', title: 'Europe’s leading Ember experts' },
-    '/expertise/elixir-phoenix': { component: 'PageElixirExpertise', title: 'Elixir & Phoenix' },
+    '/cases/ddwrt': { component: 'PageCaseDdWrt' },
+    '/cases/expedition': { component: 'PageCaseStudyExpedition' },
+    '/cases/timify': { component: 'PageCaseStudyTimify' },
+    '/cases/trainline': { component: 'PageCaseStudyTrainline' },
+    '/contact': { component: 'PageContact' },
+    '/expertise/ember': { component: 'PageEmberExpertise' },
+    '/expertise/elixir-phoenix': { component: 'PageElixirExpertise' },
     '/imprint': {
       component: 'PageLegalImprint',
-      title: 'Imprint',
       bundle: { asset: '/legal.js', module: '__legal__' },
     },
     '/playbook': {
       component: 'PagePlaybook',
-      title: 'Playbook',
       bundle: { asset: '/playbook.js', module: '__playbook__' },
     },
     '/privacy': {
       component: 'PageLegalPrivacy',
-      title: 'Privacy Policy',
       bundle: { asset: '/legal.js', module: '__legal__' },
     },
-    '/services': { component: 'PageServices', title: 'Services' },
+    '/services': { component: 'PageServices' },
     '/services/full-stack-engineering': {
       component: 'PageFullStackEngineering',
-      title: 'Full Stack Engineering | Services',
     },
-    '/services/team-augmentation': { component: 'PageTeamAugmentation', title: 'Team Augmentation | Services' },
-    '/services/tutoring': { component: 'PageTutoring', title: 'Tutoring | Services' },
-    '/talks': { component: 'PageTalks', title: 'Talks', bundle: { asset: '/talks.js', module: '__talks__' } },
-    '/why-simplabs': { component: 'PageWhySimplabs', title: 'Why simplabs' },
-    '/work': { component: 'PageWork', title: 'Work' },
-    '/webinars/modern-web': { component: 'PageLandingPwaWebinar', title: 'Webinar: Modern Web Applications' },
+    '/services/team-augmentation': { component: 'PageTeamAugmentation' },
+    '/services/tutoring': { component: 'PageTutoring' },
+    '/talks': { component: 'PageTalks', bundle: { asset: '/talks.js', module: '__talks__' } },
+    '/why-simplabs': { component: 'PageWhySimplabs' },
+    '/work': { component: 'PageWork' },
+    '/webinars/modern-web': { component: 'PageLandingPwaWebinar' },
   };
 
   return routes;

--- a/lib/generate-blog/lib/templates/author/template.hbs
+++ b/lib/generate-blog/lib/templates/author/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @active="blog" @flex-content="true">
+  <Header @active="blog" @flex-content="true" @title="Posts by {{name}}" @pageTitle="Posts by {{name}} | Blog">
     <div class="blog-post.badge">
       <div class="blog-post.badge-image">
         <img class="fluid-image.image" src="/assets/images/authors/{{twitter}}.jpg" alt="photo of {{name}}" />

--- a/lib/generate-blog/lib/templates/author/template.hbs
+++ b/lib/generate-blog/lib/templates/author/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @active="blog" @flex-content="true" @title="Posts by {{name}}" @pageTitle="Posts by {{name}} | Blog">
+  <Header @active="blog" @flex-content="true" @title="Posts by {{name}}" @documentTitle="Posts by {{name}} | Blog">
     <div class="blog-post.badge">
       <div class="blog-post.badge-image">
         <img class="fluid-image.image" src="/assets/images/authors/{{twitter}}.jpg" alt="photo of {{name}}" />

--- a/lib/generate-blog/lib/templates/post/template.hbs
+++ b/lib/generate-blog/lib/templates/post/template.hbs
@@ -64,7 +64,7 @@
     "@context": "http://schema.org"
   }
   </script>
-  <Header @active="blog" @flex-content="true">
+  <Header @active="blog" @flex-content="true" @title="{{title}}" @pageTitle="{{title}} | Blog">
     <div class="blog-post.badge">
       <div class="blog-post.badge-image">
         <img

--- a/lib/generate-blog/lib/templates/post/template.hbs
+++ b/lib/generate-blog/lib/templates/post/template.hbs
@@ -64,7 +64,7 @@
     "@context": "http://schema.org"
   }
   </script>
-  <Header @active="blog" @flex-content="true" @title="{{title}}" @pageTitle="{{title}} | Blog">
+  <Header @active="blog" @flex-content="true" @title="{{title}}" @documentTitle="{{title}} | Blog">
     <div class="blog-post.badge">
       <div class="blog-post.badge-image">
         <img

--- a/lib/generate-blog/lib/templates/start-page/template.hbs
+++ b/lib/generate-blog/lib/templates/start-page/template.hbs
@@ -28,7 +28,7 @@
     "@context": "http://schema.org"
   }
   </script>
-  <Header @active="blog" @title="Blog" />
+  <Header @active="blog" @headline="Blog" @title="Blog" />
   <ShapeBlog>
     <article>
       <span class="typography.tag">

--- a/lib/generate-calendar/lib/templates/page/template.hbs
+++ b/lib/generate-calendar/lib/templates/page/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @title="Calendar">
+  <Header @headline="Calendar" @title="Calendar">
     <p class="typography.lead">
       Find out about upcoming events, conferences and meetups we will be attending or organizing.
     </p>

--- a/lib/generate-talks-archive/lib/templates/page/template.hbs
+++ b/lib/generate-talks-archive/lib/templates/page/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @title="Talks">
+  <Header @headline="Talks" @title="Talks">
     <p class="typography.lead">
       We strongly believe in the value of sharing our expertise and experience with others. Here are a collection of talks that members of our team have given at various conferences all over the world in the past years.
     </p>

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ app.registerInitializer({
       }
 
     // tslint:disable-next-line:max-classes-per-file
-    class create {
+    class AppState {
 
       public static create() {
         return new AppState();

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ app.registerInitializer({
       }
 
     // tslint:disable-next-line:max-classes-per-file
-    class AppState {
+    class create {
 
       public static create() {
         return new AppState();

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,15 @@ function register(registry, key: string, object: any) {
   }
 }
 
+function readRoutesMap() {
+  let script: HTMLElement | null = document.querySelector('[data-shoebox-routes]');
+  if (script) {
+    return JSON.parse(script.innerText);
+  } else {
+    return {};
+  }
+}
+
 app.registerInitializer({
   initialize(registry) {
     function registerBundle(module) {
@@ -36,6 +45,25 @@ app.registerInitializer({
 
       public registerBundle(module) {
         registerBundle(module);
+      }
+
+    // tslint:disable-next-line:max-classes-per-file
+    class AppState {
+
+      public static create() {
+        return new AppState();
+      }
+
+      public isSSR: boolean;
+      public route: string;
+      public origin: string;
+      public routesMap: IRoutesMap;
+
+      constructor() {
+        this.isSSR = false;
+        this.route = window.location.pathname;
+        this.origin = window.location.origin;
+        this.routesMap = readRoutesMap();
       }
     }
 
@@ -64,6 +92,16 @@ app.registerInitializer({
       `component`,
       'headTags',
       `utils:/${app.appName}/head-tags/main`,
+    );
+
+    registry.register(
+      `app-state:/${app.appName}/main/main`,
+      AppState
+    );
+    registry.registerInjection(
+      `component`,
+      'appState',
+      `app-state:/${app.appName}/main/main`
     );
   }
 });

--- a/src/ui/components/HeadTag/component.ts
+++ b/src/ui/components/HeadTag/component.ts
@@ -1,10 +1,19 @@
 import Component from '@glimmer/component';
 
 export default class HeadTag extends Component {
+  private appState: IAppState;
+
   constructor(options) {
     super(options);
 
-    this.setMetaTags();
+    if (this.appState.isSSR) {
+      this.setMetaTags();
+    } else {
+      // when changing routes, the willDestroy of a component previously in the DOM
+      // will be called *after* the constructor of one rendered *after* the route
+      // change, so we have to delay writing the tag…
+      window.setTimeout(() => this.setMetaTags());
+    }
   }
 
   public willDestroy() {

--- a/src/ui/components/Header/component.ts
+++ b/src/ui/components/Header/component.ts
@@ -4,11 +4,11 @@ export default class Header extends Component {
   constructor(options) {
     super(options);
 
-    let pageTitle = this.args.pageTitle === undefined ? this.args.title : this.args.pageTitle;
-    this.pageTitle = formatPageTitle(pageTitle);
+    let documentTitle = this.args.documentTitle === undefined ? this.args.title : this.args.documentTitle;
+    this.documentTitle = formatformatDocumentTitle(documentTitle);
   }
 }
 
-function formatPageTitle(title) {
+function formatformatDocumentTitle(title) {
   return `${title ? `${title} | ` : ''}simplabs`;
 }

--- a/src/ui/components/Header/component.ts
+++ b/src/ui/components/Header/component.ts
@@ -1,0 +1,14 @@
+import Component from '@glimmer/component';
+
+export default class Header extends Component {
+  constructor(options) {
+    super(options);
+
+    let pageTitle = this.args.pageTitle === undefined ? this.args.title : this.args.pageTitle;
+    this.pageTitle = formatPageTitle(pageTitle);
+  }
+}
+
+function formatPageTitle(title) {
+  return `${title ? `${title} | ` : ''}simplabs`;
+}

--- a/src/ui/components/Header/template.hbs
+++ b/src/ui/components/Header/template.hbs
@@ -48,14 +48,14 @@
     </div>
   </div>
   <div class="content" state:flex-content={{@flex-content}}>
-    {{#if @title}}
+    {{#if @headline}}
       <h1 class="typography.display">
         {{#if @label}}
           <small class="typography.small">
             {{@label}}<span class="typography.hidden">:</span>
           </small>
         {{/if}}
-        {{@title}}
+        {{@headline}}
       </h1>
     {{/if}}
     {{yield}}

--- a/src/ui/components/Header/template.hbs
+++ b/src/ui/components/Header/template.hbs
@@ -1,4 +1,6 @@
 <header>
+  <HeadTag @name="title" @content={{this.pageTitle}} />
+  <HeadTag @name="meta" @keys={{hash property="og:title" name="twitter:title"}} @values={{hash content=@title}} />
   <input id="toggle" type="checkbox" hidden="true" />
   <div class="navbar" data-menu>
     <div class="wrapper">

--- a/src/ui/components/Header/template.hbs
+++ b/src/ui/components/Header/template.hbs
@@ -1,5 +1,5 @@
 <header>
-  <HeadTag @name="title" @content={{this.pageTitle}} />
+  <HeadTag @name="title" @content={{this.documentTitle}} />
   <HeadTag @name="meta" @keys={{hash property="og:title" name="twitter:title"}} @values={{hash content=@title}} />
   <input id="toggle" type="checkbox" hidden="true" />
   <div class="navbar" data-menu>

--- a/src/ui/components/Page404/template.hbs
+++ b/src/ui/components/Page404/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header>
+  <Header @title="Not found">
     <div class="block">
       <h1 class="typography.display headline">
         We can't find the page you are looking for.

--- a/src/ui/components/PageCaseDdWrt/template.hbs
+++ b/src/ui/components/PageCaseDdWrt/template.hbs
@@ -1,5 +1,12 @@
 <div>
-  <Header @active="work" @label="embeDD Case Study" @headline="A modern UI for an open-source router firmware" />
+  <Header
+    @active="work"
+    @label="DD-WRT NXT Case Study"
+    @headline="A modern UI for an open-source router firmware"
+    @title="DD-WRT NXT Case Study"
+    @pageTitle="DD-WRT NXT Case Study | Work"
+   />
+
   <div class="layout.main offset.after-21">
     <p class="typography.lead">
       DD-WRT is a Linux based firmware for wireless routers. Originally designed for the Linksys WRT54G series, it now runs on a wide variety of models and is installed on millions of devices worldwide.

--- a/src/ui/components/PageCaseDdWrt/template.hbs
+++ b/src/ui/components/PageCaseDdWrt/template.hbs
@@ -4,7 +4,7 @@
     @label="DD-WRT NXT Case Study"
     @headline="A modern UI for an open-source router firmware"
     @title="DD-WRT NXT Case Study"
-    @pageTitle="DD-WRT NXT Case Study | Work"
+    @documentTitle="DD-WRT NXT Case Study | Work"
    />
 
   <div class="layout.main offset.after-21">

--- a/src/ui/components/PageCaseDdWrt/template.hbs
+++ b/src/ui/components/PageCaseDdWrt/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @active="work" @label="embeDD Case Study" @title="A modern UI for an open-source router firmware" />
+  <Header @active="work" @label="embeDD Case Study" @headline="A modern UI for an open-source router firmware" />
   <div class="layout.main offset.after-21">
     <p class="typography.lead">
       DD-WRT is a Linux based firmware for wireless routers. Originally designed for the Linksys WRT54G series, it now runs on a wide variety of models and is installed on millions of devices worldwide.

--- a/src/ui/components/PageCaseStudyExpedition/template.hbs
+++ b/src/ui/components/PageCaseStudyExpedition/template.hbs
@@ -4,7 +4,7 @@
     @label="Expedition Case Study"
     @headline="An online travel magazine for global citizens"
     @title="Expedition Case Study"
-    @pageTitle="Expedition Case Study | Work"
+    @documentTitle="Expedition Case Study | Work"
    />
 
   <div class="layout.main offset.after-21">

--- a/src/ui/components/PageCaseStudyExpedition/template.hbs
+++ b/src/ui/components/PageCaseStudyExpedition/template.hbs
@@ -1,5 +1,12 @@
 <div>
-  <Header @active="work" @label="Expedition Case Study" @headline="An online travel magazine for global citizens" />
+  <Header
+    @active="work"
+    @label="Expedition Case Study"
+    @headline="An online travel magazine for global citizens"
+    @title="Expedition Case Study"
+    @pageTitle="Expedition Case Study | Work"
+   />
+
   <div class="layout.main offset.after-21">
     <p class="typography.lead">
       Expedition approached simplabs when they needed help laying the foundation for advanced features in their Elixir and Phoenix based API as well as making sure their Ember.js based client was following best practices.

--- a/src/ui/components/PageCaseStudyExpedition/template.hbs
+++ b/src/ui/components/PageCaseStudyExpedition/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @active="work" @label="Expedition Case Study" @title="An online travel magazine for global citizens" />
+  <Header @active="work" @label="Expedition Case Study" @headline="An online travel magazine for global citizens" />
   <div class="layout.main offset.after-21">
     <p class="typography.lead">
       Expedition approached simplabs when they needed help laying the foundation for advanced features in their Elixir and Phoenix based API as well as making sure their Ember.js based client was following best practices.

--- a/src/ui/components/PageCaseStudyTimify/template.hbs
+++ b/src/ui/components/PageCaseStudyTimify/template.hbs
@@ -4,7 +4,7 @@
     @label="Timify Case Study"
     @headline="Modern online appointment scheduling"
     @title="Timify Case Study"
-    @pageTitle="Timify Case Study | Work"
+    @documentTitle="Timify Case Study | Work"
    />
 
   <div class="layout.main">

--- a/src/ui/components/PageCaseStudyTimify/template.hbs
+++ b/src/ui/components/PageCaseStudyTimify/template.hbs
@@ -1,5 +1,12 @@
 <div>
-  <Header @active="work" @label="Timify Case Study" @headline="Modern online appointment scheduling" />
+  <Header
+    @active="work"
+    @label="Timify Case Study"
+    @headline="Modern online appointment scheduling"
+    @title="Timify Case Study"
+    @pageTitle="Timify Case Study | Work"
+   />
+
   <div class="layout.main">
     <p class="typography.lead">
       Timify is an online appointment scheduling service that connects service providers with clients.

--- a/src/ui/components/PageCaseStudyTimify/template.hbs
+++ b/src/ui/components/PageCaseStudyTimify/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @active="work" @label="Timify Case Study" @title="Modern online appointment scheduling" />
+  <Header @active="work" @label="Timify Case Study" @headline="Modern online appointment scheduling" />
   <div class="layout.main">
     <p class="typography.lead">
       Timify is an online appointment scheduling service that connects service providers with clients.

--- a/src/ui/components/PageCaseStudyTrainline/template.hbs
+++ b/src/ui/components/PageCaseStudyTrainline/template.hbs
@@ -4,7 +4,7 @@
     @label="Trainline Case Study"
     @headline="A mobile train ticket counter"
     @title="Trainline Case Study"
-    @pageTitle="Trainline Case Study | Work"
+    @documentTitle="Trainline Case Study | Work"
    />
 
   <div class="layout.main">

--- a/src/ui/components/PageCaseStudyTrainline/template.hbs
+++ b/src/ui/components/PageCaseStudyTrainline/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @active="work" @label="Trainline Case Study" @title="A mobile train ticket counter" />
+  <Header @active="work" @label="Trainline Case Study" @headline="A mobile train ticket counter" />
   <div class="layout.main">
     <p class="typography.lead">
       simplabs worked closely with Trainline’s in-house engineering team and built a mobile web app to accompany the existing desktop app. A dedicated site for mobile devices allowed Trainline to better serve customers on the go and leverage the full market potential.

--- a/src/ui/components/PageCaseStudyTrainline/template.hbs
+++ b/src/ui/components/PageCaseStudyTrainline/template.hbs
@@ -1,5 +1,12 @@
 <div>
-  <Header @active="work" @label="Trainline Case Study" @headline="A mobile train ticket counter" />
+  <Header
+    @active="work"
+    @label="Trainline Case Study"
+    @headline="A mobile train ticket counter"
+    @title="Trainline Case Study"
+    @pageTitle="Trainline Case Study | Work"
+   />
+
   <div class="layout.main">
     <p class="typography.lead">
       simplabs worked closely with Trainline’s in-house engineering team and built a mobile web app to accompany the existing desktop app. A dedicated site for mobile devices allowed Trainline to better serve customers on the go and leverage the full market potential.

--- a/src/ui/components/PageContact/template.hbs
+++ b/src/ui/components/PageContact/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @active="contact" @headline="Contact Us" />
+  <Header @active="contact" @headline="Contact Us" @title="Contact" />
   <div class="layout.main offset.after-21">
     <p class="typography.lead offset.after-12">
       Whatever you're planning, we'd be excited to hear more. We can turn your ideas into successful digital products, improve existing ones or increase your team's effectiveness.

--- a/src/ui/components/PageContact/template.hbs
+++ b/src/ui/components/PageContact/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @active="contact" @title="Contact Us" />
+  <Header @active="contact" @headline="Contact Us" />
   <div class="layout.main offset.after-21">
     <p class="typography.lead offset.after-12">
       Whatever you're planning, we'd be excited to hear more. We can turn your ideas into successful digital products, improve existing ones or increase your team's effectiveness.

--- a/src/ui/components/PageElixirExpertise/template.hbs
+++ b/src/ui/components/PageElixirExpertise/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @title="The best of all worlds">
+  <Header @headline="The best of all worlds">
     <p class="typography.lead">
       Elixir combines the expressiveness and simplicity of Ruby with the performance and stability of the Erlang VM. Phoenix builds on the concepts first introduced by Ruby on Rails, combining them with a number of architectural improvements to take the architecture into the future.
     </p>

--- a/src/ui/components/PageElixirExpertise/template.hbs
+++ b/src/ui/components/PageElixirExpertise/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @headline="The best of all worlds">
+  <Header @headline="The best of all worlds" @title="Elixir & Phoenix">
     <p class="typography.lead">
       Elixir combines the expressiveness and simplicity of Ruby with the performance and stability of the Erlang VM. Phoenix builds on the concepts first introduced by Ruby on Rails, combining them with a number of architectural improvements to take the architecture into the future.
     </p>

--- a/src/ui/components/PageEmberExpertise/template.hbs
+++ b/src/ui/components/PageEmberExpertise/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @headline="Europe's leading Ember experts">
+  <Header @headline="Europe's leading Ember experts" @title="Europe's leading Ember experts">
     <p class="typography.lead">
       simplabs has unique expertise and insights into Ember.js with a good part of our engineering team being on the Ember.js core team and maintaining widely adopted add-ons.
     </p>

--- a/src/ui/components/PageEmberExpertise/template.hbs
+++ b/src/ui/components/PageEmberExpertise/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @title="Europe's leading Ember experts">
+  <Header @headline="Europe's leading Ember experts">
     <p class="typography.lead">
       simplabs has unique expertise and insights into Ember.js with a good part of our engineering team being on the Ember.js core team and maintaining widely adopted add-ons.
     </p>

--- a/src/ui/components/PageFullStackEngineering/template.hbs
+++ b/src/ui/components/PageFullStackEngineering/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @active="services" @label="Services" @title="Full-Stack Engineering" />
+  <Header @active="services" @label="Services" @headline="Full-Stack Engineering" />
   <div class="layout.main offset.after-21">
     <h2>
       Ambitious software solutions – From Idea to Release

--- a/src/ui/components/PageFullStackEngineering/template.hbs
+++ b/src/ui/components/PageFullStackEngineering/template.hbs
@@ -1,5 +1,12 @@
 <div>
-  <Header @active="services" @label="Services" @headline="Full-Stack Engineering" />
+  <Header
+    @active="services"
+    @label="Services"
+    @headline="Full-Stack Engineering"
+    @title="Full-Stack Engineering"
+    @pageTitle="Full-Stack Engineering | Services"
+   />
+
   <div class="layout.main offset.after-21">
     <h2>
       Ambitious software solutions – From Idea to Release

--- a/src/ui/components/PageFullStackEngineering/template.hbs
+++ b/src/ui/components/PageFullStackEngineering/template.hbs
@@ -4,7 +4,7 @@
     @label="Services"
     @headline="Full-Stack Engineering"
     @title="Full-Stack Engineering"
-    @pageTitle="Full-Stack Engineering | Services"
+    @documentTitle="Full-Stack Engineering | Services"
    />
 
   <div class="layout.main offset.after-21">

--- a/src/ui/components/PageHomepage/template.hbs
+++ b/src/ui/components/PageHomepage/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @headline="Solid Solutions for Ambitious Projects" @title="simplabs" @pageTitle="">
+  <Header @headline="Solid Solutions for Ambitious Projects" @title="simplabs" @documentTitle="">
     <p class="typography.lead">
       We deliver ambitious digital products on the web and mobile for our clients to rely on. Our expert team manages projects from idea to release, covering strategy, design and engineering.
     </p>

--- a/src/ui/components/PageHomepage/template.hbs
+++ b/src/ui/components/PageHomepage/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @headline="Solid Solutions for Ambitious Projects">
+  <Header @headline="Solid Solutions for Ambitious Projects" @title="simplabs" @pageTitle="">
     <p class="typography.lead">
       We deliver ambitious digital products on the web and mobile for our clients to rely on. Our expert team manages projects from idea to release, covering strategy, design and engineering.
     </p>

--- a/src/ui/components/PageHomepage/template.hbs
+++ b/src/ui/components/PageHomepage/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @title="Solid Solutions for Ambitious Projects">
+  <Header @headline="Solid Solutions for Ambitious Projects">
     <p class="typography.lead">
       We deliver ambitious digital products on the web and mobile for our clients to rely on. Our expert team manages projects from idea to release, covering strategy, design and engineering.
     </p>

--- a/src/ui/components/PageLandingPwaWebinar/template.hbs
+++ b/src/ui/components/PageLandingPwaWebinar/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @title="The ultimate marketers guide to modern web apps and why users are demanding more">
+  <Header @headline="The ultimate marketers guide to modern web apps and why users are demanding more">
     <p class="typography.lead">
       Want to know how forward looking marketing departments are taking advantage of modern web apps to capture new demand with incredible online experiences?
     </p>

--- a/src/ui/components/PageLandingPwaWebinar/template.hbs
+++ b/src/ui/components/PageLandingPwaWebinar/template.hbs
@@ -1,5 +1,8 @@
 <div>
-  <Header @headline="The ultimate marketers guide to modern web apps and why users are demanding more">
+  <Header
+    @headline="The ultimate marketers guide to modern web apps and why users are demanding more"
+    @title="Webinar: the ultimate marketers guide to modern web apps"
+  >
     <p class="typography.lead">
       Want to know how forward looking marketing departments are taking advantage of modern web apps to capture new demand with incredible online experiences?
     </p>

--- a/src/ui/components/PageLegalImprint/template.hbs
+++ b/src/ui/components/PageLegalImprint/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @label="Legal Info" @title="Imprint" />
+  <Header @label="Legal Info" @headline="Imprint" />
   <div class="layout.full offset.after-21">
     <h2>
       Publisher information according to §6 Teledienstgesetz (TDG)

--- a/src/ui/components/PageLegalImprint/template.hbs
+++ b/src/ui/components/PageLegalImprint/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @label="Legal Info" @headline="Imprint" />
+  <Header @label="Legal Info" @headline="Imprint" @title="Imprint" />
   <div class="layout.full offset.after-21">
     <h2>
       Publisher information according to §6 Teledienstgesetz (TDG)

--- a/src/ui/components/PageLegalPrivacy/template.hbs
+++ b/src/ui/components/PageLegalPrivacy/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @label="Legal Info" @title="Privacy Policy" />
+  <Header @label="Legal Info" @headline="Privacy Policy" />
   <div class="layout.full offset.after-21">
     <p>
       We are very delighted that you have shown interest in our enterprise. Data protection is of a particularly high priority for the management of the simplabs GmbH. The use of the Internet pages of the simplabs GmbH is possible without any indication of personal data; however, if a data subject wants to use special enterprise services via our website, processing of personal data could become necessary. If the processing of personal data is necessary and there is no statutory basis for such processing, we generally obtain consent from the data subject.

--- a/src/ui/components/PageLegalPrivacy/template.hbs
+++ b/src/ui/components/PageLegalPrivacy/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @label="Legal Info" @headline="Privacy Policy" />
+  <Header @label="Legal Info" @headline="Privacy Policy" @title="Privacy Policy" />
   <div class="layout.full offset.after-21">
     <p>
       We are very delighted that you have shown interest in our enterprise. Data protection is of a particularly high priority for the management of the simplabs GmbH. The use of the Internet pages of the simplabs GmbH is possible without any indication of personal data; however, if a data subject wants to use special enterprise services via our website, processing of personal data could become necessary. If the processing of personal data is necessary and there is no statutory basis for such processing, we generally obtain consent from the data subject.

--- a/src/ui/components/PagePlaybook/template.hbs
+++ b/src/ui/components/PagePlaybook/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @title="Playbook">
+  <Header @headline="Playbook">
     <p class="typography.lead">
       We maintain a lean process that supports the team rather than stand in its way. It ensures the right tasks are being worked on at the right time and provides a reasonable level of short term predictability. At the same time it remains flexible enough to adapt to unexpected events. Our process does not depend on specific tools and works for projects and teams in all environments.
     </p>

--- a/src/ui/components/PagePlaybook/template.hbs
+++ b/src/ui/components/PagePlaybook/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @headline="Playbook">
+  <Header @headline="Playbook" @title="Playbook">
     <p class="typography.lead">
       We maintain a lean process that supports the team rather than stand in its way. It ensures the right tasks are being worked on at the right time and provides a reasonable level of short term predictability. At the same time it remains flexible enough to adapt to unexpected events. Our process does not depend on specific tools and works for projects and teams in all environments.
     </p>

--- a/src/ui/components/PageServices/template.hbs
+++ b/src/ui/components/PageServices/template.hbs
@@ -2,7 +2,7 @@
   <Header
     @active="services"
     @label="Services"
-    @title="We turn ideas into products and help tech teams move faster with confidence"
+    @headline="We turn ideas into products and help tech teams move faster with confidence"
    />
 
   <section class="layout.main offset.after-21">

--- a/src/ui/components/PageServices/template.hbs
+++ b/src/ui/components/PageServices/template.hbs
@@ -3,6 +3,7 @@
     @active="services"
     @label="Services"
     @headline="We turn ideas into products and help tech teams move faster with confidence"
+    @title="Services"
    />
 
   <section class="layout.main offset.after-21">

--- a/src/ui/components/PageTeamAugmentation/template.hbs
+++ b/src/ui/components/PageTeamAugmentation/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @active="services" @label="Services" @title="Team Augmentation" />
+  <Header @active="services" @label="Services" @headline="Team Augmentation" />
   <div class="layout.main offset.after-21">
     <h2>
       Bring in the experts when you need them

--- a/src/ui/components/PageTeamAugmentation/template.hbs
+++ b/src/ui/components/PageTeamAugmentation/template.hbs
@@ -1,5 +1,12 @@
 <div>
-  <Header @active="services" @label="Services" @headline="Team Augmentation" />
+  <Header
+    @active="services"
+    @label="Services"
+    @headline="Team Augmentation"
+    @title="Team Augmentation"
+    @pageTitle="Team Augmentation | Services"
+   />
+
   <div class="layout.main offset.after-21">
     <h2>
       Bring in the experts when you need them

--- a/src/ui/components/PageTeamAugmentation/template.hbs
+++ b/src/ui/components/PageTeamAugmentation/template.hbs
@@ -4,7 +4,7 @@
     @label="Services"
     @headline="Team Augmentation"
     @title="Team Augmentation"
-    @pageTitle="Team Augmentation | Services"
+    @documentTitle="Team Augmentation | Services"
    />
 
   <div class="layout.main offset.after-21">

--- a/src/ui/components/PageTutoring/template.hbs
+++ b/src/ui/components/PageTutoring/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @active="services" @label="Services" @title="Tutoring" />
+  <Header @active="services" @label="Services" @headline="Tutoring" />
   <div class="layout.main offset.after-21">
     <h2 class="typography.h2">
       Raising confidence for increased productivity and quality

--- a/src/ui/components/PageTutoring/template.hbs
+++ b/src/ui/components/PageTutoring/template.hbs
@@ -1,5 +1,12 @@
 <div>
-  <Header @active="services" @label="Services" @headline="Tutoring" />
+  <Header
+    @active="services"
+    @label="Services"
+    @headline="Tutoring"
+    @title="Tutoring"
+    @pageTitle="Tutoring | Services"
+   />
+
   <div class="layout.main offset.after-21">
     <h2 class="typography.h2">
       Raising confidence for increased productivity and quality

--- a/src/ui/components/PageTutoring/template.hbs
+++ b/src/ui/components/PageTutoring/template.hbs
@@ -4,7 +4,7 @@
     @label="Services"
     @headline="Tutoring"
     @title="Tutoring"
-    @pageTitle="Tutoring | Services"
+    @documentTitle="Tutoring | Services"
    />
 
   <div class="layout.main offset.after-21">

--- a/src/ui/components/PageWhySimplabs/template.hbs
+++ b/src/ui/components/PageWhySimplabs/template.hbs
@@ -1,5 +1,10 @@
 <div>
-  <Header @active="about" @label="Why simplabs" @headline="Cutting edge solutions – From Idea to Release">
+  <Header
+    @active="about"
+    @label="Why simplabs"
+    @headline="Cutting edge solutions – From Idea to Release"
+    @title="Why simplabs"
+  >
     <p class="typography.lead">
       We build cutting edge web apps for clients around the world. Our team of experts delivers everything from ideation to design and engineering, guiding our clients along the way.
     </p>

--- a/src/ui/components/PageWhySimplabs/template.hbs
+++ b/src/ui/components/PageWhySimplabs/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header @active="about" @label="Why simplabs" @title="Cutting edge solutions – From Idea to Release">
+  <Header @active="about" @label="Why simplabs" @headline="Cutting edge solutions – From Idea to Release">
     <p class="typography.lead">
       We build cutting edge web apps for clients around the world. Our team of experts delivers everything from ideation to design and engineering, guiding our clients along the way.
     </p>

--- a/src/ui/components/PageWork/template.hbs
+++ b/src/ui/components/PageWork/template.hbs
@@ -2,7 +2,7 @@
   <Header
     @active="work"
     @label="Work"
-    @title="A proven track record of successful projects for international clients."
+    @headline="A proven track record of successful projects for international clients."
    />
 
   <div class="layout.split-leading">

--- a/src/ui/components/PageWork/template.hbs
+++ b/src/ui/components/PageWork/template.hbs
@@ -3,6 +3,7 @@
     @active="work"
     @label="Work"
     @headline="A proven track record of successful projects for international clients."
+    @title="Work"
    />
 
   <div class="layout.split-leading">

--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -21,7 +21,6 @@ declare global {
 interface IRoutesMap {
   [route: string]: {
     component: string;
-    title: string;
     bundle: any;
     parentBundle: any;
   };
@@ -53,13 +52,6 @@ export default class Simplabs extends Component {
   constructor(options) {
     super(options);
 
-    this.appState = this.appState || {
-      isSSR: false,
-      origin: window.location.origin,
-      route: window.location.pathname,
-      routesMap: this._readRoutesMap(),
-    };
-
     this._setupRouting();
     this._bindInternalLinks();
     this._restoreActiveComponentState();
@@ -86,10 +78,9 @@ export default class Simplabs extends Component {
     this.router = new Navigo(this.appState.origin);
 
     Object.keys(this.appState.routesMap).forEach(path => {
-      let { component, title = '', bundle, parentBundle } = (this.appState.routesMap as IRoutesMap)[path];
+      let { component, bundle, parentBundle } = (this.appState.routesMap as IRoutesMap)[path];
       let options: INavigoHooks = {
         after: () => {
-          this._setPageTitle(title);
           this._setCanonicalUrl(path);
           if (!this.appState.isSSR) {
             window.scrollTo(0, 0);
@@ -206,16 +197,6 @@ export default class Simplabs extends Component {
     this.document.body.appendChild(script);
   }
 
-  private _setPageTitle(title) {
-    this.headTags.write('title', {}, {}, formatPageTitle(title));
-    this.headTags.write('meta', {
-      name: 'twitter:title',
-      property: 'og:title',
-    }, {
-      content: title,
-    });
-  }
-
   private _setCanonicalUrl(path) {
     this.headTags.write('meta', {
       property: 'og:url',
@@ -239,15 +220,6 @@ export default class Simplabs extends Component {
       }
     }
   }
-
-  private _readRoutesMap() {
-    let script: HTMLElement | null = document.querySelector('[data-shoebox-routes]');
-    if (script) {
-      return JSON.parse(script.innerText);
-    } else {
-      return {};
-    }
-  }
 }
 
 function trackPageView(route) {
@@ -255,10 +227,6 @@ function trackPageView(route) {
     window.ga('set', 'page', route);
     window.ga('send', 'pageview');
   }
-}
-
-function formatPageTitle(title) {
-  return `${title ? `${title} | ` : ''}simplabs`;
 }
 
 function findLinkParent(target) {

--- a/src/utils/test-helpers/setup-rendering-test.ts
+++ b/src/utils/test-helpers/setup-rendering-test.ts
@@ -1,6 +1,27 @@
 import { classnames } from '@css-blocks/glimmer/dist/cjs/src/helpers/classnames';
 import { concat } from '@css-blocks/glimmer/dist/cjs/src/helpers/concat';
 import { setupRenderingTest as originalSetupRenderingTest } from '@glimmer/test-helpers';
+import hash from '../helpers/hash';
+import HeadTags from '../head-tags';
+
+class TestAppState {
+
+  public static create() {
+    return new TestAppState();
+  }
+
+  public isSSR: boolean;
+  public route: string;
+  public origin: string;
+  public routesMap: IRoutesMap;
+
+  constructor() {
+    this.isSSR = false;
+    this.route = window.location.pathname;
+    this.origin = window.location.origin;
+    this.routesMap = {};
+  }
+}
 
 export const setupRenderingTest = function(hooks) {
   originalSetupRenderingTest(hooks);
@@ -15,6 +36,30 @@ export const setupRenderingTest = function(hooks) {
         registry._resolver.registry._entries[
           `helper:/${rootName}/components/-css-blocks-concat`
         ] = concat;
+
+        registry._resolver.registry._entries[
+          `helper:/${rootName}/components/hash`
+        ] = hash;
+
+        registry.register(
+          `app-state:/${rootName}/main/main`,
+          TestAppState
+        );
+        registry.registerInjection(
+          `component`,
+          'appState',
+          `app-state:/${rootName}/main/main`
+        );
+
+        registry.register(
+          `utils:/${rootName}/head-tags/main`,
+          HeadTags
+        );
+        registry.registerInjection(
+          `component`,
+          'headTags',
+          `utils:/${rootName}/head-tags/main`,
+        );
       }
     });
   });

--- a/src/utils/test-helpers/setup-rendering-test.ts
+++ b/src/utils/test-helpers/setup-rendering-test.ts
@@ -1,8 +1,8 @@
 import { classnames } from '@css-blocks/glimmer/dist/cjs/src/helpers/classnames';
 import { concat } from '@css-blocks/glimmer/dist/cjs/src/helpers/concat';
 import { setupRenderingTest as originalSetupRenderingTest } from '@glimmer/test-helpers';
-import hash from '../helpers/hash';
 import HeadTags from '../head-tags';
+import hash from '../helpers/hash';
 
 class TestAppState {
 

--- a/ssr/ssr-application.ts
+++ b/ssr/ssr-application.ts
@@ -85,7 +85,7 @@ export default class SSRApplication extends Application {
           AppState
         );
         registry.registerInjection(
-          `component:/${rootName}/components/Simplabs`,
+          `component`,
           'appState',
           `app-state:/${rootName}/main/main`
         );


### PR DESCRIPTION
This is a bit of cleanup related to the work on #627. Previously we were setting the title tag and related tags in the `Simplabs` component's source which meant we had to have the title etc. in the route map. As we're aiming to have more page-component specific meta tags like `meta[name="description"]` with that solution we would have had all these tags and their content in the routes map as well which would have gotten messy quickly and would have grown the JSON we're injecting in every page to get the route map into the running app quite a bit. With this approach we're simply using the  new `<HeadTag>` component to render tags in the `<head>` which we can invoke from any template - that way we get the same  functionality but can keep all of the tags attributes and content in the templates where it belongs.