### PR TITLE
Add Trainline quote shape

### DIFF
--- a/src/ui/components/PageServices/template.hbs
+++ b/src/ui/components/PageServices/template.hbs
@@ -130,6 +130,9 @@
       Learn more
     </ArrowLink>
   </div>
+  <div layout:scope offset:class="after-21">
+    <ShapeQuoteTrainline />
+  </div>
   <div layout:class="full" offset:class="after-21">
     <h3 typography:class="h3">
       <small typography:class="small">

--- a/src/ui/components/ShapeQuoteTrainline/component-test.ts
+++ b/src/ui/components/ShapeQuoteTrainline/component-test.ts
@@ -1,0 +1,15 @@
+import hbs from '@glimmer/inline-precompile';
+import { render } from '@glimmer/test-helpers';
+import { setupRenderingTest } from '../../../utils/test-helpers/setup-rendering-test';
+
+const { module, test } = QUnit;
+
+module('Component: ShapeQuoteTrainline', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`<ShapeQuoteTrainline />`);
+
+    assert.ok(this.containerElement.querySelector('q'));
+  });
+});

--- a/src/ui/components/ShapeQuoteTrainline/stylesheet.css
+++ b/src/ui/components/ShapeQuoteTrainline/stylesheet.css
@@ -1,0 +1,7 @@
+@block typography from "../../styles/blocks/typography.block.css";
+
+:scope {
+  block-name: ShapeQuoteTrainline;
+}
+
+@export typography;

--- a/src/ui/components/ShapeQuoteTrainline/template.hbs
+++ b/src/ui/components/ShapeQuoteTrainline/template.hbs
@@ -1,0 +1,14 @@
+<ShapeFeature
+  @srcset="/assets/images/photos/trainline-comp@604.jpg 604w, /assets/images/photos/trainline-comp@1208.jpg 1208w"
+  @sizes="(max-width: 887px) 604px, 1208px"
+  @srcAlt="Trainline"
+>
+  <p>
+    <q typography:class="quote" lang="en">
+      We started working with simplabs to build a state-of-the-art mobile web app from the ground up and it was an absolute success! Not only are they web specialists, but their expertise in development practices and agile processes made our collaboration an absolute delight.
+    </q>
+  </p>
+  <p typography:class="small">
+    Carl Andersson, General Manager of Trainline international
+  </p>
+</ShapeFeature>


### PR DESCRIPTION
This adds a Trainline quote shape with a quote from Carl Andersson to the _"Services"_ page:

![localhost_4200_services_](https://user-images.githubusercontent.com/1510/76304663-0a0da580-62c4-11ea-9f9a-0ca5bbeb917f.png)

closes #945 