### PR TITLE
Additional blog meta tags

### DIFF
--- a/lib/generate-blog/lib/templates/post/template.hbs
+++ b/lib/generate-blog/lib/templates/post/template.hbs
@@ -1,5 +1,6 @@
 <div>
   <HeadTag @name='meta' @keys=\{{hash property="article:published_time"}} @values=\{{hash content="{{isoDate}}"}} />
+  <HeadTag @name='meta' @keys=\{{hash property="article:section"}} @values=\{{hash content="{{topic}}"}} />
   <HeadTag @name='meta' @keys=\{{hash name="twitter:creator"}} @values=\{{hash content="{{author.twitter}}"}} />
   <script type="application/ld+json">
     {

--- a/lib/generate-blog/lib/templates/post/template.hbs
+++ b/lib/generate-blog/lib/templates/post/template.hbs
@@ -1,5 +1,6 @@
 <div>
   <HeadTag @name='meta' @keys=\{{hash property="article:published_time"}} @values=\{{hash content="{{isoDate}}"}} />
+  <HeadTag @name='meta' @keys=\{{hash name="twitter:creator"}} @values=\{{hash content="{{author.twitter}}"}} />
   <script type="application/ld+json">
     {
       "@type": "BlogPosting",


### PR DESCRIPTION
This adds  the `meta[property="article:section"]` and `meta[name="twitter:creator"]` tags for blog  posts.

closes #655 

(the other tags mentioned in the issue are either present already or in the case  of  the descriptions are added via #672 )