### PR TITLE
Extract clipped image shapes into ShapeImage component

### DIFF
--- a/src/ui/components/PageDigitalProducts/template.hbs
+++ b/src/ui/components/PageDigitalProducts/template.hbs
@@ -33,14 +33,11 @@
     </p>
   </div>
   <div layout:class="bleed-left" offset:class="after-16">
-    <div fluid-image:class="clipped-left">
-      <img
-        fluid-image:class="clipped-image"
-        srcset="/assets/images/photos/sketching@600.jpg 600w, /assets/images/photos/sketching@1200.jpg 1200w"
-        sizes="(max-width: 887px) 600px, 1200px)"
-        alt=""
-      />
-    </div>
+    <ShapeImage
+      @srcset="/assets/images/photos/sketching@600.jpg 600w, /assets/images/photos/sketching@1200.jpg 1200w"
+      @sizes="(max-width: 887px) 600px, 1200px)"
+      @align="left"
+    />
   </div>
   <div layout:class="split-trailing" offset:class="after-16">
     <ul list:class="vertical">
@@ -104,14 +101,11 @@
     </ArrowLink>
   </div>
   <div layout:class="bleed-right" offset:class="after-16">
-    <div fluid-image:class="clipped-right">
-      <img
-        fluid-image:class="clipped-image"
-        srcset="/assets/images/photos/ui-sketching@600.jpg 600w, /assets/images/photos/ui-sketching@1200.jpg 1200w"
-        sizes="(max-width: 887px) 600px, 1200px)"
-        alt=""
-      />
-    </div>
+    <ShapeImage
+      @srcset="/assets/images/photos/ui-sketching@600.jpg 600w, /assets/images/photos/ui-sketching@1200.jpg 1200w"
+      @sizes="(max-width: 887px) 600px, 1200px)"
+      @align="right"
+    />
   </div>
   <div layout:class="full" offset:class="after-12">
     <h3 typography:class="h3">
@@ -125,14 +119,11 @@
     </p>
   </div>
   <div layout:class="bleed-left" offset:class="after-12">
-    <div fluid-image:class="clipped-left">
-      <img
-        fluid-image:class="clipped-image"
-        srcset="/assets/images/photos/team-coding@600.jpg 600w, /assets/images/photos/team-coding@1200.jpg 1200w"
-        sizes="(max-width: 887px) 600px, 1200px)"
-        alt=""
-      />
-    </div>
+    <ShapeImage
+      @srcset="/assets/images/photos/team-coding@600.jpg 600w, /assets/images/photos/team-coding@1200.jpg 1200w"
+      @sizes="(max-width: 887px) 600px, 1200px)"
+      @align="left"
+    />
   </div>
   <div layout:class="split-trailing" offset:class="after-12">
     <ul list:class="vertical">

--- a/src/ui/components/PageProductDesign/template.hbs
+++ b/src/ui/components/PageProductDesign/template.hbs
@@ -59,14 +59,11 @@
     </ArrowLink>
   </div>
   <div layout:class="bleed-right" offset:class="after-16">
-    <div fluid-image:class="clipped-right">
-      <img
-        fluid-image:class="clipped-image"
-        srcset="/assets/images/photos/wireframe@600.jpg 600w, /assets/images/photos/wireframe@1200.jpg 1200w"
-        sizes="(max-width: 887px) 600px, 1200px)"
-        alt=""
-      />
-    </div>
+    <ShapeImage
+      @srcset="/assets/images/photos/wireframe@600.jpg 600w, /assets/images/photos/wireframe@1200.jpg 1200w"
+      @sizes="(max-width: 887px) 600px, 1200px)"
+      @align="right"
+    />
   </div>
   <div layout:class="full" offset:class="after-12">
     <h2>
@@ -77,14 +74,11 @@
     </p>
   </div>
   <div layout:class="bleed-left" offset:class="after-16">
-    <div fluid-image:class="clipped-left">
-      <img
-        fluid-image:class="clipped-image"
-        srcset="/assets/images/photos/whiteboard@600.jpg 600w, /assets/images/photos/whiteboard@1200.jpg 1200w"
-        sizes="(max-width: 887px) 600px, 1200px)"
-        alt=""
-      />
-    </div>
+    <ShapeImage
+      @srcset="/assets/images/photos/whiteboard@600.jpg 600w, /assets/images/photos/whiteboard@1200.jpg 1200w"
+      @sizes="(max-width: 887px) 600px, 1200px)"
+      @align="left"
+    />
   </div>
   <div layout:class="split-trailing" offset:class="after-12">
     <ul list:class="vertical">

