### PR TITLE
Exclude certain pages from sitemap.xml

### DIFF
--- a/config/routes-map.js
+++ b/config/routes-map.js
@@ -37,7 +37,7 @@ module.exports = function() {
     ...blogPostRoutes,
     ...blogAuthorsRoutes,
     '/': { component: 'PageHomepage' },
-    '/404': { component: 'Page404', sitemap: false },
+    '/404': { component: 'Page404' },
     '/blog': { component: 'PageBlog', bundle: { asset: '/blog.js', module: '__blog__' } },
     '/calendar': {
       component: 'PageCalendar',
@@ -53,7 +53,6 @@ module.exports = function() {
     '/imprint': {
       component: 'PageLegalImprint',
       bundle: { asset: '/legal.js', module: '__legal__' },
-      sitemap: false,
     },
     '/playbook': {
       component: 'PagePlaybook',
@@ -62,7 +61,6 @@ module.exports = function() {
     '/privacy': {
       component: 'PageLegalPrivacy',
       bundle: { asset: '/legal.js', module: '__legal__' },
-      sitemap: false,
     },
     '/services': { component: 'PageServices' },
     '/services/full-stack-engineering': {

--- a/config/routes-map.js
+++ b/config/routes-map.js
@@ -37,7 +37,7 @@ module.exports = function() {
     ...blogPostRoutes,
     ...blogAuthorsRoutes,
     '/': { component: 'PageHomepage' },
-    '/404': { component: 'Page404' },
+    '/404': { component: 'Page404', sitemap: false },
     '/blog': { component: 'PageBlog', bundle: { asset: '/blog.js', module: '__blog__' } },
     '/calendar': {
       component: 'PageCalendar',
@@ -53,6 +53,7 @@ module.exports = function() {
     '/imprint': {
       component: 'PageLegalImprint',
       bundle: { asset: '/legal.js', module: '__legal__' },
+      sitemap: false,
     },
     '/playbook': {
       component: 'PagePlaybook',
@@ -61,6 +62,7 @@ module.exports = function() {
     '/privacy': {
       component: 'PageLegalPrivacy',
       bundle: { asset: '/legal.js', module: '__legal__' },
+      sitemap: false,
     },
     '/services': { component: 'PageServices' },
     '/services/full-stack-engineering': {

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -45,8 +45,13 @@ function generateSitemap(routes) {
       <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   `;
 
-  let paths = Object.keys(routes).filter(path => path !== '/404');
+  let paths = Object.keys(routes);
+
   for (let path of paths) {
+    if (routes[path].sitemap === false) {
+      continue;
+    }
+
     if (!path.endsWith('/')) {
       path = `${path}/`;
     }

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -13,11 +13,13 @@ module.exports = {
     this.routes = routesMap();
   },
 
+  excludedRoutes: ['/404', '/imprint', '/privacy'],
+
   treeFor(type) {
     if (type === 'public') {
       return new MergeTrees([
         writeFile('routes.json', JSON.stringify(this.routes)),
-        writeFile('sitemap.xml', generateSitemap(this.routes)),
+        writeFile('sitemap.xml', generateSitemap(this.routes, this.excludedRoutes)),
       ]);
     }
   },
@@ -39,7 +41,7 @@ module.exports = {
   },
 };
 
-function generateSitemap(routes) {
+function generateSitemap(routes, excluded) {
   let sitemap = `
     <?xml version="1.0" encoding="UTF-8"?>
       <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
@@ -48,7 +50,7 @@ function generateSitemap(routes) {
   let paths = Object.keys(routes);
 
   for (let path of paths) {
-    if (routes[path].sitemap === false) {
+    if (excluded.includes(path)) {
       continue;
     }
 


### PR DESCRIPTION
404, Imprint, and Privacy should not be part of the `sitemap.xml`. This adds a basic filter mechanism that can be controlled from the routes configuration.

Closes #686