### PR TITLE
Blog post descriptions

### DIFF
--- a/_posts/2013-06-15-authentication-in-emberjs.md
+++ b/_posts/2013-06-15-authentication-in-emberjs.md
@@ -5,6 +5,7 @@ github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
 topic: ember
+description: "Marco Otte-Witte describes an approach for implementing a session mechanism, authentication and authorization in Ember.js applications."
 ---
 
 **Update:**_I released an Ember.js plugin that makes it very easy to implement an authentication system as described in this post: [Ember.SimpleAuth](/blog/2013/10/09/embersimpleauth)._

--- a/_posts/2013-06-27-excellent-172.md
+++ b/_posts/2013-06-27-excellent-172.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte announces excellent 1.7.2 with 3 new checks and a more forgiving and stable parser mechanism."
 topic: ruby
 ---
 

--- a/_posts/2013-06-28-excellent-200.md
+++ b/_posts/2013-06-28-excellent-200.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte announces excellent 2.0.0 with support for a configuration file, a whitelist of allowed global variables and re-enabled standard checks."
 topic: ruby
 ---
 

--- a/_posts/2013-08-08-better-authentication-in-emberjs.md
+++ b/_posts/2013-08-08-better-authentication-in-emberjs.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte introduces an update to the mechanism for implementing a session, authentication and authorization in Ember.js applications."
 topic: ember
 ---
 

--- a/_posts/2013-10-09-embersimpleauth.md
+++ b/_posts/2013-10-09-embersimpleauth.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte announces Ember.SimpleAuth, an addon for implementing a session mechanism, authentication and authorization for Ember.js applications."
 topic: ember
 ---
 

--- a/_posts/2013-10-28-embersimpleauth-implements-rfc-6749-oauth-20.md
+++ b/_posts/2013-10-28-embersimpleauth-implements-rfc-6749-oauth-20.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte announces support for OAuth 2.0 in Ember.SimpleAuth, the addon for implementing a session and authentication/authorization for Ember.js."
 topic: ember
 ---
 

--- a/_posts/2014-01-20-embersimpleauth-010.md
+++ b/_posts/2014-01-20-embersimpleauth-010.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte announces Ember.SimpleAuth 0.1.0 with an improved architecture that allows for arbitrary authentication and authorization strategies."
 topic: ember
 ---
 

--- a/_posts/2014-03-11-embersimpleauth-020.md
+++ b/_posts/2014-03-11-embersimpleauth-020.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte announces Ember.SimpleAuth 0.2.0 with a completely rebuilt build and testing infrastructure as well as important bug fixes."
 topic: ember
 ---
 

--- a/_posts/2014-04-06-embersimpleauth-021.md
+++ b/_posts/2014-04-06-embersimpleauth-021.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte announces Ember.SimpleAuth 0.2.1 with some minor improvements."
 topic: ember
 ---
 

--- a/_posts/2014-04-10-embersimpleauth-030.md
+++ b/_posts/2014-04-10-embersimpleauth-030.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte announces Ember.SimpleAuth 0.3.0, splitting the addon into a core and extensions for specific authentication/authorization mechanisms."
 topic: ember
 ---
 

--- a/_posts/2014-04-24-embersimpleauth-needs-a-logo.md
+++ b/_posts/2014-04-24-embersimpleauth-needs-a-logo.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte posts a request for the community to contribute a logo to Ember.SimpleAuth."
 topic: ember
 ---
 

--- a/_posts/2014-06-30-using-ember-simple-auth-with-ember-cli.md
+++ b/_posts/2014-06-30-using-ember-simple-auth-with-ember-cli.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte announces the release of ember-cli-simple-auth as an Ember CLI addon."
 topic: ember
 ---
 

--- a/_posts/2014-07-25-testing-with-ember-simple-auth-and-ember-cli.md
+++ b/_posts/2014-07-25-testing-with-ember-simple-auth-and-ember-cli.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte explains how to test Ember CLI applications using ember-cli-simple-auth with the testing package ember-cli-simple-auth-testing."
 topic: ember
 ---
 

--- a/_posts/2014-10-15-the-most-important-command-when-working-with-xcode-6.md
+++ b/_posts/2014-10-15-the-most-important-command-when-working-with-xcode-6.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte shows how to disable XCode 6's crash reporter dialog for a less annoying development experience."
 topic: misc
 ---
 