--- a/src/ui/components/PageProductDevelopment/template.hbs
+++ b/src/ui/components/PageProductDevelopment/template.hbs
@@ -59,14 +59,11 @@
     </ArrowLink>
   </div>
   <div layout:class="bleed-right" offset:class="after-16">
-    <div fluid-image:class="clipped-right">
-      <img
-        fluid-image:class="clipped-image"
-        srcset="/assets/images/photos/ember-simple-auth@600.jpg 600w, /assets/images/photos/ember-simple-auth@1200.jpg 1200w"
-        sizes="(max-width: 887px) 600px, 1200px)"
-        alt=""
-      />
-    </div>
+    <ShapeImage
+      @srcset="/assets/images/photos/ember-simple-auth@600.jpg 600w, /assets/images/photos/ember-simple-auth@1200.jpg 1200w"
+      @sizes="(max-width: 887px) 600px, 1200px)"
+      @align="right"
+    />
   </div>
   <div layout:class="full" offset:class="after-12">
     <h2>
@@ -77,14 +74,11 @@
     </p>
   </div>
   <div layout:class="bleed-left" offset:class="after-16">
-    <div fluid-image:class="clipped-left">
-      <img
-        fluid-image:class="clipped-image"
-        srcset="/assets/images/photos/marco-computer@600.jpg 600w, /assets/images/photos/marco-computer@1200.jpg 1200w"
-        sizes="(max-width: 887px) 600px, 1200px)"
-        alt=""
-      />
-    </div>
+    <ShapeImage
+      @srcset="/assets/images/photos/marco-computer@600.jpg 600w, /assets/images/photos/marco-computer@1200.jpg 1200w"
+      @sizes="(max-width: 887px) 600px, 1200px)"
+      @align="left"
+    />
   </div>
   <div layout:class="split-trailing" offset:class="after-21">
     <ul list:class="vertical" offset:class="after-5">

--- a/src/ui/components/PageServices/template.hbs
+++ b/src/ui/components/PageServices/template.hbs
@@ -124,14 +124,11 @@
     </ArrowLink>
   </div>
   <div layout:class="bleed-right" offset:class="after-16">
-    <div fluid-image:class="clipped-right">
-      <img
-        fluid-image:class="clipped-image"
-        srcset="/assets/images/photos/sketching-table@600.jpg 600w, /assets/images/photos/sketching-table@1200.jpg 1200w"
-        sizes="(max-width: 887px) 600px, 1200px)"
-        alt=""
-      />
-    </div>
+    <ShapeImage
+      @srcset="/assets/images/photos/sketching-table@600.jpg 600w, /assets/images/photos/sketching-table@1200.jpg 1200w"
+      @sizes="(max-width: 887px) 600px, 1200px)"
+      @align="right"
+    />
   </div>
   <div layout:class="full" offset:class="after-12">
     <h3 typography:class="h3">

--- a/src/ui/components/PageTeamAugmentation/template.hbs
+++ b/src/ui/components/PageTeamAugmentation/template.hbs
@@ -59,14 +59,11 @@
     </ArrowLink>
   </div>
   <div layout:class="bleed-right" offset:class="after-16">
-    <div fluid-image:class="clipped-right">
-      <img
-        fluid-image:class="clipped-image"
-        srcset="/assets/images/photos/kanban@600.jpg 600w, /assets/images/photos/kanban@1200.jpg 1200w"
-        sizes="(max-width: 887px) 600px, 1200px)"
-        alt=""
-      />
-    </div>
+    <ShapeImage
+      @srcset="/assets/images/photos/kanban@600.jpg 600w, /assets/images/photos/kanban@1200.jpg 1200w"
+      @sizes="(max-width: 887px) 600px, 1200px)"
+      @align="right"
+    />
   </div>
   <div layout:class="full" offset:class="after-21">
     <h2>

--- a/src/ui/components/PageTutoring/template.hbs
+++ b/src/ui/components/PageTutoring/template.hbs
@@ -50,14 +50,11 @@
     </p>
   </div>
   <div layout:class="bleed-right" offset:class="after-16">
-    <div fluid-image:class="clipped-right">
-      <img
-        fluid-image:class="clipped-image"
-        srcset="/assets/images/photos/tutoring-content@600.jpg 600w, /assets/images/photos/tutoring-content@1200.jpg 1200w"
-        sizes="(max-width: 887px) 600px, 1200px)"
-        alt=""
-      />
-    </div>
+    <ShapeImage
+      @srcset="/assets/images/photos/tutoring-content@600.jpg 600w, /assets/images/photos/tutoring-content@1200.jpg 1200w"
+      @sizes="(max-width: 887px) 600px, 1200px)"
+      @align="right"
+    />
   </div>
   <WorkWithUs @teamMember="ricardo" />
   <Footer />

