### PR TITLE
add missing title to playbook page

### DIFF
--- a/src/ui/components/PagePlaybook/template.hbs
+++ b/src/ui/components/PagePlaybook/template.hbs
@@ -1,5 +1,5 @@
 <div>
-  <Header>
+  <Header @title="Playbook">
     <HeaderContent @headline="Playbook" @label="Process">
       <p class="typography.lead">
         We maintain a lean process that supports the team rather than stand in its way. It ensures the right tasks are being worked on at the right time and provides a reasonable level of short term predictability. At the same time it remains flexible enough to adapt to unexpected events. Our process does not depend on specific tools and works for projects and teams in all environments.


### PR DESCRIPTION
…which  was accidentially dropped while refactoring the title and  the header component apparently.