### PR TITLE
Remove additional whitespace on blog

### DIFF
--- a/src/ui/styles/blocks/blog-post.block.css
+++ b/src/ui/styles/blocks/blog-post.block.css
@@ -17,7 +17,7 @@
   grid-template-columns: repeat(6, 1fr);
   grid-column-gap: var(--col-gap);
   grid-auto-flow: dense;
-  margin-bottom: 3rem;
+  margin-bottom: -4rem;
 }
 
 /* Duplicating Header.content here as CSS Blocks is not capable
@@ -107,7 +107,6 @@
 @media (min-width: 888px) {
   .header {
     margin-top: 21rem;
-    margin-bottom: 12rem;
   }
 
   .headline {
@@ -155,6 +154,10 @@
 }
 
 @media (max-width: 887px) {
+  .header {
+    margin-bottom: 0;
+  }
+
   .badge {
     display: flex;
   }


### PR DESCRIPTION
This PR removes additional whitespace on the blog post header. The whitespace that is added via `margin-bottom` on the `<Header>` is simply removed again with a negative `margin-bottom` again by the content the blog post puts into the header.

### Before

<img width="1110" alt="Bildschirmfoto 2020-03-11 um 16 40 09" src="https://user-images.githubusercontent.com/1510/76435221-00b13580-63b7-11ea-96f2-96b9173f07d5.png">

### After

<img width="1110" alt="Bildschirmfoto 2020-03-11 um 16 40 14" src="https://user-images.githubusercontent.com/1510/76435231-03138f80-63b7-11ea-9b5e-f46b11e211fd.png">

closes #982 