### PR TITLE
Fix hard-coded values in ShapeImage component

### DIFF
--- a/src/ui/components/ShapeImage/template.hbs
+++ b/src/ui/components/ShapeImage/template.hbs
@@ -1,8 +1,3 @@
 <div block:scope block:align={{@align}}>
-  <img
-    fluid-image:class="image-clipped"
-    srcset="/assets/images/photos/sketching@600.jpg 600w, /assets/images/photos/sketching@1200.jpg 1200w"
-    sizes="(max-width: 887px) 600px, 1200px)"
-    alt=""
-  />
+  <img fluid-image:class="image-clipped" srcset={{@srcset}} sizes={{@sizes}} alt="" />
 </div>


### PR DESCRIPTION
ShapeImage was [merged](https://github.com/simplabs/simplabs.github.io/pull/959) with hard-coded values, and as such all clipped images were the same.
This PR addressed that by using the named arguments passed instead.