### PR TITLE
Improve preloading in service worker

### DIFF
--- a/lib/generate-blog/lib/templates/author/template.hbs
+++ b/lib/generate-blog/lib/templates/author/template.hbs
@@ -1,4 +1,5 @@
 <div>
+  <LazyPreloadTrigger @bundle="blog" />
   <Header
     @active="blog"
     @title="Posts by {{name}}" @documentTitle="Posts by {{name}} | Blog"

--- a/lib/generate-blog/lib/templates/list-page/template.hbs
+++ b/lib/generate-blog/lib/templates/list-page/template.hbs
@@ -1,4 +1,5 @@
 <div>
+  <LazyPreloadTrigger @bundle="blog" />
   <script type="application/ld+json">
     {
     "@type": "Blog",

--- a/lib/generate-blog/lib/templates/post/template.hbs
+++ b/lib/generate-blog/lib/templates/post/template.hbs
@@ -1,4 +1,5 @@
 <div>
+  <LazyPreloadTrigger @bundle="blog" />
   <HeadTag @name='meta' @keys=\{{hash property="article:published_time"}} @values=\{{hash content="{{isoDate}}"}} />
   <HeadTag @name='meta' @keys=\{{hash property="article:section"}} @values=\{{hash content="{{topic}}"}} />
   <HeadTag @name='meta' @keys=\{{hash name="twitter:creator"}} @values=\{{hash content="{{author.twitter}}"}} />

--- a/lib/service-workers/lib/worker-builder.js
+++ b/lib/service-workers/lib/worker-builder.js
@@ -23,17 +23,27 @@ module.exports = class WorkerBuilder extends BroccoliPlugin {
     let [assetsFolder, workersFolder] = this.inputPaths;
 
     let preloadAssetsList = this.findPreloadAssets(assetsFolder);
+    let blogContentPreloadAssetsList = this.findBlogContentPreloadAssets(assetsFolder);
 
     let workers = this.findWorkers(workersFolder);
 
-    let rollupPlugins = this.configureRollupPlugins(preloadAssetsList);
+    let rollupPlugins = this.configureRollupPlugins(preloadAssetsList, blogContentPreloadAssetsList);
     return Promise.all(workers.map(worker => this.rollupWorker(workersFolder, worker, rollupPlugins)));
   }
 
   findPreloadAssets(assetsFolder) {
     let files = walkSync(assetsFolder, {
       globs: ['**/*.png', '**/*.jpg', '**/*.gif', '**/*.svg', '**/blog/page/*.js', '**/blog/author-*.js'],
-      ignore: ['**/posts/**/*'],
+      ignore: ['**/posts/**/*', '**/authors/**/*'],
+    });
+    return JSON.stringify(files);
+  }
+
+  findBlogContentPreloadAssets(assetsFolder) {
+    let files = walkSync(assetsFolder, {
+      globs: ['**/posts/**/*', '**/authors/**/*'],
+      ignore: ['**/posts/**/og-image?(-*).png'],
+      directories: false,
     });
     return JSON.stringify(files);
   }
@@ -60,10 +70,11 @@ module.exports = class WorkerBuilder extends BroccoliPlugin {
     }
   }
 
