### PR TITLE
add og:type, twitter:card meta tags

### DIFF
--- a/lib/generate-blog/lib/templates/post/template.hbs
+++ b/lib/generate-blog/lib/templates/post/template.hbs
@@ -46,7 +46,7 @@
       "@context": "http://schema.org"
     }
   </script>
-  <Header @active="blog" @title="{{title}}" @documentTitle="{{title}} | Blog">
+  <Header @active="blog" @title="{{title}}" @documentTitle="{{title}} | Blog" @pageType="article">
     <div class="blog-post.header">
       <div class="blog-post.headline">
         <h1 class="typography.display">

--- a/lib/head-data/index.js
+++ b/lib/head-data/index.js
@@ -16,6 +16,7 @@ module.exports = {
         <meta property="fb:admins" content="699569440119973" />
         <meta property="og:site_name" content="simplabs" />
         <meta name="twitter:site" content="@simplabs">
+        <meta name="twitter:card" content="summary">
         <link type="application/atom+xml" rel="alternate" href="https://simplabs.com/feed.xml" title="simplabs Blog" />
       `;
     } else {

--- a/src/ui/components/Header/component.ts
+++ b/src/ui/components/Header/component.ts
@@ -7,8 +7,9 @@ export default class Header extends Component {
     super(options);
 
     let documentTitle = this.args.documentTitle === undefined ? this.args.title : this.args.documentTitle;
-    
     this.documentTitle = formatformatDocumentTitle(documentTitle);
+
+    this.pageType = this.args.pageType || 'website';
   }
 }
 

--- a/src/ui/components/Header/component.ts
+++ b/src/ui/components/Header/component.ts
@@ -2,6 +2,7 @@ import Component from '@glimmer/component';
 
 export default class Header extends Component {
   public documentTitle = '';
+  private pageType = 'website';
 
   constructor(options) {
     super(options);
@@ -9,7 +10,7 @@ export default class Header extends Component {
     let documentTitle = this.args.documentTitle === undefined ? this.args.title : this.args.documentTitle;
     this.documentTitle = formatformatDocumentTitle(documentTitle);
 
-    this.pageType = this.args.pageType || 'website';
+    this.pageType = this.args.pageType || this.pageType;
   }
 }
 

--- a/src/ui/components/Header/template.hbs
+++ b/src/ui/components/Header/template.hbs
@@ -1,6 +1,7 @@
 <header>
   <HeadTag @name="title" @content={{this.documentTitle}} />
   <HeadTag @name="meta" @keys={{hash property="og:title" name="twitter:title"}} @values={{hash content=@title}} />
+  <HeadTag @name="meta" @keys={{hash property="og:type"}} @values={{hash content=this.pageType}} />
   <input id="toggle" type="checkbox" hidden="true" />
   <div class="navbar" data-menu>
     <div class="wrapper">


### PR DESCRIPTION
This addresses parts of #654 by adding the `meta[property="og:type"]` and `meta[name="twitter:card]"` tags to the document head.