### PR TITLE
Add digital product page

### DIFF
--- a/config/routes-map.js
+++ b/config/routes-map.js
@@ -85,6 +85,9 @@ module.exports = function() {
     '/services/full-stack-engineering': {
       component: 'PageFullStackEngineering',
     },
+    '/services/digital-products': {
+      component: 'PageDigitalProducts',
+    },
     '/services/team-augmentation': { component: 'PageTeamAugmentation' },
     '/services/tutoring': { component: 'PageTutoring' },
     '/talks': { component: 'PageTalks', bundle: { asset: '/talks.js', module: '__talks__' } },

--- a/src/ui/components/PageDigitalProducts/component-test.ts
+++ b/src/ui/components/PageDigitalProducts/component-test.ts
@@ -1,0 +1,15 @@
+import hbs from '@glimmer/inline-precompile';
+import { render } from '@glimmer/test-helpers';
+import { setupRenderingTest } from '../../../utils/test-helpers/setup-rendering-test';
+
+const { module, test } = QUnit;
+
+module('Component: PageDigitalProducts', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`<PageDigitalProducts />`);
+
+    assert.ok(this.containerElement.querySelector('div'));
+  });
+});

--- a/src/ui/components/PageDigitalProducts/stylesheet.css
+++ b/src/ui/components/PageDigitalProducts/stylesheet.css
@@ -1,0 +1,10 @@
+@block container from "../../styles/blocks/container.block.css";
+@block fluid-image from "../../styles/blocks/fluid-image.block.css";
+@block layout from "../../styles/blocks/layout.block.css";
+@block offset from "../../styles/blocks/offset.block.css";
+@block typography from "../../styles/blocks/typography.block.css";
+
+:scope {
+  block-name: PageDigitalProducts;
+  composes: 'layout';
+}

--- a/src/ui/components/PageDigitalProducts/template.hbs
+++ b/src/ui/components/PageDigitalProducts/template.hbs
@@ -44,6 +44,10 @@
         Extreme attention to detail
       </li>
     </ul>
+    {{! TODO: fix link once target page exists! }}
+    <ArrowLink @href="/">
+      Learn how we work
+    </ArrowLink>
   </div>
   <div class="layout.full offset.after-12">
     <h3 class="typography.h3">

--- a/src/ui/components/PageDigitalProducts/template.hbs
+++ b/src/ui/components/PageDigitalProducts/template.hbs
@@ -26,22 +26,22 @@
     </p>
     <ul>
       <li>
-        Wireframing & prototyping
+        Market validation
       </li>
       <li>
-        Delight users with great UX
+        Idea extraction & strategy
       </li>
       <li>
-        Clean aesthetics
+        Validate essential assumptions
       </li>
       <li>
-        Overcome complex design problems
+        Groom the product roadmap
       </li>
       <li>
-        Develop a consistent design system
+        Define product principles
       </li>
       <li>
-        Extreme attention to detail
+        Separate MVPs and follow-on improvements
       </li>
     </ul>
     {{! TODO: fix link once target page exists! }}

--- a/src/ui/components/PageDigitalProducts/template.hbs
+++ b/src/ui/components/PageDigitalProducts/template.hbs
@@ -5,10 +5,7 @@
     @documentTitle="Digital Products"
     @description="Our team of experts delivers everything from ideation to design and engineering. We can turn any idea sketched on the back of a napkin into a final, shipped product."
   >
-    <HeaderContent
-      @label="Services"
-      @headline="Turning your visionary ideas into a shipped products"
-    >
+    <HeaderContent @label="Services" @headline="Turning your visionary ideas into a shipped products">
       <p class="typography.lead">
         Today, the influence of software and technology on our everyday lives is bigger that ever. Whether it’s a corporate venture or an ambitious founder, modern companies need true excellence in developing state-of-the-art digital experiences, to deliver on their ambitions.
       </p>
@@ -28,12 +25,24 @@
       Great products are born out of a deep understanding of user needs and market demands. Product strategy sprints turn assumptions into evidence and visionary ideas into focused, validated product concepts. Strategic clarity lead to building best-in-class products.
     </p>
     <ul>
