### PR TITLE
add descriptions for pages

### DIFF
--- a/lib/generate-blog/lib/templates/author/template.hbs
+++ b/lib/generate-blog/lib/templates/author/template.hbs
@@ -1,5 +1,9 @@
 <div>
-  <Header @active="blog" @title="Posts by {{name}}" @documentTitle="Posts by {{name}} | Blog">
+  <Header
+    @active="blog"
+    @title="Posts by {{name}}" @documentTitle="Posts by {{name}} | Blog"
+    @description="Our teams shares what they learn in our blog, covering topics around tech, design/UX and the engineering process. Find all posts by {{name}} here."
+  >
     <div class="blog-post.header">
       <div class="blog-post.headline">
         <h1 class="typography.display">

--- a/lib/generate-blog/lib/templates/start-page/template.hbs
+++ b/lib/generate-blog/lib/templates/start-page/template.hbs
@@ -28,7 +28,11 @@
     "@context": "http://schema.org"
   }
   </script>
-  <Header @active="blog" @title="Blog">
+  <Header
+    @active="blog"
+    @title="Blog"
+    @description="Stay on top of what's happening with our Blog. We mostly write about topics like Ember.js, Elixir, Phoenix and Progressive Web Apps as well as design and UX."
+  >
     <HeaderContent @headline="Blog" />
   </Header>
   <ShapeBlog>

--- a/lib/generate-calendar/lib/templates/page/template.hbs
+++ b/lib/generate-calendar/lib/templates/page/template.hbs
@@ -1,5 +1,8 @@
 <div>
-  <Header @title="Calendar">
+  <Header
+    @title="Calendar"
+    @description="Find out where and when there are upcoming events, conferences and meetups we will be attending or organizing in our calendar."
+  >
     <HeaderContent @headline="Calendar">
       <p class="typography.lead">
         Find out about upcoming events, conferences and meetups we will be attending or organizing.

--- a/lib/generate-talks-archive/lib/templates/page/template.hbs
+++ b/lib/generate-talks-archive/lib/templates/page/template.hbs
@@ -1,5 +1,8 @@
 <div>
-  <Header @title="Talks">
+  <Header
+    @title="Talks"
+    @description="We share our expertise and experience with others. Here are a collection of talks that our team has given at international conferences in the past years."
+  >
     <HeaderContent @headline="Talks">
       <p class="typography.lead">
         We strongly believe in the value of sharing our expertise and experience with others. Here are a collection of talks that members of our team have given at various conferences all over the world in the past years.

--- a/src/ui/components/Header/template.hbs
+++ b/src/ui/components/Header/template.hbs
@@ -2,6 +2,10 @@
   <HeadTag @name="title" @content={{this.documentTitle}} />
   <HeadTag @name="meta" @keys={{hash property="og:title" name="twitter:title"}} @values={{hash content=@title}} />
   <HeadTag @name="meta" @keys={{hash property="og:type"}} @values={{hash content=this.pageType}} />
