### PR TITLE
Fix Percy integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,4 +106,6 @@ jobs:
         run: yarn build
 
       - name: validation
+        env:
+          PERCY_TARGET_BRANCH: ${{ github.base_ref }}
         run: yarn ${{ matrix.validation-suite }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,4 +108,5 @@ jobs:
       - name: validation
         env:
           PERCY_TARGET_BRANCH: ${{ github.base_ref }}
+          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
         run: yarn ${{ matrix.validation-suite }}


### PR DESCRIPTION
This fixed the Percy integration that broke with the move to GitHub Actions (🤦‍♂ ). It adds the percy token so that we will actually be able to send things to Percy and not just fail silently which is what we're doing now. It also explicitly defines the Percy target branch so we get proper validations for PRs that do not target the `master` branch.