### PR TITLE
fix typos in meta description on services page

### DIFF
--- a/src/ui/components/PageServices/template.hbs
+++ b/src/ui/components/PageServices/template.hbs
@@ -3,7 +3,7 @@
     @active="services"
     @title="Services"
     @documentTitle="Digital Products & Team Augmentation & Training and Support | Our Services"
-    @description="We turns ideas into products, managing projects from start to end and help tech teams move faster with confidence via Team Augmentation and Tuturing."
+    @description="We turn ideas into products, managing projects from start to end and help tech teams move faster with confidence via Team Augmentation and Tutoring."
     @backgroundVariation="inclined"
   >
     <HeaderContent


### PR DESCRIPTION
This fixes typos in the meta description of the services page.

closes #1021 