### PR TITLE
Fixup changes in PR #683 and #685

### DIFF
--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -47,7 +47,7 @@ function generateSitemap(routes) {
 
   let paths = Object.keys(routes).filter(path => path !== '/404');
   for (let path of paths) {
-    if (path.slice(-1) !== '/') {
+    if (!path.endsWith('/')) {
       path = `${path}/`;
     }
 

--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -199,9 +199,11 @@ export default class Simplabs extends Component {
 
   private _setCanonicalUrl(path) {
     // Ensure trailing slash
-    if (path.slice(-1) !== '/') {
+    if (!path.endsWith('/')) {
       path = `${path}/`;
     }
+
+    path = `https://simplabs.com${path}`;
 
     this.headTags.write(
       'meta',
@@ -209,7 +211,7 @@ export default class Simplabs extends Component {
         property: 'og:url',
       },
       {
-        content: `https://simplabs.com${path}`,
+        content: path,
       },
     );
 
@@ -221,7 +223,7 @@ export default class Simplabs extends Component {
         rel: 'canonical',
       },
       {
-        href: `https://simplabs.com${path}`,
+        href: path,
       },
     );
   }


### PR DESCRIPTION
- remove repetition in head meta tag configuration
- use `String.endsWith()` when possible*

*: browser-support is lagging behind. We could polyfill but it's only used in one place and the polyfill is larger than using the more old fashioned `String.slice()` option.