### PR TITLE
Fix feature shape on mobile viewport

### DIFF
--- a/src/ui/components/ShapeFeature/stylesheet.css
+++ b/src/ui/components/ShapeFeature/stylesheet.css
@@ -34,11 +34,10 @@
   display: block;
   margin-top: -20rem;
   margin-bottom: 5rem;
-  margin-left: -4rem;
 
   clip-path: polygon(31% 0, 100% 30%, 100% 80%, 60% 100%, 0 86%, 0 10%);
   -webkit-clip-path: polygon(31% 0, 100% 30%, 100% 80%, 60% 100%, 0 86%, 0 10%);
-  grid-column: 1/-1;
+  grid-column: 2/-2;
 }
 
 .bottom,
@@ -103,6 +102,7 @@
   }
 
   .img-wrapper {
+    margin-left: -4rem;
     grid-column: 1/5;
   }
 


### PR DESCRIPTION
Part of https://github.com/simplabs/simplabs.github.io/issues/905.

The `ShapeFeature` component was not properly aligned to the grid on mobile viewports.
This PR address that in the least impactful way.

Before:
<img width="499" alt="image" src="https://user-images.githubusercontent.com/32344/76217237-f6056d80-6209-11ea-8a3f-fdc62ad2d433.png">

After:
<img width="492" alt="image" src="https://user-images.githubusercontent.com/32344/76217078-a9219700-6209-11ea-8c1d-b7ca09cf4f54.png">
