### PR TITLE
Fix mobile menu problem with ShapeFeature

### DIFF
--- a/src/ui/components/ShapeFeature/stylesheet.css
+++ b/src/ui/components/ShapeFeature/stylesheet.css
@@ -9,7 +9,6 @@
   --shape-color: var(--color-accent);
   block-name: ShapeFeature;
   grid-column: 1/-1;
-  z-index: 100;
 }
 
 .container {


### PR DESCRIPTION
This fixes the mobile menu underflowing a subsequent `<ShapeFeature>` component by removing an unnecessary `z-index` from `<ShapeFeature>` that puts it above most/all other elements on the site. That `z-index` should not be needed at all and I could not find any usages of `<ShapeFeature>` that break without it.

### Before

![76396365-56ff8380-6379-11ea-94df-84d5a156cf96](https://user-images.githubusercontent.com/1510/76398295-eeb2a100-637c-11ea-8a1c-7e6e2b868f9a.png)

### After

![localhost_4200_blog_2019_04_05_spas-pwas-and-ssr(iPhone X)](https://user-images.githubusercontent.com/1510/76398307-f2462800-637c-11ea-8ba9-67a5aa73cddc.png)


closes #965 