-      <li>Wireframing & prototyping</li>
-      <li>Delight users with great UX</li>
-      <li>Clean aesthetics</li>
-      <li>Overcome complex design problems</li>
-      <li>Develop a consistent design system</li>
-      <li>Extreme attention to detail</li>
+      <li>
+        Wireframing & prototyping
+      </li>
+      <li>
+        Delight users with great UX
+      </li>
+      <li>
+        Clean aesthetics
+      </li>
+      <li>
+        Overcome complex design problems
+      </li>
+      <li>
+        Develop a consistent design system
+      </li>
+      <li>
+        Extreme attention to detail
+      </li>
     </ul>
   </div>
   <div class="layout.full offset.after-12">
@@ -47,14 +56,26 @@
       Great product design combined with outspoken aesthetic elements will make your new digital product remarkable and unique, as well as drive activation and engagement. Great user experiences can position your product uniquely in the market, and win both raving fans and loyal audiences.
     </p>
     <ul>
-      <li>Wireframing & prototyping</li>
-      <li>Delight users with great UX</li>
-      <li>Clean aesthetics</li>
-      <li>Overcome complex design problems</li>
-      <li>Develop a consistent design system</li>
-      <li>Extreme attention to detail</li>
+      <li>
+        Wireframing & prototyping
+      </li>
+      <li>
+        Delight users with great UX
+      </li>
+      <li>
+        Clean aesthetics
+      </li>
+      <li>
+        Overcome complex design problems
+      </li>
+      <li>
+        Develop a consistent design system
+      </li>
+      <li>
+        Extreme attention to detail
+      </li>
     </ul>
-    {{!-- TODO: fix link once target page exists! --}}
+    {{! TODO: fix link once target page exists! }}
     <ArrowLink @href="/">
       Explore our design process
     </ArrowLink>
@@ -70,14 +91,26 @@
       Involve our senior engineers to quickly establish all required functionalities for your app. Engineering is our true passion, and unmistakable in every product we deliver.
     </p>
     <ul>
-      <li>Full-stack development</li>
-      <li>World-class engineering quality</li>
-      <li>Robust, reliable, secure code</li>
-      <li>Architected for the future</li>
-      <li>Modern process best practices</li>
-      <li>Our promise of excellence</li>
+      <li>
+        Full-stack development
+      </li>
+      <li>
+        World-class engineering quality
+      </li>
+      <li>
+        Robust, reliable, secure code
+      </li>
+      <li>
+        Architected for the future
+      </li>
+      <li>
+        Modern process best practices
+      </li>
+      <li>
+        Our promise of excellence
+      </li>
     </ul>
-    {{!-- TODO: fix link once target page exists! --}}
+    {{! TODO: fix link once target page exists! }}
     <ArrowLink @href="/">
       Learn about bespoke development
     </ArrowLink>

--- a/src/ui/components/PageDigitalProducts/template.hbs
+++ b/src/ui/components/PageDigitalProducts/template.hbs
@@ -115,7 +115,6 @@
       Learn about bespoke development
     </ArrowLink>
   </div>
-  <ShapeAcrossLeadingExperts />
   <WorkWithUs />
   <Footer />
 </div>

--- a/src/ui/components/PageDigitalProducts/template.hbs
+++ b/src/ui/components/PageDigitalProducts/template.hbs
@@ -5,7 +5,7 @@
     @documentTitle="Digital Products"
     @description="Our team of experts delivers everything from ideation to design and engineering. We can turn any idea sketched on the back of a napkin into a final, shipped product."
   >
-    <HeaderContent @label="Services" @headline="Turning your visionary ideas into a shipped products">
+    <HeaderContent @label="Digital Products" @headline="Turning your visionary ideas into a shipped products">
       <p class="typography.lead">
         Today, the influence of software and technology on our everyday lives is bigger that ever. Whether it’s a corporate venture or an ambitious founder, modern companies need true excellence in developing state-of-the-art digital experiences, to deliver on their ambitions.
       </p>

