### PR TITLE
Fix quote shape on mobile

### DIFF
--- a/lib/global-css/css/baseline.css
+++ b/lib/global-css/css/baseline.css
@@ -16,7 +16,8 @@
   --col-max: 19.5rem;
   --offset-horizontal: 8rem;
 
-  --grid-template-columns: minmax(var(--offset-horizontal), 1fr) repeat(6, minmax(var(--col), var(--col-max)))
+  --grid-content-columns: repeat(6, minmax(var(--col), var(--col-max)));
+  --grid-template-columns: minmax(var(--offset-horizontal), 1fr) var(--grid-content-columns)
     minmax(var(--offset-horizontal), 1fr);
 
   /* Spacing */

--- a/src/ui/components/PageServices/template.hbs
+++ b/src/ui/components/PageServices/template.hbs
@@ -70,7 +70,7 @@
       </p>
     </div>
   </div>
-  <div layout:class="full" offset:class="after-21">
+  <div layout:scope offset:class="after-21">
     <ShapeQuoteTimify />
   </div>
   <div layout:class="full" offset:class="after-12">

--- a/src/ui/components/ShapeFeature/stylesheet.css
+++ b/src/ui/components/ShapeFeature/stylesheet.css
@@ -13,8 +13,9 @@
 }
 
 .container {
-  margin-bottom: 0;
-  composes: 'layout';
+  display: grid;
+  column-gap: var(--col-gap);
+  grid-column: 1/-1;
 }
 
 .content {
@@ -88,6 +89,10 @@
     grid-column: 2/-2;
     margin-left: 0;
   }
+
+  .container {
+    grid-template-columns: var(--grid-template-columns);
+  }
 }
 
 @media (min-width: 888px) {
@@ -97,7 +102,7 @@
   }
 
   .container {
-    margin: 0;
+    grid-template-columns: var(--grid-content-columns);
   }
 
   .top {
@@ -108,11 +113,12 @@
 
   .img-wrapper {
     margin-left: -4rem;
-    grid-column: 1/5;
+    grid-column: 1/4;
   }
 
   .content {
-    grid-column: -3/5;
+    grid-column: 4/-1;
+    padding: 5rem;
   }
 
   .tagline {

--- a/src/ui/components/ShapeFeature/stylesheet.css
+++ b/src/ui/components/ShapeFeature/stylesheet.css
@@ -118,7 +118,7 @@
 
   .content {
     grid-column: 4/-1;
-    padding: 5rem;
+    padding: 5rem 5rem 0 5rem;
   }
 
   .tagline {

--- a/src/ui/components/ShapeFeature/stylesheet.css
+++ b/src/ui/components/ShapeFeature/stylesheet.css
@@ -83,6 +83,11 @@
   :scope {
     margin: 16rem 0;
   }
+
+  .img-wrapper {
+    grid-column: 2/-2;
+    margin-left: 0;
+  }
 }
 
 @media (min-width: 888px) {

--- a/src/ui/components/ShapeFeature/template.hbs
+++ b/src/ui/components/ShapeFeature/template.hbs
@@ -2,7 +2,7 @@
   <div block:class="top"></div>
   <div block:class="middle">
     {{#if @srcset}}
-      <figure block:class="container" layout:scope>
+      <figure block:class="container">
         <div block:class="img-wrapper">
           <img
             block:class="img"
@@ -18,7 +18,7 @@
         </figcaption>
       </figure>
     {{else}}
-      <div block:class="container" layout:scope>
+      <div block:class="container">
         <p block:class="content">
           {{yield}}
         </p>


### PR DESCRIPTION
This fixes the quote shape on mobile and also fixes the alignment on bigger viewports. Previously the content did not really fit in with our general grid layout which this PR fixes:

![localhost_4200_services_](https://user-images.githubusercontent.com/1510/76225830-56ea7100-621d-11ea-8975-27601f1f6765.png)


<img width="1063" alt="Bildschirmfoto 2020-03-09 um 15 47 14" src="https://user-images.githubusercontent.com/1510/76225820-53ef8080-621d-11ea-8e52-4380505f844e.png">

closes #941 