### PR TITLE
check serviceworker controller exists before posting to it

### DIFF
--- a/lib/service-workers/workers/service-worker.js
+++ b/lib/service-workers/workers/service-worker.js
@@ -63,6 +63,7 @@ function preload(assets) {
 }
 
 self.addEventListener('install', function(event) {
+  self.skipWaiting();
   event.waitUntil(preload(PRE_CACHED_ASSETS));
 });
 
@@ -86,6 +87,7 @@ self.addEventListener('activate', function(event) {
       );
     }),
   );
+  event.waitUntil(clients.claim());
 });
 
 self.addEventListener('fetch', function(event) {

--- a/src/ui/components/LazyPreloadTrigger/component.ts
+++ b/src/ui/components/LazyPreloadTrigger/component.ts
@@ -15,7 +15,9 @@ export default class LazyPreloadTrigger extends Component {
 
       await ready;
 
-      controller.postMessage({ preload: this.args.bundle });
+      if (controller) {
+        controller.postMessage({ preload: this.args.bundle });
+      }
     }
   }
 }


### PR DESCRIPTION
We currently have a bug in our code that posts to the ServiceWorker before it is active which should be the case for new visitors where the ServiceWorker is installed on the first visit but not active until a refresh or the next visit. This checks whether the controller interface to the ServiceWorker exists (which is only the case when the ServiceWorker is actually active) before posting to it.

It also immediately activates the service worker when it is installed so that no reload is necessary until the service worker is actually active for all of the already open tabs. According to the [Workbox.js docs](https://developers.google.com/web/tools/workbox/guides/generate-complete-sw#skip_waiting_and_clients_claim), the only risk with that approach would be if any of the open tabs would rely on resources that would only be available in a previous service worker which is not the case for simplabs.com as we're only using the worker for improved caching.

See https://sentry.io/organizations/simplabs/issues/1289162377/?project=1456103&query=is%3Aunresolved