### PR TITLE
Rebuild mobile menu with clip-path

### DIFF
--- a/lib/global-css/css/menu.css
+++ b/lib/global-css/css/menu.css
@@ -1,9 +1,9 @@
 @media (max-width: 887px) {
   [data-menu] nav {
     display: block;
-    background: var(--color-accent);
     z-index: -1;
     pointer-events: none;
+    margin-top: -8rem;
   }
 
   [data-menu] nav a,
@@ -31,7 +31,7 @@
   }
 
   #toggle:checked + [data-menu] nav {
-    padding-top: 8rem;
+    margin-top: 0;
     top: 0;
     z-index: 2;
     opacity: 1;

--- a/src/ui/components/Header/stylesheet.css
+++ b/src/ui/components/Header/stylesheet.css
@@ -124,20 +124,6 @@
     width: 100%;
   }
 
-  .nav:before {
-    position: absolute;
-    bottom: -50vw;
-    display: block;
-    width: 100%;
-    height: 50vw;
-    margin-top: -10px;
-    background: 50% 0% no-repeat;
-    background-image: url("data:image/svg+xml,%3Csvg width='320' height='148' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath fill='%23007df6' d='M0 0h320v10L240.5 148 0 10z' fill-rule='evenodd'/%3E%3C/svg%3E");
-    background-size: cover;
-    content: '';
-    clear: both;
-  }
-
   .nav-item,
   .work-with-us {
     float: left;
@@ -146,11 +132,25 @@
     transform: translate(-50%);
   }
 
-  .nav:after {
+  .links {
+    padding-top: 8rem;
+    background: var(--color-accent);
+  }
+
+  .links:after {
     float: none;
     clear: both;
     display: block;
     content: '';
+  }
+
+  .bottom {
+    background: var(--color-accent);
+    width: 100%;
+    padding-bottom: 50%;
+    margin-top: -1px;
+    clip-path: polygon(0 12.5%, 77.5% 100%, 100% 22.5%, 100% 0, 0 0);
+    -webkit-clip-path: polygon(0 12.5%, 77.5% 100%, 100% 22.5%, 100% 0, 0 0);
   }
 
   .nav-item,
@@ -175,7 +175,7 @@
     padding: 8rem 0 0;
   }
 
-  .nav {
+  .links {
     flex: 1 1 auto;
     display: flex;
     align-items: center;

--- a/src/ui/components/Header/template.hbs
+++ b/src/ui/components/Header/template.hbs
@@ -35,21 +35,25 @@
         </label>
       </div>
       <nav block:class="nav">
-        <a href="/services/" block:class="nav-item" block:active={{if (eq @active 'services') 'active'}} data-internal>
-          Services
-        </a>
-        <a href="/work/" block:class="nav-item" block:active={{if (eq @active 'work') 'active'}} data-internal>
-          Work
-        </a>
-        <a href="/why-simplabs/" block:class="nav-item" block:active={{if (eq @active 'about') 'active'}} data-internal>
-          Why simplabs
-        </a>
-        <a href="/blog/" block:class="nav-item" block:active={{if (eq @active 'blog') 'active'}} data-internal>
-          Blog
-        </a>
-        <a href="/contact/" block:class="work-with-us" block:active={{if (eq @active 'contact') 'active'}} data-internal>
-          Work with us
-        </a>
+        <div block:class="links">
+          <a href="/services/" block:class="nav-item" block:active={{if (eq @active 'services') 'active'}} data-internal>
+            Services
+          </a>
+          <a href="/work/" block:class="nav-item" block:active={{if (eq @active 'work') 'active'}} data-internal>
+            Work
+          </a>
+          <a href="/why-simplabs/" block:class="nav-item" block:active={{if (eq @active 'about') 'active'}} data-internal>
+            Why simplabs
+          </a>
+          <a href="/blog/" block:class="nav-item" block:active={{if (eq @active 'blog') 'active'}} data-internal>
+            Blog
+          </a>
+          <a href="/contact/" block:class="work-with-us" block:active={{if (eq @active 'contact') 'active'}} data-internal>
+            Work with us
+          </a>
+        </div>
+        <div block:class="bottom">
+        </div>
       </nav>
     </div>
   </div>


### PR DESCRIPTION
This rebuilds the mobile menu with `clip-path` instead of relying on SVG which fixes #916 and is something we'd want to do after #849 anyway with which we convert all of the angled shapes from SVG to `clip-path`. The menu looks and works all the same as before but instead of having a shaped SVG background image, we use an additional `div` at the bottom with a background color and `clip-path`.

![localhost_4200_(Pixel 2 XL)](https://user-images.githubusercontent.com/1510/75767531-416bd780-5d43-11ea-98ad-4a4c3c75c299.png)

closes #916 