### PR TITLE
Cleanup shape feature

### DIFF
--- a/src/ui/components/ShapeFeature/component-test.ts
+++ b/src/ui/components/ShapeFeature/component-test.ts
@@ -12,4 +12,22 @@ module('Component: ShapeFeature', function(hooks) {
 
     assert.ok(this.containerElement.querySelector('div'));
   });
+
+  module('when invoked with a @srcset', function() {
+    test('it renders figure and figcaption elements', async function(assert) {
+      await render(hbs`<ShapeFeature @srcset="./some/image/source.png" />`);
+
+      assert.ok(this.containerElement.querySelector('figure'));
+      assert.ok(this.containerElement.querySelector('figcaption'));
+    });
+  });
+
+  module('when invoked without a @srcset', function() {
+    test('it does not render figure and figcaption elements', async function(assert) {
+      await render(hbs`<ShapeFeature />`);
+
+      assert.notOk(this.containerElement.querySelector('figure'));
+      assert.notOk(this.containerElement.querySelector('figcaption'));
+    });
+  });
 });

--- a/src/ui/components/ShapeFeature/stylesheet.css
+++ b/src/ui/components/ShapeFeature/stylesheet.css
@@ -84,9 +84,6 @@
   :scope {
     margin: 16rem 0;
   }
-
-  :scope[hasImage] .bottom {
-  }
 }
 
 @media (min-width: 888px) {

--- a/src/ui/components/ShapeFeature/template.hbs
+++ b/src/ui/components/ShapeFeature/template.hbs
@@ -1,8 +1,8 @@
 <div>
   <div block:class="top"></div>
   <div block:class="middle">
-    <figure block:class="container" layout:scope>
-      {{#if @srcset}}
+    {{#if @srcset}}
+      <figure block:class="container" layout:scope>
         <div block:class="img-wrapper">
           <img
             block:class="img"
@@ -13,11 +13,17 @@
             height={{@height}}
           />
         </div>
-      {{/if}}
-      <figcaption block:class="content">
-        {{yield}}
-      </figcaption>
-    </figure>
+        <figcaption block:class="content">
+          {{yield}}
+        </figcaption>
+      </figure>
+    {{else}}
+      <div block:class="container" layout:scope>
+        <p block:class="content">
+          {{yield}}
+        </p>
+      </div>
+    {{/if}}
   </div>
   <div block:class="bottom"></div>
 </div>

--- a/src/ui/components/ShapeFeature/template.hbs
+++ b/src/ui/components/ShapeFeature/template.hbs
@@ -1,4 +1,4 @@
-<div block:hasImage={{@src}}>
+<div>
   <div block:class="top"></div>
   <div block:class="middle">
     <figure block:class="container" layout:scope>


### PR DESCRIPTION
This cleans up the `ShapeFeature` component a bit by:

* removing the unused `hasImage` state
* for the case that no `@srcset` is provided (thus no image is shown), using `div`/`p` tags instead of `figure`/`figcaption`

closes #884 