### PR TITLE
Make clipped images slightly taller

### DIFF
--- a/src/ui/components/ShapeImage/stylesheet.css
+++ b/src/ui/components/ShapeImage/stylesheet.css
@@ -7,17 +7,17 @@
   background-color: #ccc;
   width: 100%;
   height: auto;
-  padding-bottom: 100%;
+  padding-bottom: 120%;
 }
 
 :scope[align='left'] {
-  -webkit-clip-path: polygon(100% 20%, 100% 80%, 30% 100%, 0 95%, 0 0);
-  clip-path: polygon(100% 20%, 100% 80%, 30% 100%, 0 95%, 0 0);
+  -webkit-clip-path: polygon(100% 20%, 100% 91%, 30% 100%, 0 97%, 0 0);
+  clip-path: polygon(100% 20%, 100% 91%, 30% 100%, 0 97%, 0 0);
 }
 
 :scope[align='right'] {
-  -webkit-clip-path: polygon(80% 0, 100% 5%, 100% 100%, 0 80%, 0 20%);
-  clip-path: polygon(80% 0, 100% 5%, 100% 100%, 0 80%, 0 20%);
+  -webkit-clip-path: polygon(80% 0, 100% 5%, 100% 100%, 0 90%, 0 14%);
+  clip-path: polygon(80% 0, 100% 5%, 100% 100%, 0 90%, 0 14%);
 }
 
 @export fluid-image;


### PR DESCRIPTION
This makes the clipped images slightly taller which also requires updating the `clip-path`s since they are relative to the dimensions of the image. This is more in line with what we have designed in Abstract and uses the available space better.

### Before

<img width="985" alt="Bildschirmfoto 2020-03-11 um 11 11 19" src="https://user-images.githubusercontent.com/1510/76405867-1d367900-6389-11ea-8207-2a94ac6ff9d0.png">

### After

<img width="982" alt="Bildschirmfoto 2020-03-11 um 11 11 32" src="https://user-images.githubusercontent.com/1510/76405874-20ca0000-6389-11ea-9325-f3052acf3d47.png">

closes #960 