### PR TITLE
center left/right bleeding content vertically

### DIFF
--- a/src/ui/styles/blocks/layout.block.css
+++ b/src/ui/styles/blocks/layout.block.css
@@ -58,6 +58,12 @@
     grid-column: 1/-6;
   }
 
+  .bleed-left,
+  .bleed-right {
+    display: flex;
+    align-items: center;
+  }
+
   .content {
     grid-column: 3/-3;
   }


### PR DESCRIPTION
This centers the content of `bleed-left` and `bleed-right` columns vertically.

### Before 

<img width="997" alt="Bildschirmfoto 2020-03-11 um 12 20 34" src="https://user-images.githubusercontent.com/1510/76411766-bddd6680-6392-11ea-86c2-6e276c525415.png">

### After

<img width="1086" alt="Bildschirmfoto 2020-03-11 um 12 19 59" src="https://user-images.githubusercontent.com/1510/76411715-a8683c80-6392-11ea-99af-ef49cdd884bb.png">

closes #974 