--- a/src/ui/components/PageDigitalProducts/template.hbs
+++ b/src/ui/components/PageDigitalProducts/template.hbs
@@ -1,0 +1,88 @@
+<div>
+  <Header
+    @active="services"
+    @title="Services"
+    @documentTitle="Digital Products"
+    @description="Our team of experts delivers everything from ideation to design and engineering. We can turn any idea sketched on the back of a napkin into a final, shipped product."
+  >
+    <HeaderContent
+      @label="Services"
+      @headline="Turning your visionary ideas into a shipped products"
+    >
+      <p class="typography.lead">
+        Today, the influence of software and technology on our everyday lives is bigger that ever. Whether it’s a corporate venture or an ambitious founder, modern companies need true excellence in developing state-of-the-art digital experiences, to deliver on their ambitions.
+      </p>
+      <p class="typography.lead">
+        simplabs is a reliable partner to transform ideas from a rough outline into a final, shipped product.
+      </p>
+    </HeaderContent>
+  </Header>
+  <div class="layout.full offset.after-12">
+    <h3 class="typography.h3">
+      <small class="typography.small">
+        Product Strategy
+      </small>
+      Rapid explorations, research and validation
+    </h3>
+    <p class="typography.lead offset.after-5">
+      Great products are born out of a deep understanding of user needs and market demands. Product strategy sprints turn assumptions into evidence and visionary ideas into focused, validated product concepts. Strategic clarity lead to building best-in-class products.
+    </p>
+    <ul>
+      <li>Wireframing & prototyping</li>
+      <li>Delight users with great UX</li>
+      <li>Clean aesthetics</li>
+      <li>Overcome complex design problems</li>
+      <li>Develop a consistent design system</li>
+      <li>Extreme attention to detail</li>
+    </ul>
+  </div>
+  <div class="layout.full offset.after-12">
+    <h3 class="typography.h3">
+      <small class="typography.small">
+        Product Design
+      </small>
+      Design experiences that users love
+    </h3>
+    <p class="typography.lead offset.after-5">
+      Great product design combined with outspoken aesthetic elements will make your new digital product remarkable and unique, as well as drive activation and engagement. Great user experiences can position your product uniquely in the market, and win both raving fans and loyal audiences.
+    </p>
+    <ul>
+      <li>Wireframing & prototyping</li>
+      <li>Delight users with great UX</li>
+      <li>Clean aesthetics</li>
+      <li>Overcome complex design problems</li>
+      <li>Develop a consistent design system</li>
+      <li>Extreme attention to detail</li>
+    </ul>
+    {{!-- TODO: fix link once target page exists! --}}
+    <ArrowLink @href="/">
+      Explore our design process
+    </ArrowLink>
+  </div>
+  <div class="layout.full offset.after-12">
+    <h3 class="typography.h3">
+      <small class="typography.small">
+        Product Development
+      </small>
+      Engineered to impeccable standards
+    </h3>
+    <p class="typography.lead offset.after-5">
+      Involve our senior engineers to quickly establish all required functionalities for your app. Engineering is our true passion, and unmistakable in every product we deliver.
+    </p>
+    <ul>
+      <li>Full-stack development</li>
+      <li>World-class engineering quality</li>
+      <li>Robust, reliable, secure code</li>
+      <li>Architected for the future</li>
+      <li>Modern process best practices</li>
+      <li>Our promise of excellence</li>
+    </ul>
+    {{!-- TODO: fix link once target page exists! --}}
+    <ArrowLink @href="/">
+      Learn about bespoke development
+    </ArrowLink>
+  </div>
+  <ShapeAcrossLeadingExperts />
+  <WorkWithUs />
+  <Footer />
+</div>

--- a/src/ui/components/PageHomepage/template.hbs
+++ b/src/ui/components/PageHomepage/template.hbs
@@ -53,6 +53,9 @@
     <p>
       Our team of experts delivers everything from ideation to design and engineering. We can turn any idea sketched on the back of a napkin into a final, shipped product.
     </p>
+    <ArrowLink @href="/services/digital-products/" @leftAlign={{true}}>
+      Learn More
+    </ArrowLink>
     <h3>
       Team Augmentation
     </h3>

--- a/src/ui/components/PageServices/template.hbs
+++ b/src/ui/components/PageServices/template.hbs
@@ -73,7 +73,7 @@
     <p class="typography.lead offset.after-5">
       Our team of experts delivers everything from ideation to design and engineering. We can turn any idea sketched on the back of a napkin into a final, shipped product.
     </p>
-    <a class="button" href="/contact/" data-internal>
+    <a class="button" href="/services/digital-products/" data-internal>
       How we can Help
     </a>
   </div>


### PR DESCRIPTION
This adds the _"digital products"_ page with the content as defined in Basecamp. It does **not** style the page.

closes #862