### PR TITLE
Add Product design page

### DIFF
--- a/config/routes-map.js
+++ b/config/routes-map.js
@@ -86,6 +86,7 @@ module.exports = function() {
       component: 'PageFullStackEngineering',
     },
     '/services/team-augmentation': { component: 'PageTeamAugmentation' },
+    '/services/product-design': { component: 'PageProductDesign' },
     '/services/tutoring': { component: 'PageTutoring' },
     '/talks': { component: 'PageTalks', bundle: { asset: '/talks.js', module: '__talks__' } },
     '/why-simplabs': { component: 'PageWhySimplabs' },

--- a/src/ui/components/PageProductDesign/component-test.ts
+++ b/src/ui/components/PageProductDesign/component-test.ts
@@ -1,0 +1,15 @@
+import hbs from '@glimmer/inline-precompile';
+import { render } from '@glimmer/test-helpers';
+import { setupRenderingTest } from '../../../utils/test-helpers/setup-rendering-test';
+
+const { module, test } = QUnit;
+
+module('Component: PageProductDesign', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`<PageProductDesign />`);
+
+    assert.ok(this.containerElement.querySelector('div'));
+  });
+});

--- a/src/ui/components/PageProductDesign/stylesheet.css
+++ b/src/ui/components/PageProductDesign/stylesheet.css
@@ -1,0 +1,11 @@
+@block container from "../../styles/blocks/container.block.css";
+@block fluid-image from "../../styles/blocks/fluid-image.block.css";
+@block layout from "../../styles/blocks/layout.block.css";
+@block offset from "../../styles/blocks/offset.block.css";
+@block typography from "../../styles/blocks/typography.block.css";
+@block button from "../../styles/blocks/button.block.css";
+
+:scope {
+  block-name: PageProductDesign;
+  composes: 'layout';
+}

--- a/src/ui/components/PageProductDesign/template.hbs
+++ b/src/ui/components/PageProductDesign/template.hbs
@@ -1,0 +1,84 @@
+<div>
+  <Header
+    @active="services"
+    @title="Product Design"
+    @documentTitle="Product Design | Services"
+    @description="From start to finish you work with the same team of product experts, engineers and designers to bring your product to live."
+  >
+    <HeaderContent @label="Product Design" @headline="Design digital products that users love">
+      <p class="typography.lead">
+        The greatest product designs are almost invisible—the experience is so simple and fluid, you can barely imagine how you'd do things without the product. The process to create such experiences is one of fast iterations, rapid prototyping and experimenting our way forward. It's the safest path to practical, elegant and profoundly useful digital products.
+      </p>
+      <p class="typography.lead">
+        We cover all aspects of the design process. Our designers and product experts help you at every stage to develop your vision into unique experiences.
+      </p>
+    </HeaderContent>
+  </Header>
+  <div class="layout.full offset.after-12">
+    <h2>
+      What we believe about design
+    </h2>
+    <p class="typography.lead">
+      A strong design process allows experimentation and rapid iterations to uncover the true essence of a product. We hold a design philosophy that’s about creating digital experiences that are clean, functional and focused.
+    </p>
+  </div>
+  <div class="layout.main offset.after-12">
+    <h4>
+      Easy is delightful
+    </h4>
+    <p>
+      More than “making it pretty”, design is about providing users functional, effective tools to get the job done with confidence, speed and ease.
+    </p>
+    <ArrowLink @href="/blog/">
+      Read more on the blog
+    </ArrowLink>
+    <h4>
+      Every interaction matters
+    </h4>
+    <p>
+      To craft products that users love means hearing every stakeholder, considering all edge cases, and paying attention to every corner of the design.
+    </p>
+    <ArrowLink @href="/playbook/">
+      We like doing things “the right way”
+    </ArrowLink>
+    <h4>
+      Clean, functional aesthetics
+    </h4>
+    <p>
+      Modern interfaces should be aesthetic, clean and focused, so that even complicated functionalities can become places of joy and delight.
+    </p>
+    <ArrowLink @href="/contact/">
+      Book a call with a designer
+    </ArrowLink>
+  </div>
+  <div class="layout.full offset.after-12">
+    <h2>
+      Your design partner, from “start” to “shipped”
+    </h2>
+    <p class="typography.lead">
+      simplabs provides product design expertise throughout the entire product creation process—from rough concept sketches to tested, final implementation.
+    </p>
+    <ul>
+      <li>
+        Multi-stakeholder design research
+      </li>
+      <li>
+        Ideation across the entire user journey
+      </li>
+      <li>
+        Rapid prototyping & concept development
+      </li>
+      <li>
+        Wireframing & mocks
+      </li>
+      <li>
+        User delight & striking details
+      </li>
+      <li>
+        Adaptive, iterative design process
+      </li>
+    </ul>
+  </div>
+  <WorkWithUs @teamMember="ghislaine" />
+  <Footer />
+</div>


### PR DESCRIPTION
This adds the page on product design. It **only** adds the page and text content – stying and images are still missing and will have to be added in a follow-up PR.

![localhost_4200_services_product-design](https://user-images.githubusercontent.com/1510/73852386-5bdb8f80-482f-11ea-8ee7-1b666d54e397.png)

closes #865 