### PR TITLE
Add Product Development page

### DIFF
--- a/config/routes-map.js
+++ b/config/routes-map.js
@@ -86,6 +86,7 @@ module.exports = function() {
       component: 'PageFullStackEngineering',
     },
     '/services/team-augmentation': { component: 'PageTeamAugmentation' },
+    '/services/product-development': { component: 'PageProductDevelopment' },
     '/services/tutoring': { component: 'PageTutoring' },
     '/talks': { component: 'PageTalks', bundle: { asset: '/talks.js', module: '__talks__' } },
     '/why-simplabs': { component: 'PageWhySimplabs' },

--- a/src/ui/components/PageProductDevelopment/component-test.ts
+++ b/src/ui/components/PageProductDevelopment/component-test.ts
@@ -1,0 +1,15 @@
+import hbs from '@glimmer/inline-precompile';
+import { render } from '@glimmer/test-helpers';
+import { setupRenderingTest } from '../../../utils/test-helpers/setup-rendering-test';
+
+const { module, test } = QUnit;
+
+module('Component: PageProductDevelopment', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`<PageProductDevelopment />`);
+
+    assert.ok(this.containerElement.querySelector('div'));
+  });
+});

--- a/src/ui/components/PageProductDevelopment/stylesheet.css
+++ b/src/ui/components/PageProductDevelopment/stylesheet.css
@@ -1,0 +1,11 @@
+@block container from "../../styles/blocks/container.block.css";
+@block fluid-image from "../../styles/blocks/fluid-image.block.css";
+@block layout from "../../styles/blocks/layout.block.css";
+@block offset from "../../styles/blocks/offset.block.css";
+@block typography from "../../styles/blocks/typography.block.css";
+@block button from "../../styles/blocks/button.block.css";
+
+:scope {
+  block-name: PageProductDevelopment;
+  composes: 'layout';
+}

--- a/src/ui/components/PageProductDevelopment/template.hbs
+++ b/src/ui/components/PageProductDevelopment/template.hbs
@@ -78,6 +78,9 @@
         Deployment and Operation
       </li>
     </ul>
+    <ArrowLink @href="/playbook/">
+      Learn how we work
+    </ArrowLink>
   </div>
   <div class="layout.full offset.after-12">
     <h2>

--- a/src/ui/components/PageProductDevelopment/template.hbs
+++ b/src/ui/components/PageProductDevelopment/template.hbs
@@ -1,0 +1,92 @@
+<div>
+  <Header
+    @active="services"
+    @title="Product Development"
+    @documentTitle="Product Development | Services"
+    @description="From start to finish you work with the same team of product experts, engineers and designers to bring your product to live."
+  >
+    <HeaderContent @label="Product Development" @headline="Engineering excellence means building things to last">
+      <p class="typography.lead">
+        simplabs has its origins in engineering and development. We obsess over crafting the absolute best products we can, built on architectures that are easy to extend, update and maintain. Our process depends on close collaboration between designers and developers to release well-tested products in dynamic, fast-paced iterations.
+      </p>
+      <p class="typography.lead">
+        As a leading development house in Europe, we love to take on projects that pose interesting and complex engineering challenges.
+      </p>
+    </HeaderContent>
+  </Header>
+  <div class="layout.full offset.after-12">
+    <h2>
+      Our guiding principles
+    </h2>
+    <p class="typography.lead">
+      Today, the influence of software and technology on our everyday lives is bigger that ever. We love to create digital products that contribute to that trend in a meaningful way.
+    </p>
+  </div>
+  <div class="layout.main offset.after-12">
+    <h4>
+      Code excellence. Always.
+    </h4>
+    <p>
+      No excuses for sloppy code and quick-fix solutions. Well-written code is less prone to errors or bugs, more secure, and faster.
+    </p>
+    <ArrowLink @href="/blog/">
+      Read more on the blog
+    </ArrowLink>
+    <h4>
+      Collaboration is essential
+    </h4>
+    <p>
+      Designers support the project end-to-end. Close collaboration allows space for early user feedback, reducing risks, and improved outcomes.
+    </p>
+    <ArrowLink @href="/playbook/">
+      Explore our process in the simplabs playbook
+    </ArrowLink>
+    <h4>
+      Build software that you can maintain
+    </h4>
+    <p>
+      In a fast-changing world, it’s essential to build on a foundation that is sustainable yet able to change and adapt. Build for change.
+    </p>
+    <ArrowLink @href="/contact/">
+      Talk to an engineer
+    </ArrowLink>
+  </div>
+  <div class="layout.full offset.after-12">
+    <h2>
+      Excellence in engineering, from first commit to finished product
+    </h2>
+    <p class="typography.lead">
+      Our standards for code quality and engineering are second to none. Our digital product development support includes:
+    </p>
+    <ul>
+      <li>
+        Full-stack development
+      </li>
+      <li>
+        Effective process, run by seasoned product teams
+      </li>
+      <li>
+        Continuous Delivery of Product Increments
+      </li>
+      <li>
+        Intensive automated testing and QA
+      </li>
+      <li>
+        Engineering Team of Technology Leaders
+      </li>
+      <li>
+        Deployment and Operation
+      </li>
+    </ul>
+  </div>
+  <div class="layout.full offset.after-12">
+    <h2>
+      We love open source &mdash; we’re the leading Ember.js team in Europe
+    </h2>
+    <p class="typography.lead">
+      We co-host EmberFest (the biggest Ember.js conference in Europe) and we actively contribute to the open source projects we're leveraging for our projects.
+    </p>
+  </div>
+  <WorkWithUs @teamMember="chris" />
+  <Footer />
+</div>


### PR DESCRIPTION
This adds the page for product development. It **only** adds the page and text content – styling and addition of images etc. is still needed to be done in a follow-up PR.

![localhost_4200_services_product-development](https://user-images.githubusercontent.com/1510/73851277-80366c80-482d-11ea-8296-01e43d6176a9.png)

closes #862 