### PR TITLE
#full and #plain images in blog posts for art direction

### DIFF
--- a/lib/generate-blog/lib/components-builder.js
+++ b/lib/generate-blog/lib/components-builder.js
@@ -203,8 +203,28 @@ function wrapNode(dom, node, className, element = 'div') {
 
 function replaceWithFigure(dom, element, content) {
   let figure = dom.createElement('figure');
+  let img = content;
+  let className = 'blog-post.figure';
 
-  figure.classList.add('blog-post.figure');
+  if (img.tagName !== 'IMG') {
+    img = content.querySelector('img');
+  }
+
+  if (img.src.endsWith('#full')) {
+    img.src = img.src.replace(/#full$/, '');
+    img.classList.add('figure.content-full');
+
+    className = 'blog-post.figure-plain';
+  } else if (img.src.endsWith('#plain')) {
+    img.src = img.src.replace(/#plain$/, '');
+    img.classList.add('figure.content-centered');
+
+    className = 'blog-post.figure-plain';
+  } else {
+    img.classList.add('figure.content-centered');
+  }
+
+  figure.classList.add(className);
   figure.appendChild(content);
 
   element.parentElement.insertBefore(figure, element);
@@ -217,20 +237,14 @@ function htmlizeBody(content) {
       let paragraph = img.parentElement;
 
       if (paragraph.children.length === 1) {
-        img.classList.add('figure.content-centered');
-
         replaceWithFigure(dom, paragraph, img);
       } else {
         img.classList.add('blog-post.image');
       }
     });
 
-    dom.querySelectorAll('p > a > img').forEach(img => {
-      let paragraph = img.parentElement.parentElement;
-
-      img.classList.add('figure.content-centered');
-
-      replaceWithFigure(dom, paragraph, img.parentElement);
+    dom.querySelectorAll('p > a > img:only-child').forEach(img => {
+      replaceWithFigure(dom, img.parentElement.parentElement, img.parentElement);
     });
 
     dom.querySelectorAll('table').forEach(table => {

--- a/src/ui/styles/blocks/blog-post.block.css
+++ b/src/ui/styles/blocks/blog-post.block.css
@@ -71,10 +71,14 @@
   width: var(--col-1);
 }
 
-.figure {
+.figure,
+.figure-plain {
   composes: 'figure';
   margin: 2rem 0;
   padding: 0;
+}
+
+.figure {
   background: #f5f5f5;
 }
 

--- a/src/ui/styles/blocks/figure.block.css
+++ b/src/ui/styles/blocks/figure.block.css
@@ -12,3 +12,13 @@
   display: block;
   margin: 0 auto;
 }
+
+.content-full {
+  position: relative;
+  top: 0;
+  left: 50%;
+  margin: 0;
+  transform: translate(-50%, 0);
+  width: 100vw;
+  max-width: unset;
+}


### PR DESCRIPTION
Makes it possible to have full width images and figures without a border. Necessary for #737