### PR TITLE
fix intro text on talks page

### DIFF
--- a/lib/generate-appearances-archive/lib/templates/page/template.hbs
+++ b/lib/generate-appearances-archive/lib/templates/page/template.hbs
@@ -5,7 +5,7 @@
   >
     <HeaderContent @headline="Talks">
       <p class="typography.lead">
-        We strongly believe in the value of sharing our expertise and experience with others. Here are a collection of event talks and other appearances that members of our team made at various events all over the world in the past years.
+        We strongly believe in the value of sharing our expertise and experience with others. Here are a collection of conference talks and other appearances that members of our team made at various events all over the world in the past years.
       </p>
     </HeaderContent>
   </Header>


### PR DESCRIPTION
This fixes the intro text on the talks page which doesn't really make much sense as it is currently, in particular _"…Here are a collection of event talks and other appearances that members of our team made at various events all over the world in the past years.…"_ - _"event talk"_ isn't really a thing after all 🤦‍♂ 