--- a/src/ui/components/ShapeImage/component-test.ts
+++ b/src/ui/components/ShapeImage/component-test.ts
@@ -1,0 +1,15 @@
+import hbs from '@glimmer/inline-precompile';
+import { render } from '@glimmer/test-helpers';
+import { setupRenderingTest } from '../../../utils/test-helpers/setup-rendering-test';
+
+const { module, test } = QUnit;
+
+module('Component: ShapeImage', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`<ShapeImage />`);
+
+    assert.ok(this.containerElement.querySelector('div'));
+  });
+});

--- a/src/ui/components/ShapeImage/stylesheet.css
+++ b/src/ui/components/ShapeImage/stylesheet.css
@@ -1,0 +1,23 @@
+@block fluid-image from "../../styles/blocks/fluid-image.block.css";
+
+:scope {
+  block-name: ShapeImage;
+
+  position: relative;
+  background-color: #ccc;
+  width: 100%;
+  height: auto;
+  padding-bottom: 100%;
+}
+
+:scope[align='left'] {
+  -webkit-clip-path: polygon(100% 20%, 100% 80%, 30% 100%, 0 95%, 0 0);
+  clip-path: polygon(100% 20%, 100% 80%, 30% 100%, 0 95%, 0 0);
+}
+
+:scope[align='right'] {
+  -webkit-clip-path: polygon(80% 0, 100% 5%, 100% 100%, 0 80%, 0 20%);
+  clip-path: polygon(80% 0, 100% 5%, 100% 100%, 0 80%, 0 20%);
+}
+
+@export fluid-image;

--- a/src/ui/components/ShapeImage/template.hbs
+++ b/src/ui/components/ShapeImage/template.hbs
@@ -1,6 +1,6 @@
 <div block:scope block:align={{@align}}>
   <img
-    fluid-image:class="clipped-image"
+    fluid-image:class="image-clipped"
     srcset="/assets/images/photos/sketching@600.jpg 600w, /assets/images/photos/sketching@1200.jpg 1200w"
     sizes="(max-width: 887px) 600px, 1200px)"
     alt=""

--- a/src/ui/components/ShapeImage/template.hbs
+++ b/src/ui/components/ShapeImage/template.hbs
@@ -1,0 +1,8 @@
+<div block:scope block:align={{@align}}>
+  <img
+    fluid-image:class="clipped-image"
+    srcset="/assets/images/photos/sketching@600.jpg 600w, /assets/images/photos/sketching@1200.jpg 1200w"
+    sizes="(max-width: 887px) 600px, 1200px)"
+    alt=""
+  />
+</div>

--- a/src/ui/styles/blocks/fluid-image.block.css
+++ b/src/ui/styles/blocks/fluid-image.block.css
@@ -14,7 +14,7 @@
   object-fit: cover;
 }
 
-.clipped-image {
+.image-clipped {
   position: absolute;
   width: 100%;
   height: 100%;

--- a/src/ui/styles/blocks/fluid-image.block.css
+++ b/src/ui/styles/blocks/fluid-image.block.css
@@ -14,26 +14,6 @@
   object-fit: cover;
 }
 
-.clipped-right {
-  position: relative;
-  background-color: #ccc;
-  width: 100%;
-  height: auto;
-  padding-bottom: 100%;
-  -webkit-clip-path: polygon(80% 0, 100% 5%, 100% 100%, 0 80%, 0 20%);
-  clip-path: polygon(80% 0, 100% 5%, 100% 100%, 0 80%, 0 20%);
-}
-
-.clipped-left {
-  position: relative;
-  background-color: #ccc;
-  width: 100%;
-  height: auto;
-  padding-bottom: 100%;
-  -webkit-clip-path: polygon(100% 20%, 100% 80%, 30% 100%, 0 95%, 0 0);
-  clip-path: polygon(100% 20%, 100% 80%, 30% 100%, 0 95%, 0 0);
-}
-
 .clipped-image {
   position: absolute;
   width: 100%;


### PR DESCRIPTION
As a cleanup, I extracted the clipped images left and right-aligned shapes into a ShapeImage component. This implementation is using the cssblocks state feature to define which side the image should align to.
This aligns with what we do with other shapes, help prevent copy-paste mistakes, and allow changes to one location to spread to all usages of the component.

There should be no visual changes.