### PR TITLE
Blog shape whitespace

### DIFF
--- a/src/ui/components/ShapeBlog/stylesheet.css
+++ b/src/ui/components/ShapeBlog/stylesheet.css
@@ -8,6 +8,7 @@
   position: relative;
   width: 100%;
   grid-column: 1/-1;
+  margin-top: 12rem;
 
   --shape-color: var(--color-accent);
 }
@@ -42,6 +43,10 @@
 }
 
 @media (max-width: 887px) {
+  :scope {
+    margin-top: 0;
+  }
+
   .content {
     width: 100%;
   }


### PR DESCRIPTION
This adds additional whitespace above the `<ShapeBlog>` component so that it doesn't stick to the header directly but vertically aligns with the `<HeaderContent>`.

### Before

<img width="1795" alt="76440271-e3339a00-63bd-11ea-89d0-745caf24db1d" src="https://user-images.githubusercontent.com/1510/76441388-9c46a400-63bf-11ea-9b81-46d657d674cb.png">

### After

<img width="1795" alt="Bildschirmfoto 2020-03-11 um 17 42 04" src="https://user-images.githubusercontent.com/1510/76441409-a36db200-63bf-11ea-970f-13638676649f.png">


closes #987 