### PR TITLE
add empty alt attribute to header image

### DIFF
--- a/src/ui/components/HeaderContent/template.hbs
+++ b/src/ui/components/HeaderContent/template.hbs
@@ -19,7 +19,7 @@
     {{#if @attachment}}
       <div block:class="sidebar">
         <div block:class="image-wrapper">
-          <img srcset="{{@srcset}}" sizes="{{@sizes}}" block:class="image" />
+          <img srcset="{{@srcset}}" sizes="{{@sizes}}" block:class="image" alt="" />
         </div>
         {{#if (eq @attachment "blue-ribbon")}}
           <div block:class="background">


### PR DESCRIPTION
…since this will always just be an illustrative image without any real meaning.

As it turns out this image is the only one that was missing an `alt` attribute.

closes #980 