### PR TITLE
Fix uneven layout

### DIFF
--- a/lib/global-css/css/baseline.css
+++ b/lib/global-css/css/baseline.css
@@ -2,8 +2,8 @@
   --base-scale: calc(6 / 8);
 
   /* Sizing */
-  --col: calc(128 / 1440 * 100vw);
-  --col-gap: 8rem;
+  --col: calc(156 / 1440 * 100vw);
+  --col-gap: 3rem;
   --max-width: calc(var(--col) * 6 + var(--col-gap) * 5);
 
   --col-1: var(--col);
@@ -13,7 +13,7 @@
   --col-5: calc(var(--col) * 5 + var(--col-gap) * 4);
   --col-6: calc(var(--col) * 6 + var(--col-gap) * 5);
 
-  --col-max: 16rem;
+  --col-max: 19.5rem;
   --offset-horizontal: 8rem;
 
   --grid-template-columns: minmax(var(--offset-horizontal), 1fr) repeat(6, minmax(var(--col), var(--col-max)))

--- a/src/ui/components/PageHomepage/stylesheet.css
+++ b/src/ui/components/PageHomepage/stylesheet.css
@@ -11,9 +11,9 @@
 .logos-list {
   display: flex;
   width: calc(100% + var(--offset-horizontal));
-  flex-flow: nowrap;
+  justify-content: center;
+  flex-flow: wrap;
   align-items: center;
-  justify-content: space-between;
   margin: 0 calc(var(--offset-horizontal) / -2) 6rem;
 }
 
@@ -29,13 +29,10 @@
 }
 
 @media (max-width: 888px) {
-  .logos-list {
-    justify-content: center;
-    flex-flow: wrap;
-  }
   .logos-logo {
     padding: 2rem;
   }
+
   .padding-right-1 {
     padding-right: 0;
   }

--- a/src/ui/components/ShapeFeature/stylesheet.css
+++ b/src/ui/components/ShapeFeature/stylesheet.css
@@ -88,7 +88,7 @@
 
 @media (min-width: 888px) {
   :scope {
-    margin: 4rem calc(-1 * var(--offset-horizontal));
+    margin: 4rem 0;
     grid-column: 2/-2;
   }
 


### PR DESCRIPTION
This fixes the horizontally uneven layout of the website revamp:

<img width="996" alt="Bildschirmfoto 2020-03-06 um 17 00 32" src="https://user-images.githubusercontent.com/1510/76101144-3678a780-5fce-11ea-9040-9fc716fc487b.png">

Currently there is more whitespace to the left than to the right. This PR fixes that by reverting the [layout changes made in the `website-revamp` branch](https://github.com/simplabs/simplabs.github.io/commit/b44fe791c67247a991b78ebd19e830ff6e15ba6e). It also fixes the alignment of the client logos which were bleeding out of the main content area – this is likely broken on the current production page already but not as visible since there is a different kind of shape above the logos which bleeds until the sides of the viewport anyway.

closes #936 