### PR TITLE
Add canonical link tag to head

### DIFF
--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -198,11 +198,32 @@ export default class Simplabs extends Component {
   }
 
   private _setCanonicalUrl(path) {
-    this.headTags.write('meta', {
-      property: 'og:url',
-    }, {
-      content: `https://simplabs.com${path}`,
-    });
+    // Ensure trailing slash
+    if (path.slice(-1) !== '/') {
+      path = `${path}/`;
+    }
+
+    this.headTags.write(
+      'meta',
+      {
+        property: 'og:url',
+      },
+      {
+        content: `https://simplabs.com${path}`,
+      },
+    );
+
+    // Canonical urls are required by search engines to define what represents
+    // the one true URL of a page, which should exclude query params, anchors, …
+    this.headTags.write(
+      'link',
+      {
+        rel: 'canonical',
+      },
+      {
+        href: `https://simplabs.com${path}`,
+      },
+    );
   }
 
   private _injectActiveComponentState() {


### PR DESCRIPTION
Google Search Console seems to be unhappy about missing "Canonical URLs", this adds them.

Closes #682 