### PR TITLE
remove static title tag

### DIFF
--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>simplabs</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     {{content-for "head"}}


### PR DESCRIPTION
This removes the static `title` tag from `src/ui/index.html`  as we're  now always generating that on the fly which  can lead to duplicate `title` tags during the SSR pass.

closes #675 