### PR TITLE
fix angles of feature shape image wrapper

### DIFF
--- a/src/ui/components/ShapeFeature/stylesheet.css
+++ b/src/ui/components/ShapeFeature/stylesheet.css
@@ -36,8 +36,8 @@
   margin-top: -20rem;
   margin-bottom: 5rem;
 
-  clip-path: polygon(31% 0, 100% 30%, 100% 80%, 60% 100%, 0 86%, 0 10%);
-  -webkit-clip-path: polygon(31% 0, 100% 30%, 100% 80%, 60% 100%, 0 86%, 0 10%);
+  clip-path: polygon(31% 0, 100% 20%, 100% 92%, 60% 100%, 0 90%, 0 7%);
+  -webkit-clip-path: polygon(31% 0, 100% 20%, 100% 92%, 60% 100%, 0 90%, 0 7%);
   grid-column: 2/-2;
 }
 
@@ -84,6 +84,8 @@
   .img-wrapper {
     grid-column: 2/-2;
     margin-left: 0;
+    clip-path: polygon(31% 0, 100% 30%, 100% 88%, 60% 100%, 0 87%, 0 10%);
+    -webkit-clip-path: polygon(31% 0, 100% 30%, 100% 88%, 60% 100%, 0 87%, 0 10%);
   }
 
   .container {


### PR DESCRIPTION
This fixes the angles of the shape for the image wrapper on the `ShapeFeature` component.

### Before

<img width="829" alt="Bildschirmfoto 2020-03-10 um 12 08 01" src="https://user-images.githubusercontent.com/1510/76307936-10068500-62ca-11ea-8e16-774c7accf8d5.png">

### After

<img width="948" alt="Bildschirmfoto 2020-03-10 um 12 23 13" src="https://user-images.githubusercontent.com/1510/76307947-14cb3900-62ca-11ea-8a2d-81cf4ee23c19.png">

closes #955 