+  {{#if @description}}
+    <HeadTag @name="meta" @keys={{hash property="og:description" name="description"}} @values={{hash content=@description}} />
+    <HeadTag @name="meta" @keys={{hash name="twitter:description"}} @values={{hash content=@description}} />
+  {{/if}}
   <input id="toggle" type="checkbox" hidden="true" />
   <div class="navbar" data-menu>
     <div class="wrapper">

--- a/src/ui/components/PageCaseDdWrt/template.hbs
+++ b/src/ui/components/PageCaseDdWrt/template.hbs
@@ -1,5 +1,10 @@
 <div>
-  <Header @active="work" @title="DD-WRT NXT Case Study" @documentTitle="DD-WRT NXT Case Study | Work">
+  <Header
+    @active="work"
+    @title="DD-WRT NXT Case Study"
+    @documentTitle="DD-WRT NXT Case Study | Work"
+    @description="DD-WRT is a firmware for wireless routers running on millions of devices worldwide. simplabs developed an Ember.js based foundation for a new configuration UI."
+  >
     <HeaderContent @label="DD-WRT NXT Case Study" @headline="A modern UI for an open-source router firmware" />
   </Header>
   <div class="layout.main offset.after-21">

--- a/src/ui/components/PageCaseStudyExpedition/template.hbs
+++ b/src/ui/components/PageCaseStudyExpedition/template.hbs
@@ -1,5 +1,10 @@
 <div>
-  <Header @active="work" @title="Expedition Case Study" @documentTitle="Expedition Case Study | Work">
+  <Header
+    @active="work"
+    @title="Expedition Case Study"
+    @documentTitle="Expedition Case Study | Work"
+    @description="simplabs helped Expedition to develop a stable and sustainable architecture, getting the most out of their technology stack based on Ember.js and Elixir."
+  >
     <HeaderContent @label="Expedition Case Study" @headline="An online travel magazine for global citizens" />
   </Header>
   <div class="layout.main offset.after-21">

--- a/src/ui/components/PageCaseStudyTimify/template.hbs
+++ b/src/ui/components/PageCaseStudyTimify/template.hbs
@@ -1,5 +1,10 @@
 <div>
-  <Header @active="work" @title="Timify Case Study" @documentTitle="Timify Case Study | Work">
+  <Header
+    @active="work"
+    @title="Timify Case Study"
+    @documentTitle="Timify Case Study | Work"
+    @description="We rebuilt Timify's MVP into a well-architected system that would be the foundation for future evolution, setting them up for sustainable long-term success."
+  >
     <HeaderContent @label="Timify Case Study" @headline="Modern online appointment scheduling" />
   </Header>
   <div class="layout.main">

--- a/src/ui/components/PageCaseStudyTrainline/template.hbs
+++ b/src/ui/components/PageCaseStudyTrainline/template.hbs
@@ -1,5 +1,10 @@
 <div>
-  <Header @active="work" @title="Trainline Case Study" @documentTitle="Trainline Case Study | Work">
+  <Header
+    @active="work"
+    @title="Trainline Case Study"
+    @documentTitle="Trainline Case Study | Work"
+    @description="Trainline is Europe’s leading rail and coach platform. We helper them deliver a high-performance mobile web app, along with an improved engineering process."
+  >
     <HeaderContent @label="Trainline Case Study" @headline="A mobile train ticket counter" />
   </Header>
   <div class="layout.main">

--- a/src/ui/components/PageContact/template.hbs
+++ b/src/ui/components/PageContact/template.hbs
@@ -1,5 +1,9 @@
 <div>
-  <Header @active="contact" @title="Contact">
+  <Header
+    @active="contact"
+    @title="Contact"
+    @description="Whatever you're planning, we'd love to hear more. Send us a message and we will schedule a call to understand your situation and discuss how we can help best."
+  >
     <HeaderContent @headline="Contact Us" @label="Work with Us" />
   </Header>
   <div class="layout.main offset.after-21">

--- a/src/ui/components/PageElixirExpertise/template.hbs
+++ b/src/ui/components/PageElixirExpertise/template.hbs
@@ -1,5 +1,8 @@
 <div>
-  <Header @title="Elixir & Phoenix | Elixir Consulting">
+  <Header
+    @title="Elixir & Phoenix | Elixir Consulting"
+    @description="Elixir combines expressiveness, simplicity, performance and stability. We were early adopters of the technology and are an active member of the community."
+  >
     <HeaderContent @headline="The best of all worlds" @label="Elixir">
       <p class="typography.lead">
         Elixir combines the expressiveness and simplicity of Ruby with the performance and stability of the Erlang VM. Phoenix builds on the concepts first introduced by Ruby on Rails, combining them with a number of architectural improvements to take the architecture into the future.

--- a/src/ui/components/PageEmberExpertise/template.hbs
+++ b/src/ui/components/PageEmberExpertise/template.hbs
@@ -1,5 +1,8 @@
 <div>
-  <Header @title="Europe's leading Ember experts | Ember consulting">
+  <Header
+    @title="Europe's leading Ember experts | Ember consulting"
+    @description="simplabs are Europe's leading Ember experts with unique expertise and insights with a good part of our engineering team being on the Ember.js core team."
+  >
     <HeaderContent @headline="Europe's leading Ember experts" @label="Ember.js">
       <p class="typography.lead">
         simplabs has unique expertise and insights into Ember.js with a good part of our engineering team being on the Ember.js core team and maintaining widely adopted add-ons.

--- a/src/ui/components/PageFullStackEngineering/template.hbs
+++ b/src/ui/components/PageFullStackEngineering/template.hbs
@@ -1,5 +1,10 @@
 <div>
-  <Header @active="services" @title="Full-Stack Engineering" @documentTitle="Full-Stack Engineering | Services">
+  <Header
+    @active="services"
+    @title="Full-Stack Engineering"
+    @documentTitle="Full-Stack Engineering | Services"
+    @description="Our expert team guides clients through the complete project from idea to release, managing everything from concept and design to engineering and operations."
+  >
     <HeaderContent @label="Services" @headline="Full-Stack Engineering" />
   </Header>
   <div class="layout.main offset.after-21">

--- a/src/ui/components/PageHomepage/template.hbs
+++ b/src/ui/components/PageHomepage/template.hbs
@@ -1,5 +1,8 @@
 <div>
-  <Header @title="simplabs – Solid Solutions for Ambitious Projects">
+  <Header
+    @title="simplabs – Solid Solutions for Ambitious Projects"
+    @description="We deliver ambitious digital products on the web and mobile devices for our clients to rely on. Our team of experts manages projects from idea to release."
+  >
     <HeaderContent @headline="Solid Solutions for Ambitious Projects">
       <p class="typography.lead">
         We deliver ambitious digital products on the web and mobile for our clients to rely on. Our expert team manages projects from idea to release, covering strategy, design and engineering.

--- a/src/ui/components/PageServices/template.hbs
+++ b/src/ui/components/PageServices/template.hbs
@@ -1,5 +1,9 @@
 <div>
-  <Header @active="services" @title="Services">
+  <Header
+    @active="services"
+    @title="Services"
+    @description="We turns ideas into products, managing projects from start to end and helps tech teams move faster with confidence via Team Augmentation and Tuturing."
+  >
     <HeaderContent
       @label="Services"
       @headline="We turn ideas into products and help tech teams move faster with confidence"

--- a/src/ui/components/PageTeamAugmentation/template.hbs
+++ b/src/ui/components/PageTeamAugmentation/template.hbs
@@ -1,5 +1,10 @@
 <div>
-  <Header @active="services" @title="Team Augmentation" @documentTitle="Team Augmentation | Services">
+  <Header
+    @active="services"
+    @title="Team Augmentation"
+    @documentTitle="Team Augmentation | Services"
+    @description="By augmenting our clients’ engineering teams, we grow them both in numbers and capability. We will share our know-how and expertise for sustainable value."
+  >
     <HeaderContent @label="Services" @headline="Team Augmentation" />
   </Header>
   <div class="layout.main offset.after-21">

--- a/src/ui/components/PageTutoring/template.hbs
+++ b/src/ui/components/PageTutoring/template.hbs
@@ -1,5 +1,9 @@
 <div>
-  <Header @active="services" @title="Tutoring">
+  <Header
+    @active="services"
+    @title="Tutoring"
+    @description="We tutor teams that approach new technologies, overcome long standing issues or struggle with delivering large scale projects on time and budget."
+  >
     <HeaderContent @label="Services" @headline="Tutoring" />
   </Header>
   <div class="layout.main offset.after-21">

--- a/src/ui/components/PageWhySimplabs/template.hbs
+++ b/src/ui/components/PageWhySimplabs/template.hbs
@@ -1,5 +1,9 @@
 <div>
-  <Header @active="about" @title="Why simplabs">
+  <Header
+    @active="about"
+    @title="Why simplabs"
+    @description="We gather the best experts in their fields wherever they are, delivering cutting edge web apps for our clients around the world, enabling their success."
+  >
     <HeaderContent @label="Why simplabs" @headline="Cutting edge solutions – From Idea to Release">
       <p class="typography.lead">
         We build cutting edge web apps for clients around the world. Our team of experts delivers everything from ideation to design and engineering, guiding our clients along the way.

--- a/src/ui/components/PageWork/template.hbs
+++ b/src/ui/components/PageWork/template.hbs
@@ -1,5 +1,9 @@
 <div>
-  <Header @active="work" @title="Work">
+  <Header
+    @active="work"
+    @title="Work"
+    @description="simplabs has a proven track record of successful projects for international clients. We have worked with companies from small startups to big enterprises."
+  >
     <HeaderContent @label="Work" @headline="A proven track record of successful projects for international clients." />
   </Header>
   <div class="layout.split-leading">

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>simplabs</title>
-    <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {{content-for "head"}}


### PR DESCRIPTION
This adds `meta[name="description"][property="og:description"]` and `meta[name="twitter:description"]` tags for all pages except the blog posts. It's one more step in order to close #654 but we need to add descriptions for the blog posts still.