### PR TITLE
add missing spacing before Trainline quote

### DIFF
--- a/src/ui/components/PageServices/template.hbs
+++ b/src/ui/components/PageServices/template.hbs
@@ -133,7 +133,7 @@
       />
     </div>
   </div>
-  <div layout:class="full" offset:class="after-12">
+  <div layout:class="full" offset:class="after-21">
     <h3 typography:class="h3">
       <small typography:class="small">
         Team Augmentation


### PR DESCRIPTION
This adds missing space between the paragraph about our team augmentation offering and the following Trainline quote.

### Before

![76396222-11db5180-6379-11ea-95a1-06fdf9e3e889](https://user-images.githubusercontent.com/1510/76397490-70093400-637b-11ea-9b2c-3113b4d55ad9.png)


### After

![localhost_4200_(iPhone X)](https://user-images.githubusercontent.com/1510/76397514-7a2b3280-637b-11ea-8385-b1a0fd8ed72a.png)

closes #964 