### PR TITLE
Make `yarn start` render limit content archive by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "build": "PRERENDER=1 ember build -prod && node scripts/prerender.js",
     "crawl": "node scripts/crawl.js",
-    "start": "ember server",
-    "start-dev": "LIMIT_CONTENT_ARCHIVE=true ember server",
+    "start": "LIMIT_CONTENT_ARCHIVE=true ember server",
+    "start:production": "ember server",
     "test": "ember test",
     "lint:ts": "tslint -c tslint.json 'src/**/*.ts' -t codeFrame",
     "lint:js": "eslint . --cache",


### PR DESCRIPTION

Since most times when we are working on the website we do not need
the full content archive to be rendered, either because we are working
on a specific page or on a blog post that should be within the range
of the limited content archive, I think making `yarn start` is a quality
of life improvement.
I replaced `start-dev` with a `start:production` script for when
the full content archive is required.

Let me know if I am missing something in our pre-rendering pipeline
that might be affected by this change.