### PR TITLE
Fix shape feature

### DIFF
--- a/lib/generate-blog/lib/templates/post/template.hbs
+++ b/lib/generate-blog/lib/templates/post/template.hbs
@@ -89,11 +89,7 @@
     {{{body}}}
   </div>
   {{#if related}}
-    <ShapeFeature
-      @color="{{related.teaserBackground}}"
-      @background="{{related.teaserBackground}}"
-      @backgroundImage="{{related.teaserImage}}"
-    >
+    <ShapeFeature>
       <p typography:class="small">
         Continue Reading
       </p>

--- a/src/ui/components/ShapeFeature/template.hbs
+++ b/src/ui/components/ShapeFeature/template.hbs
@@ -19,9 +19,9 @@
       </figure>
     {{else}}
       <div block:class="container">
-        <p block:class="content">
+        <div block:class="content">
           {{yield}}
-        </p>
+        </div>
       </div>
     {{/if}}
   </div>


### PR DESCRIPTION
This restructures the `<ShapeFeature>` component so that instead of using a `<p>` for its content it uses a `<div>`. The problem is we are sometimes using the component passing in additional content which can contain `<p>` tags but also headings etc. which cannot actually appear within a `<p>` tag. While the browser seems to ignore that, when pre-rendering the application during build, jsdom seems to auto-correct that and instead of rendering the `<p>` inside of the `<p>`, it renders them as siblings which destroys the layout of course.

closes #984