### PR TITLE
Fix shape feature margins

### DIFF
--- a/src/ui/components/Header/stylesheet.css
+++ b/src/ui/components/Header/stylesheet.css
@@ -6,7 +6,7 @@
   position: relative;
   grid-column: 1/-1;
   composes: 'layout';
-  margin-bottom: 10rem;
+  margin-bottom: 16rem;
 }
 
 .navbar {
@@ -125,6 +125,10 @@
 }
 
 @media (max-width: 887px) {
+  :scope {
+    margin-bottom: 12rem;
+  }
+
   :scope,
   .navbar,
   .wrapper {
@@ -192,10 +196,6 @@
   .nav-item[active],
   .work-with-us[active] {
     box-shadow: 0 calc(2rem + 2px) 0 -2rem var(--color-link-inverted);
-  }
-
-  :scope[backgroundVariation='pointed'] {
-    margin-bottom: 16rem;
   }
 
   :scope[backgroundVariation='pointed'] .background-bottom {

--- a/src/ui/components/PageElixirExpertise/template.hbs
+++ b/src/ui/components/PageElixirExpertise/template.hbs
@@ -20,7 +20,7 @@
       simplabs was an early adopter of Elixir and Phoenix, offering trainings and leveraging the potential of the stack for our clients. We support the Elixir Munich meetup, have been actively involved with conferences like ElixirConf and ElixirConf EU and are honored to be a Founding Sponsor of the Erlang Ecosystem Foundation.
     </p>
   </div>
-  <div layout:class="side">
+  <aside layout:class="side" offset:class="after-21">
     <Card
       @label="Community"
       @title="Elixir & Erlang Munich"
@@ -34,23 +34,25 @@
         Learn more
       </ArrowLink>
     </Card>
+  </aside>
+  <div layout:class="full" offset:class="after-21">
+    <ShapeFeature
+      @color="#231230"
+      @srcset="/assets/images/elixir/eef-sponsor@604.png 604w, /assets/images/elixir/eef-sponsor@1208.png 1208w"
+      @sizes="(max-width: 887px) 604px, 1208px"
+      @srcAlt="erlang ecosystem foundation logo"
+    >
+      <h2 typography:class="small">
+        News
+      </h2>
+      <h3>
+        simplabs is a Founding Sponsor of the Erlang Ecosystem Foundation.
+      </h3>
+      <ArrowLink @href="https://erlef.org">
+        Learn more
+      </ArrowLink>
+    </ShapeFeature>
   </div>
-  <ShapeFeature
-    @color="#231230"
-    @srcset="/assets/images/elixir/eef-sponsor@604.png 604w, /assets/images/elixir/eef-sponsor@1208.png 1208w"
-    @sizes="(max-width: 887px) 604px, 1208px"
-    @srcAlt="erlang ecosystem foundation logo"
-  >
-    <h2 typography:class="small">
-      News
-    </h2>
-    <h3>
-      simplabs is a Founding Sponsor of the Erlang Ecosystem Foundation.
-    </h3>
-    <ArrowLink @href="https://erlef.org">
-      Learn more
-    </ArrowLink>
-  </ShapeFeature>
   <div layout:class="main" offset:class="after-21">
     <h2>
       We share our expertise

--- a/src/ui/components/PageHomepage/template.hbs
+++ b/src/ui/components/PageHomepage/template.hbs
@@ -19,7 +19,7 @@
   <div layout:scope offset:class="after-21">
     <ShapeFeatureTrainline @label="Featured Case Study" />
 
-    <section layout:class="full">
+    <section layout:class="full" offset:class="before-5">
       <h2 typography:class="hidden">
         Selected clients
       </h2>

--- a/src/ui/components/ShapeFeature/stylesheet.css
+++ b/src/ui/components/ShapeFeature/stylesheet.css
@@ -2,7 +2,7 @@
 
 :scope {
   padding: 0;
-  margin: 0;
+  margin: 2rem 0 0 0;
   --color-muted: var(--color-text-inverted);
   --color-text: var(--color-text-inverted);
   --color-link: var(--color-text-inverted);
@@ -94,7 +94,6 @@
 
 @media (min-width: 888px) {
   :scope {
-    margin: 4rem 0;
     grid-column: 2/-2;
   }
 

--- a/src/ui/components/ShapeFeature/stylesheet.css
+++ b/src/ui/components/ShapeFeature/stylesheet.css
@@ -80,6 +80,10 @@
 }
 
 @media (max-width: 887px) {
+  :scope {
+    margin: 11rem 0 0 0;
+  }
+
   .img-wrapper {
     grid-column: 2/-2;
     margin-left: 0;

--- a/src/ui/styles/blocks/offset.block.css
+++ b/src/ui/styles/blocks/offset.block.css
@@ -28,6 +28,10 @@
   margin-top: 0;
 }
 
+.before-5 {
+  margin-top: 5rem;
+}
+
 .before-12 {
   margin-top: 12rem;
 }


### PR DESCRIPTION
This fixes the top margins of the `<ShapeFeature>` component to ensure it does not leak into preceding space by way of defining a negative margin on its image. That space is added back to the component itself as a top margin so that the bottom margin of the preceding element is respected correctly. This PR also changes some of the margins of preceding elements (in particular the `<Header>`) so the elements work correctly when succeeded by a `<ShapeFeature>`.

closes #969 