### PR TITLE
Tweak offsets for digital products page sections

### DIFF
--- a/src/ui/components/PageDigitalProducts/template.hbs
+++ b/src/ui/components/PageDigitalProducts/template.hbs
@@ -39,7 +39,7 @@
       @align="left"
     />
   </div>
-  <div layout:class="split-trailing" offset:class="after-16">
+  <div layout:class="split-trailing" offset:class="after-21">
     <ul list:class="vertical">
       <li list:class="vertical-item">
         Market validation
@@ -75,7 +75,7 @@
       Great product design combined with outspoken aesthetic elements will make your new digital product remarkable and unique, as well as drive activation and engagement. Great user experiences can position your product uniquely in the market, and win both raving fans and loyal audiences.
     </p>
   </div>
-  <div layout:class="split-leading" offset:class="after-21">
+  <div layout:class="split-leading" offset:class="after-16">
     <ul list:class="vertical">
       <li list:class="vertical-item">
         Wireframing & prototyping
@@ -100,7 +100,7 @@
       Explore our design process
     </ArrowLink>
   </div>
-  <div layout:class="bleed-right" offset:class="after-16">
+  <div layout:class="bleed-right" offset:class="after-21">
     <ShapeImage
       @srcset="/assets/images/photos/ui-sketching@600.jpg 600w, /assets/images/photos/ui-sketching@1200.jpg 1200w"
       @sizes="(max-width: 887px) 600px, 1200px)"
@@ -118,14 +118,14 @@
       Involve our senior engineers to quickly establish all required functionalities for your app. Engineering is our true passion, and unmistakable in every product we deliver.
     </p>
   </div>
-  <div layout:class="bleed-left" offset:class="after-12">
+  <div layout:class="bleed-left" offset:class="after-16">
     <ShapeImage
       @srcset="/assets/images/photos/team-coding@600.jpg 600w, /assets/images/photos/team-coding@1200.jpg 1200w"
       @sizes="(max-width: 887px) 600px, 1200px)"
       @align="left"
     />
   </div>
-  <div layout:class="split-trailing" offset:class="after-12">
+  <div layout:class="split-trailing" offset:class="after-21">
     <ul list:class="vertical">
       <li list:class="vertical-item">
         Full-stack development

--- a/src/ui/components/PageProductDesign/template.hbs
+++ b/src/ui/components/PageProductDesign/template.hbs
@@ -58,7 +58,7 @@
       Book a call with a designer
     </ArrowLink>
   </div>
-  <div layout:class="bleed-right" offset:class="after-16">
+  <div layout:class="bleed-right" offset:class="after-21">
     <ShapeImage
       @srcset="/assets/images/photos/wireframe@600.jpg 600w, /assets/images/photos/wireframe@1200.jpg 1200w"
       @sizes="(max-width: 887px) 600px, 1200px)"

--- a/src/ui/components/PageProductDevelopment/template.hbs
+++ b/src/ui/components/PageProductDevelopment/template.hbs
@@ -58,7 +58,7 @@
       Talk to an engineer
     </ArrowLink>
   </div>
-  <div layout:class="bleed-right" offset:class="after-16">
+  <div layout:class="bleed-right" offset:class="after-21">
     <ShapeImage
       @srcset="/assets/images/photos/ember-simple-auth@600.jpg 600w, /assets/images/photos/ember-simple-auth@1200.jpg 1200w"
       @sizes="(max-width: 887px) 600px, 1200px)"

--- a/src/ui/components/PageServices/template.hbs
+++ b/src/ui/components/PageServices/template.hbs
@@ -123,7 +123,7 @@
       Learn more
     </ArrowLink>
   </div>
-  <div layout:class="bleed-right" offset:class="after-16">
+  <div layout:class="bleed-right" offset:class="after-21">
     <ShapeImage
       @srcset="/assets/images/photos/sketching-table@600.jpg 600w, /assets/images/photos/sketching-table@1200.jpg 1200w"
       @sizes="(max-width: 887px) 600px, 1200px)"

--- a/src/ui/components/PageTeamAugmentation/template.hbs
+++ b/src/ui/components/PageTeamAugmentation/template.hbs
@@ -58,7 +58,7 @@
       Read more on the blog
     </ArrowLink>
   </div>
-  <div layout:class="bleed-right" offset:class="after-16">
+  <div layout:class="bleed-right" offset:class="after-21">
     <ShapeImage
       @srcset="/assets/images/photos/kanban@600.jpg 600w, /assets/images/photos/kanban@1200.jpg 1200w"
       @sizes="(max-width: 887px) 600px, 1200px)"

--- a/src/ui/components/PageTutoring/template.hbs
+++ b/src/ui/components/PageTutoring/template.hbs
@@ -49,7 +49,7 @@
       The needs of every team are unique, and so are our tutoring and training solutions. We cover covering technology stacks from Ruby on Rails to Ember.js and Elixir/Phoenix.
     </p>
   </div>
-  <div layout:class="bleed-right" offset:class="after-16">
+  <div layout:class="bleed-right" offset:class="after-21">
     <ShapeImage
       @srcset="/assets/images/photos/tutoring-content@600.jpg 600w, /assets/images/photos/tutoring-content@1200.jpg 1200w"
       @sizes="(max-width: 887px) 600px, 1200px)"


### PR DESCRIPTION
Fixes offsets for clipped images blocks.

- Made `bleed-left` and `split-leading` blocks have an offset of `after-16`
- Made `bleed-right` and `split-trailing` blocks have an offset of `after-21`

Closes https://github.com/simplabs/simplabs.github.io/issues/958.