### PR TITLE
Disable service worker

### DIFF
--- a/lib/service-workers/index.js
+++ b/lib/service-workers/index.js
@@ -28,22 +28,22 @@ module.exports = {
     app.options.fingerprint.exclude.push('service-worker.js');
   },
 
-  contentFor(type) {
+  contentFor(/* type */) {
     if (process.env.EMBER_ENV === 'development') {
       return '';
     }
 
-    if (type === 'body-footer') {
-      return `
-        <script>
-          if ('serviceWorker' in navigator) {
-            navigator.serviceWorker.register('/service-worker.js', { scope: '/' }).catch(function() {
-              // ignore errors
-            });
-          }
-        </script>
-      `;
-    }
+    // if (type === 'body-footer') {
+    //   return `
+    //     <script>
+    //       if ('serviceWorker' in navigator) {
+    //         navigator.serviceWorker.register('/service-worker.js', { scope: '/' }).catch(function() {
+    //           // ignore errors
+    //         });
+    //       }
+    //     </script>
+    //   `;
+    // }
 
     return '';
   },


### PR DESCRIPTION
We are still seeing relatively slow TTFB times, sometimes in the range of multiple seconds. I just want to be sure we're not doing something stupid ourselves with the service worker. This PR stops the service worker from being loaded so we can release this for some time, do some tests and re-enable it afterwards. We could of course just disable JS and thus implicitly prevent the service worker from running but that would be a very unrealistic test then of course.