### PR TITLE
Add dev server task with limited content archive

### DIFF
--- a/lib/generate-appearances-archive/lib/collect-appearances.js
+++ b/lib/generate-appearances-archive/lib/collect-appearances.js
@@ -2,42 +2,47 @@
 'use strict';
 
 const path = require('path');
+const process = require('process');
 
 const glob = require('glob');
 
 const separateMeta = require('../../markdown-content/separate-meta');
 
 module.exports = function(folder) {
-  return glob
-    .sync('*/', {
-      cwd: folder,
-      absolute: true,
-    })
-    .map(channelFolder => {
-      let date = new Date(path.basename(channelFolder).substring(0, 10));
-      let [meta, description] = separateMeta(path.join(channelFolder, 'channel.md'));
+  let channels = glob.sync('*/', {
+    cwd: folder,
+    absolute: true,
+  });
 
-      let appearances = glob
-        .sync('**/*.md', {
-          cwd: path.join(channelFolder, 'appearances'),
-          absolute: true,
-        })
-        .map(file => {
-          let [meta, description] = separateMeta(file);
+  if (process.env.LIMIT_CONTENT_ARCHIVE) {
+    channels = channels.slice(0, 3);
+  }
 
-          return {
-            meta,
-            description,
-          };
-        });
+  return channels.map(channelFolder => {
+    let date = new Date(path.basename(channelFolder).substring(0, 10));
+    let [meta, description] = separateMeta(path.join(channelFolder, 'channel.md'));
 
-      return {
-        meta: {
-          ...meta,
-          date,
-        },
-        description,
-        appearances,
-      };
-    });
+    let appearances = glob
+      .sync('**/*.md', {
+        cwd: path.join(channelFolder, 'appearances'),
+        absolute: true,
+      })
+      .map(file => {
+        let [meta, description] = separateMeta(file);
+
+        return {
+          meta,
+          description,
+        };
+      });
+
+    return {
+      meta: {
+        ...meta,
+        date,
+      },
+      description,
+      appearances,
+    };
+  });
 };

--- a/lib/generate-blog/lib/collect-posts.js
+++ b/lib/generate-blog/lib/collect-posts.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const path = require('path');
+const process = require('process');
 
 const glob = require('glob');
 const _ = require('lodash');
@@ -31,6 +32,10 @@ module.exports = function(folder) {
     .sortBy('meta.date')
     .reverse()
     .value();
+
+  if (process.env.LIMIT_CONTENT_ARCHIVE) {
+    posts = posts.slice(0, 3);
+  }
 
   let authors = _.chain(posts)
     .uniqBy('meta.twitter')

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "PRERENDER=1 ember build -prod && node scripts/prerender.js",
     "crawl": "node scripts/crawl.js",
     "start": "ember server",
+    "start-dev": "LIMIT_CONTENT_ARCHIVE=true ember server",
     "test": "ember test",
     "lint:ts": "tslint -c tslint.json 'src/**/*.ts' -t codeFrame",
     "lint:js": "eslint . --cache",


### PR DESCRIPTION
We are currently adding all of the components for the blog archive, all of the components for the talks archive etc. to the build when running `ember s`. That adds quite a bit of code to the build that needs to be transpiled, split into separate bundles etc. Most of the time, this archive content is not needed when working on the page though and only slows the build (initial build as well as subsequent rebuilds) down.

This adds a special script `yarn start-dev` that runs `ember s` but only adds the latest 3 posts and latest 3 events so we limit the number of components that get built quite dramatically and speed up the build significantly.