### PR TITLE
Configure watchman to ignore dist folder

### DIFF
--- a/.watchmanconfig
+++ b/.watchmanconfig
@@ -1,0 +1,3 @@
+{
+  "ignore_dirs": ["dist"]
+}


### PR DESCRIPTION
This is a quick patch to avoid `ember serve` going into an endless loop and running out of memory.

Fixes https://github.com/simplabs/simplabs.github.io/issues/877.