--- a/_posts/2015-06-03-emberjs-workshop-in-munich.md
+++ b/_posts/2015-06-03-emberjs-workshop-in-munich.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte announces simplabs' 3-day Ember.js workshop in Munich, introducing participants to all aspects of the framework."
 topic: ember
 ---
 

--- a/_posts/2015-07-29-ember-simple-auth-10-a-first-look.md
+++ b/_posts/2015-07-29-ember-simple-auth-10-a-first-look.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte gives an outlook on Ember Simple Auth 1.0 with Ember.js 2.0 support, a session service and discontinued support for non-Ember CLI projects."
 topic: ember
 ---
 

--- a/_posts/2015-08-07-rails-api-auth.md
+++ b/_posts/2015-08-07-rails-api-auth.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte announces rails_api_auth, a Rails engine that implements the \"Resource Owner Password Credentials Grant\" OAuth 2.0 flow."
 topic: ruby
 ---
 We are happy to announce the first public release of the [rails_api_auth gem](https://github.com/simplabs/rails_api_auth). rails_api_auth is a **lightweight Rails Engine that implements the _"Resource Owner Password Credentials Grant"_ OAuth 2.0 flow** as well as Facebook authentication and is **built for usage in API projects**. If you’re building a client side application with e.g. a browser MVC like [Ember.js](http://emberjs.com) (where you might be using [Ember Simple Auth](https://github.com/simplabs/ember-simple-auth) which works great with rails_api_auth of course), a mobile app or anything else that’s backed by a Rails-based API, rails_api_auth is for you.

--- a/_posts/2015-11-27-updating-to-ember-simple-auth-1.0.md
+++ b/_posts/2015-11-27-updating-to-ember-simple-auth-1.0.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte gives an update on the upcoming Ember Simple Auth 1.0 release and shows how to use it in Ember CLI applications."
 topic: ember
 ---
 

--- a/_posts/2015-12-3-ember-cli-deploy-notifications.md
+++ b/_posts/2015-12-3-ember-cli-deploy-notifications.md
@@ -4,6 +4,7 @@ author: "Michael Klein"
 twitter: LevelbossMike
 github: LevelbossMike
 bio: "Full-Stack Engineer, Ember CLI Deploy core team member"
+description: "Michael Klein introduces ember-cli-deploy-notifications, an ember-cli-deploy plugin for invoking arbitrary webhooks during the deployment process."
 topic: ember
 ---
 

--- a/_posts/2016-03-04-ember-test-selectors.md
+++ b/_posts/2016-03-04-ember-test-selectors.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte announces the release of ember-test-selectors, an addon that enables better element selectors in Ember.js tests."
 topic: ember
 ---
 

--- a/_posts/2016-12-06-out-of-the-box-fastboot-support-in-ember-simple-auth.md
+++ b/_posts/2016-12-06-out-of-the-box-fastboot-support-in-ember-simple-auth.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte announces out-of-the-box support for FastBoot in Ember Simple Auth and explains how it works using ember-cookies."
 topic: ember
 ---
 

--- a/_posts/2017-01-13-ember-test-selectors.md
+++ b/_posts/2017-01-13-ember-test-selectors.md
@@ -4,6 +4,7 @@ author: "Tobias Bieniek"
 github: Turbo87
 twitter: tobiasbieniek
 bio: "Senior Frontend Engineer, Ember CLI core team member"
+description: "Tobias Bieniek announces new features in ember-test-selectors such as automatic binding of data-test-* properties and how these are stripped in production."
 topic: ember
 ---
 

--- a/_posts/2017-02-01-class-based-computed-properties.md
+++ b/_posts/2017-02-01-class-based-computed-properties.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte introduces a mechanism for class based computed properties in Ember.js and how those can be used instead of helpers."
 topic: ember
 ---
 

--- a/_posts/2017-02-13-npm-libs-in-ember-cli.md
+++ b/_posts/2017-02-13-npm-libs-in-ember-cli.md
@@ -4,6 +4,7 @@ author: "Tobias Bieniek"
 github: Turbo87
 twitter: tobiasbieniek
 bio: "Senior Frontend Engineer, Ember CLI core team member"
+description: "Tobias Bieniek introduces a mechanism for using arbitrary npm libraries in Ember CLI applications and explains how that works under the hood."
 topic: ember
 ---
 

--- a/_posts/2017-03-21-on-computed-properties-vs-helpers.md
+++ b/_posts/2017-03-21-on-computed-properties-vs-helpers.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte discusses differences between computed properties and helpers and explains pros and cons of each alternative."
 topic: ember
 ---
 

--- a/_posts/2017-08-28-creating-web-components-with-glimmer.md
+++ b/_posts/2017-08-28-creating-web-components-with-glimmer.md
@@ -4,6 +4,7 @@ author: "Jessica Jordan"
 github: jessica-jordan
 twitter: jjordan_dev
 bio: "Senior Frontend Engineer, Ember Learning core team member"
+description: "Jessica Jordan explains what web components (aka custom elements) are and shows how they can be built using Glimmer.js."
 topic: ember
 ---
 

--- a/_posts/2017-09-17-magic-test-data.md
+++ b/_posts/2017-09-17-magic-test-data.md
@@ -4,6 +4,7 @@ author: "Andy Brown"
 github: geekygrappler
 twitter: geekygrappler
 bio: "Senior Frontend Engineer"
+description: "Andy Brown explains the AAA principle for writing good tests and discusses what the negative consequences of not adhering to it are."
 topic: misc
 ---
 

--- a/_posts/2017-10-24-high-level-assertions-with-qunit-dom.md
+++ b/_posts/2017-10-24-high-level-assertions-with-qunit-dom.md
@@ -4,6 +4,7 @@ author: "Tobias Bieniek"
 github: Turbo87
 twitter: tobiasbieniek
 bio: "Senior Frontend Engineer, Ember CLI core team member"
+description: "Tobias Bieniek introduces qunit-dom, an extension for qunit that allows writing more expressive and less complex UI tests using high level DOM assertions."
 topic: javascript
 ---
 

--- a/_posts/2017-11-17-ember-test-selectors-road-to-1-0.md
+++ b/_posts/2017-11-17-ember-test-selectors-road-to-1-0.md
@@ -4,6 +4,7 @@ author: "Tobias Bieniek"
 github: Turbo87
 twitter: tobiasbieniek
 bio: "Senior Frontend Engineer, Ember CLI core team member"
+description: "Tobias Bieniek goes through what happened in ember-test-selectors during the past year and what the roadmap towards a 1.0 release is."
 topic: ember
 ---
 

--- a/_posts/2017-12-04-enginification.md
+++ b/_posts/2017-12-04-enginification.md
@@ -4,6 +4,7 @@ author: "Clemens Müller"
 github: pangratz
 twitter: pangratz
 bio: "Full-Stack Engineer, Ember Data core team member"
+description: "Clemens Müller gives an overview of Ember Engines and shows how they can be used to reduce the footprint of big applications for an improved startup time."
 topic: ember
 ---
 

--- a/_posts/2018-01-24-ember-freestyle.md
+++ b/_posts/2018-01-24-ember-freestyle.md
@@ -4,6 +4,7 @@ author: "Tobias Bieniek"
 github: Turbo87
 twitter: tobiasbieniek
 bio: "Senior Frontend Engineer, Ember CLI core team member"
+description: "Tobias Bieniek gives an overview of how ember-freestyle can be used in Ember.js applications for building and testing components in isolation."
 topic: ember
 ---
 

--- a/_posts/2018-02-14-handling-webhooks-in-phoenix.md
+++ b/_posts/2018-02-14-handling-webhooks-in-phoenix.md
@@ -4,6 +4,7 @@ author: "Niklas Long"
 github: niklaslong
 twitter: niklas_long
 bio: "Backend Engineer, author of Breethe API"
+description: "Niklas Long introduces an effective and simple approach for handling incoming webhook requests in Phoenix applications with advanced routing."
 topic: elixir
 ---
 

--- a/_posts/2018-05-30-a-little-encouragement-goes-a-long-way-in-2018.md
+++ b/_posts/2018-05-30-a-little-encouragement-goes-a-long-way-in-2018.md
@@ -4,6 +4,7 @@ author: "Jessica Jordan"
 github: jessica-jordan
 twitter: jjordan_dev
 bio: "Senior Frontend Engineer, Ember Learning core team member"
+description: "Jessica Jordan shares her thoughts for Ember.js in the coming year in response to the Ember 2018 Roadmap Call for Blog Posts."
 topic: ember
 ---
 

--- a/_posts/2018-06-05-ember-component-playground.md
+++ b/_posts/2018-06-05-ember-component-playground.md
@@ -4,6 +4,7 @@ author: "Tobias Bieniek"
 github: Turbo87
 twitter: tobiasbieniek
 bio: "Senior Frontend Engineer, Ember CLI core team member"
+description: "Tobias Bieniek introduces a mechanism for automatically discovering new components in Ember.js applications and showing them in an ember-freestyle playground."
 topic: ember
 ---
 

--- a/_posts/2018-06-11-actix.md
+++ b/_posts/2018-06-11-actix.md
@@ -4,6 +4,7 @@ author: "Tobias Bieniek"
 github: Turbo87
 twitter: tobiasbieniek
 bio: "Senior Frontend Engineer, Ember CLI core team member"
+description: "Tobias Bieniek gives an overview of actix, an actor framework written in the Rust programming language."
 topic: rust
 ---
 

--- a/_posts/2018-06-18-intl-polyfill-loading.md
+++ b/_posts/2018-06-18-intl-polyfill-loading.md
@@ -4,6 +4,7 @@ author: "Tobias Bieniek"
 github: Turbo87
 twitter: tobiasbieniek
 bio: "Senior Frontend Engineer, Ember CLI core team member"
+description: "Tobias Bieniek shows how to load the necessary polyfills for the Intl API in older browsers most effectively when using ember-intl."
 topic: ember
 ---
 

--- a/_posts/2018-06-27-actix-tcp-client.md
+++ b/_posts/2018-06-27-actix-tcp-client.md
@@ -4,6 +4,7 @@ author: "Tobias Bieniek"
 github: Turbo87
 twitter: tobiasbieniek
 bio: "Senior Frontend Engineer, Ember CLI core team member"
+description: "Tobias Bieniek shows how actix, the actor framework written in Rust, can be used to build a basic TCP client."
 topic: rust
 ---
 

--- a/_posts/2018-07-03-building-a-pwa-with-glimmer-js.md
+++ b/_posts/2018-07-03-building-a-pwa-with-glimmer-js.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte dives deep into the details of how simplabs built Breethe, an open source progressive web app, with Glimmer.js."
 topic: ember
 ---
 

--- a/_posts/2018-07-24-from-spa-to-pwa.md
+++ b/_posts/2018-07-24-from-spa-to-pwa.md
@@ -4,6 +4,7 @@ author: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte goes over the characteristics of progressive web apps and shows how to make the next step from a SPA to a PWA."
 topic: javascript
 ---
 

--- a/_posts/2018-11-27-open-source-maintenance.md
+++ b/_posts/2018-11-27-open-source-maintenance.md
@@ -4,6 +4,7 @@ author: "Tobias Bieniek"
 github: Turbo87
 twitter: tobiasbieniek
 bio: "Senior Frontend Engineer, Ember CLI core team member"
+description: "Tobias Bieniek introduces best practices for simplifying and speeding up his work on open-source and other projects."
 topic: misc
 ---
 

--- a/_posts/2018-12-10-assert-your-style.md
+++ b/_posts/2018-12-10-assert-your-style.md
@@ -4,6 +4,7 @@ author: "Jessica Jordan"
 github: jessica-jordan
 twitter: jjordan_dev
 bio: "Senior Frontend Engineer, Ember Learning core team member"
+description: "Jessica Jordan explains approaches and patterns for testing styles in Ember.js applications."
 topic: javascript
 ---
 

--- a/_posts/2018-12-20-factories-best-practices.md
+++ b/_posts/2018-12-20-factories-best-practices.md
@@ -5,9 +5,10 @@ github: geekygrappler
 twitter: geekygrappler
 topic: testing
 bio: "Senior Frontend Engineer"
+description: "Andy Brown introduces best practices for using factories in order to make your colleagues' and your own future self's lives easier."
 ---
 
-Writing tests is like drinking beer 🍻. When you first try it, the taste is really quite unpalatable, but everyone else around you is doing it and they seem to be enjoying it.  You've heard about all the benefits of it, people won't stop telling you how great it is, how it changed their lives for the better. Also there is a lot of peer pressure and judgement involved, don't be that dev... so you conceal your grimace and keep trying it, on a daily basis here at simplabs. And just like beer, in no time at all, on a long hot day, when you feel yourself tiring of writing all those features and tweaking all that CSS, you realise that what you need to relax is to write a good, concise, logical, cool and refreshing test. At least that's been my experience and I want to share a few tips for factories so that your tests are easy for your ~~friends~~, ~~colleagues~~, the next developer to read.
+Writing tests is like drinking beer 🍻. When you first try it, the taste is really quite unpalatable, but everyone else around you is doing it and they seem to be enjoying it. You've heard about all the benefits of it, people won't stop telling you how great it is, how it changed their lives for the better. Also there is a lot of peer pressure and judgement involved, don't be that dev... so you conceal your grimace and keep trying it, on a daily basis here at simplabs. And just like beer, in no time at all, on a long hot day, when you feel yourself tiring of writing all those features and tweaking all that CSS, you realise that what you need to relax is to write a good, concise, logical, cool and refreshing test. At least that's been my experience and I want to share a few tips for factories so that your tests are easy for your ~~friends~~, ~~colleagues~~, the next developer to read.
 
 <!--break-->
 

--- a/_posts/2019-02-08-ember-js-film-release.md
+++ b/_posts/2019-02-08-ember-js-film-release.md
@@ -5,6 +5,7 @@ github: mrmrcoleman
 twitter: mrmrcoleman
 topic: ember
 bio: "Communications and Community Outreach Specialist"
+description: "Mark Coleman announces the release of \"Ember.js: The Documentary\" in which simplabs is featured among other well-known figures from the Ember.js community."
 ---
 
 We're very pleased to announce that simplabs are featured in the new  [HoneyPot](https://www.honeypot.io/) film **'Ember: A Mini Documentary'** that will premiere in Amsterdam this evening (2019-02-08).

--- a/_posts/2019-02-11-ember-js-film-berlin.md
+++ b/_posts/2019-02-11-ember-js-film-berlin.md
@@ -5,6 +5,7 @@ github: mrmrcoleman
 twitter: mrmrcoleman
 topic: ember
 bio: "Communications and Community Outreach Specialist"
+description: "Mark Coleman announces the screening of \"Ember.js: The Documentary\" in Berlin, Feb. 11th 2019."
 ---
 
 Following on from last week's premiere in Amsterdam the new [HoneyPot](https://www.honeypot.io/) film **'Ember: A Mini Documentary'** will be shown in Berlin this evening (2019-02-11).

--- a/_posts/2019-03-07-march-monthly-update.md
+++ b/_posts/2019-03-07-march-monthly-update.md
@@ -5,6 +5,7 @@ github: mrmrcoleman
 twitter: mrmrcoleman
 topic: simplabs
 bio: "Communications and Community Outreach Specialist"
+description: "Mark Coleman shares simplabs' monthly update for March 2019, covering EmberConf 2019, the release of \"Ember.js: The Documentary\" and various upcoming events."
 ---
 
 Welcome to our new monthly update. Each month we'll cover the events and activities that have been happening at simplabs. Enjoy.

--- a/_posts/2019-03-13-elixir-umbrella-mox.md
+++ b/_posts/2019-03-13-elixir-umbrella-mox.md
@@ -5,6 +5,7 @@ github: niklaslong
 twitter: niklas_long
 topic: elixir
 bio: "Backend Engineer, author of Breethe API"
+description: "Niklas Long shows how Elixir Umbrella applications not only improve the organization of a code base but also allow for an improved testing setup."
 ---
 
 What's the big deal with Elixir umbrellas?

--- a/_posts/2019-03-18-emberconf-update.md
+++ b/_posts/2019-03-18-emberconf-update.md
@@ -5,6 +5,7 @@ github: mrmrcoleman
 twitter: mrmrcoleman
 topic: simplabs
 bio: "Communications and Community Outreach Specialist"
+description: "Mark Coleman gives an update on the simplabs team's presence at EmberConf 2019 and our involvement with many events at and around the conference."
 ---
 
 We mentioned this in our March monthly update but in case you missed it, here's

--- a/_posts/2019-03-29-qonto-project.md
+++ b/_posts/2019-03-29-qonto-project.md
@@ -5,6 +5,7 @@ github: mrmrcoleman
 twitter: mrmrcoleman
 topic: simplabs
 bio: "Communications and Community Outreach Specialist"
+description: "Mark Coleman announces our new client Qonto, a Paris based VC funded Fintech startup who are \"the ideal banking alternative for freelancers, startups and SMEs.\""
 ---
 
 We're very pleased to announce that we've started working with [Qonto](https://qonto.eu/),

--- a/_posts/2019-04-05-april-monthly-update.md
+++ b/_posts/2019-04-05-april-monthly-update.md
@@ -5,6 +5,7 @@ github: mrmrcoleman
 twitter: mrmrcoleman
 topic: simplabs
 bio: "Communications and Community Outreach Specialist"
+description: "Mark Coleman shares simplabs' monthly update for April 2019, covering new joiners, new clients and a number of upcoming events."
 ---
 
 Welcome to the second installment of our monthly update. Each month we cover the events and activities that have been happening at simplabs along with the things we're looking forward to. Enjoy.

--- a/_posts/2019-04-05-spas-pwas-and-ssr.md
+++ b/_posts/2019-04-05-spas-pwas-and-ssr.md
@@ -5,6 +5,7 @@ github: marcoow
 twitter: marcoow
 topic: javascript
 bio: "Founding Director of simplabs, author of Ember Simple Auth"
+description: "Marco Otte-Witte dives deep into different approaches for building web apps like SPAs, PWAs, SSR and how they all can be combined for the best result."
 ---
 
 Single Page Apps, Progressive Web Apps and classic Server side rendered

--- a/_posts/2019-04-24-dependency-updates-for-gitlab.md
+++ b/_posts/2019-04-24-dependency-updates-for-gitlab.md
@@ -5,6 +5,7 @@ github: Turbo87
 twitter: tobiasbieniek
 topic: misc
 bio: "Senior Frontend Engineer, Ember CLI core team member"
+description: "Tobias Bieniek shares how to set up the Renovate bot for automatic dependency updates with self-hosted internal GitLab servers."
 ---
 
 Are your dependencies hopelessly outdated? Would you need to hire another

--- a/_posts/2019-05-10-may-monthly-update.md
+++ b/_posts/2019-05-10-may-monthly-update.md
@@ -5,6 +5,7 @@ github: mrmrcoleman
 twitter: mrmrcoleman
 topic: simplabs
 bio: "Communications and Community Outreach Specialist"
+description: "Mark Coleman shares simplabs' monthly update for May 2019, covering new joiners, new OSS projects and our involvement with the Erlang Ecosystem Foundation."
 ---
 
 Welcome to the third installment of our monthly update. Each month we cover the events and activities that have been happening at simplabs along with the things we're looking forward to. Enjoy.

--- a/_posts/2019-07-15-sentry-and-ember.md
+++ b/_posts/2019-07-15-sentry-and-ember.md
@@ -5,6 +5,7 @@ github: Turbo87
 twitter: tobiasbieniek
 topic: ember
 bio: "Senior Frontend Engineer, Ember CLI core team member"
+description: "Tobias Bieniek explains how to set up Sentry for Ember.js applications using @sentry/browser instead of the now unnecessary ember-cli-sentry."
 ---
 
 Are you confident that your apps have no bugs? Do you not need a support team

--- a/_posts/2019-07-24-july-monthly-update.md
+++ b/_posts/2019-07-24-july-monthly-update.md
@@ -5,6 +5,7 @@ github: mrmrcoleman
 twitter: mrmrcoleman
 topic: simplabs
 bio: 'Communications and Community Outreach Specialist'
+description: "Mark Coleman shares simplabs' update for July 2019, covering the release of our new website, new OSS releases and a number of upcoming events."
 ---
 
 Welcome to the fourth installment of our monthly update. This one is later than expected but still packed with all the events and activities that have been happening at simplabs along with the things we're looking forward to. Enjoy.

--- a/lib/generate-blog/lib/components-builder.js
+++ b/lib/generate-blog/lib/components-builder.js
@@ -124,6 +124,7 @@ module.exports = class ComponentsBuilder extends BaseComponentsBuilder {
 
     return {
       title: post.meta.title,
+      description: post.meta.description,
       excerpt: htmlizeExcerpt(post.content),
       body: htmlizeBody(post.content),
       date: dateformat(post.meta.date, 'mmmm d, yyyy'),

--- a/lib/generate-blog/lib/templates/post/template.hbs
+++ b/lib/generate-blog/lib/templates/post/template.hbs
@@ -48,7 +48,7 @@
       "@context": "http://schema.org"
     }
   </script>
-  <Header @active="blog" @title="{{title}}" @documentTitle="{{title}} | Blog" @pageType="article">
+  <Header @active="blog" @title="{{title}}" @documentTitle="{{title}} | Blog" @pageType="article" @description="{{description}}">
     <div class="blog-post.header">
       <div class="blog-post.headline">
         <h1 class="typography.display">


### PR DESCRIPTION
This adds descriptions for all blog posts in the `meta[name="description"][property="og:description"]` and `meta[name="twitter:description"]` tags.

closes #654 

### TODO

- [x] once #670 is merged, we need to actually add the meta tags for the descriptions