-  configureRollupPlugins(preloadAssetsList) {
+  configureRollupPlugins(preloadAssetsList, blogContentPreloadAssetsList) {
     let rollupPlugins = [
       virtual({
-        './assets/paths.js': `export default ${preloadAssetsList};`,
+        './assets/general/paths.js': `export default ${preloadAssetsList};`,
+        './assets/blog/paths.js': `export default ${blogContentPreloadAssetsList};`,
       }),
       resolve({ jsnext: true, module: true, main: true }),
       commonjs(),

--- a/lib/service-workers/lib/worker-builder.js
+++ b/lib/service-workers/lib/worker-builder.js
@@ -22,20 +22,20 @@ module.exports = class WorkerBuilder extends BroccoliPlugin {
   build() {
     let [assetsFolder, workersFolder] = this.inputPaths;
 
-    let assetFiles = this.findAssets(assetsFolder);
-    let assetsList = JSON.stringify(assetFiles);
+    let preloadAssetsList = this.findPreloadAssets(assetsFolder);
 
     let workers = this.findWorkers(workersFolder);
 
-    let rollupPlugins = this.configureRollupPlugins(assetsList);
+    let rollupPlugins = this.configureRollupPlugins(preloadAssetsList);
     return Promise.all(workers.map(worker => this.rollupWorker(workersFolder, worker, rollupPlugins)));
   }
 
-  findAssets(assetsFolder) {
-    return walkSync(assetsFolder, {
+  findPreloadAssets(assetsFolder) {
+    let files = walkSync(assetsFolder, {
       globs: ['**/*.png', '**/*.jpg', '**/*.gif', '**/*.svg', '**/blog/page/*.js', '**/blog/author-*.js'],
-      ignore: ['**/posts/**/og-image?(-*).png'],
+      ignore: ['**/posts/**/*'],
     });
+    return JSON.stringify(files);
   }
 
   findWorkers(workersFolder) {
@@ -60,10 +60,10 @@ module.exports = class WorkerBuilder extends BroccoliPlugin {
     }
   }
 
-  configureRollupPlugins(assetsList) {
+  configureRollupPlugins(preloadAssetsList) {
     let rollupPlugins = [
       virtual({
-        './assets/paths.js': `export default ${assetsList};`,
+        './assets/paths.js': `export default ${preloadAssetsList};`,
       }),
       resolve({ jsnext: true, module: true, main: true }),
       commonjs(),

--- a/lib/service-workers/workers/service-worker.js
+++ b/lib/service-workers/workers/service-worker.js
@@ -4,7 +4,8 @@ const JSON_API_CONTENT_TYPE = 'application/vnd.api+json';
 const HTML_CONTENT_TYPE = 'text/html';
 const FONT_ORIGINS = ['https://fonts.gstatic.com', 'https://fonts.googleapis.com'];
 
-import ASSETS from './assets/paths.js';
+import PRELOAD_ASSETS from './assets/general/paths.js';
+import BLOG_CONTENT_PRELOAD_ASSETS from './assets/blog/paths.js';
 
 const PRE_CACHED_ASSETS = [
   '/app.js',
@@ -15,7 +16,7 @@ const PRE_CACHED_ASSETS = [
   '/recent.js',
   '/talks.js',
   '/bare-index.html',
-].concat(ASSETS);
+].concat(PRELOAD_ASSETS);
 
 function isNavigationRequest(event) {
   return event.request.mode === 'navigate';
@@ -35,28 +36,41 @@ function isHtmlRequest(event) {
   return isNavigationRequest(event) || (isGetRequest && isHTMLRequest);
 }
 
-self.addEventListener('install', function(event) {
+function preload(assets) {
   let now = Date.now();
-  event.waitUntil(
-    caches.open(CACHE_NAME).then(function(cache) {
-      let cachePromises = PRE_CACHED_ASSETS.map(function(asset) {
-        let url = new URL(asset, location.href);
-        if (url.search) {
-          url.search += '&';
-        }
-        url.search += `sw-precache=${now}`;
-        let request = new Request(url, { mode: 'no-cors' });
-        return fetch(request).then(function(response) {
-          if (response.status >= 400) {
-            throw new Error('prefetch failed!');
+  return caches.open(CACHE_NAME).then(function(cache) {
+    let cachePromises = assets.map(function(asset) {
+      return cache.match(asset).then(function(response) {
+        if (!response) {
+          let url = new URL(asset, location.href);
+          if (url.search) {
+            url.search += '&';
           }
-          return cache.put(asset, response);
-        });
+          url.search += `sw-precache=${now}`;
+          let request = new Request(url, { mode: 'no-cors' });
+          return fetch(request).then(function(response) {
+            if (response.status >= 400) {
+              throw new Error('prefetch failed!');
+            }
+            return cache.put(asset, response);
+          });
+        }
       });
+    });
 
-      return Promise.all(cachePromises);
-    }),
-  );
+    return Promise.all(cachePromises);
+  });
+}
+
+self.addEventListener('install', function(event) {
+  event.waitUntil(preload(PRE_CACHED_ASSETS));
+});
+
+self.addEventListener('message', function(event) {
+  let { preload: preloadBundle } = event.data;
+  if (preloadBundle === 'blog') {
+    preload(BLOG_CONTENT_PRELOAD_ASSETS);
+  }
 });
 
 self.addEventListener('activate', function(event) {

--- a/src/ui/components/LazyPreloadTrigger/component.ts
+++ b/src/ui/components/LazyPreloadTrigger/component.ts
@@ -1,6 +1,8 @@
 import Component from '@glimmer/component';
 
 export default class LazyPreloadTrigger extends Component {
+  private appState: IAppState;
+
   constructor(options) {
     super(options);
 
@@ -8,9 +10,11 @@ export default class LazyPreloadTrigger extends Component {
   }
 
   private preload() {
-    let { controller: serviceWorkerController } = navigator.serviceWorker;
-    if (serviceWorkerController) {
-      serviceWorkerController.postMessage({ preload: this.args.bundle });
+    if (!this.appState.isSSR) {
+      let { controller: serviceWorkerController } = navigator.serviceWorker;
+      if (serviceWorkerController) {
+        serviceWorkerController.postMessage({ preload: this.args.bundle });
+      }
     }
   }
 }

--- a/src/ui/components/LazyPreloadTrigger/component.ts
+++ b/src/ui/components/LazyPreloadTrigger/component.ts
@@ -1,0 +1,16 @@
+import Component from '@glimmer/component';
+
+export default class LazyPreloadTrigger extends Component {
+  constructor(options) {
+    super(options);
+
+    this.preload();
+  }
+
+  private preload() {
+    let { controller: serviceWorkerController } = navigator.serviceWorker;
+    if (serviceWorkerController) {
+      serviceWorkerController.postMessage({ preload: this.args.bundle });
+    }
+  }
+}

--- a/src/ui/components/LazyPreloadTrigger/stylesheet.css
+++ b/src/ui/components/LazyPreloadTrigger/stylesheet.css
@@ -1,0 +1,3 @@
+:scope {
+  block-name: LazyPreloadTrigger;
+}


### PR DESCRIPTION
This improves the preloading behaviour of the service worker. Currently, we're preloading **all** of the assets all of the time which is not really great as we're wasting a lot of bandwidth for people and load some big GIFs etc. that they are unlikely to ever need anyway. With this change, we're only preloading the blog assets for people that actually visit the blog (any blog page). This could still be optimized further but is probably good enough, in particular since we are not loading a ton of data anyway (only around 9MB in total for the start page and about 18MB for people that visit the blog).

closes #696 