### PR TITLE
Update robots.txt to ignore legal pages

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,8 @@
 # http://www.robotstxt.org
 User-agent: *
 Disallow:
+Disallow: /imprint
+Disallow: /privacy
+Disallow: /imprint/
+Disallow: /privacy/
 Sitemap: https://simplabs.com/sitemap.xml


### PR DESCRIPTION
Sadly both variations show in search results, but this should make both go away.

Closes #661