### PR TITLE
Revert "Remove open source block from product development page"

### DIFF
--- a/src/ui/components/PageProductDevelopment/template.hbs
+++ b/src/ui/components/PageProductDevelopment/template.hbs
@@ -91,7 +91,7 @@
       Learn how we work
     </ArrowLink>
   </div>
-  <div layout:class="full" offset:class="after-12">
+  <div layout:class="full" offset:class="after-21">
     <h2>
       We love open source &mdash; we’re the leading Ember.js team in Europe
     </h2>

--- a/src/ui/components/PageProductDevelopment/template.hbs
+++ b/src/ui/components/PageProductDevelopment/template.hbs
@@ -91,6 +91,14 @@
       Learn how we work
     </ArrowLink>
   </div>
+  <div layout:class="full" offset:class="after-12">
+    <h2>
+      We love open source &mdash; we’re the leading Ember.js team in Europe
+    </h2>
+    <p typography:class="lead">
+      We co-host EmberFest (the biggest Ember.js conference in Europe) and we actively contribute to the open source projects we're leveraging for our projects.
+    </p>
+  </div>
   <WorkWithUs @teamMember="chris" />
   <Footer />
 </div>


### PR DESCRIPTION
Reverts simplabs/simplabs.github.io#935.

It seems like the designs were not up to date with the latest marketing content and this block should not have been removed.