### PR TITLE
Wrap markdown files after 80 characters

### DIFF
--- a/_appearances/2017-03-28-emberconf-2017/appearances/animate-the-web-with-ember.md
+++ b/_appearances/2017-03-28-emberconf-2017/appearances/animate-the-web-with-ember.md
@@ -5,5 +5,5 @@ url: https://www.youtube.com/watch?v=wFJPIjRTIVU
 media: video
 ---
 
-Jessica Jordan shows how to do animations on the web leveraging HTML5 canvas
-and the Web Animation API.
+Jessica Jordan shows how to do animations on the web leveraging HTML5 canvas and
+the Web Animation API.

--- a/_appearances/2017-03-28-emberconf-2017/channel.md
+++ b/_appearances/2017-03-28-emberconf-2017/channel.md
@@ -4,5 +4,5 @@ image: '/assets/images/talks/2017-03-28-emberconf-2017/logo.png'
 url: https://2017.emberconf.com
 ---
 
-EmberConf is the main yearly conference around all things Ember in Portland,
-OR, USA.
+EmberConf is the main yearly conference around all things Ember in Portland, OR,
+USA.

--- a/_appearances/2018-02-22-assertjs-2018/channel.md
+++ b/_appearances/2018-02-22-assertjs-2018/channel.md
@@ -4,5 +4,5 @@ image: '/assets/images/talks/2018-02-22-assertjs-2018/logo.png'
 url: https://2018.assertjs.com
 ---
 
-Assert(js) Testing Conference is a one-day, single-track conference with a
-laser focus on testing for JavaScript developers.
+Assert(js) Testing Conference is a one-day, single-track conference with a laser
+focus on testing for JavaScript developers.

--- a/_appearances/2018-03-13-emberconf-2018/appearances/everything-they-didnt-tell-you-about-the-ember-community.md
+++ b/_appearances/2018-03-13-emberconf-2018/appearances/everything-they-didnt-tell-you-about-the-ember-community.md
@@ -5,5 +5,5 @@ url: https://www.youtube.com/watch?v=h3YtViXranw
 media: video
 ---
 
-Jessica Jordan shares some insights to what defines the Ember Community and
-what drives it forward.
+Jessica Jordan shares some insights to what defines the Ember Community and what
+drives it forward.

--- a/_appearances/2018-03-13-emberconf-2018/channel.md
+++ b/_appearances/2018-03-13-emberconf-2018/channel.md
@@ -4,5 +4,5 @@ image: '/assets/images/talks/2018-03-13-emberconf-2018/logo.svg'
 url: https://2018.emberconf.com
 ---
 
-EmberConf is the main yearly conference around all things Ember in Portland,
-OR, USA.
+EmberConf is the main yearly conference around all things Ember in Portland, OR,
+USA.

--- a/_appearances/2018-10-11-emberfest-2018/appearances/deliver-fast-apps-even-faster.md
+++ b/_appearances/2018-10-11-emberfest-2018/appearances/deliver-fast-apps-even-faster.md
@@ -5,5 +5,5 @@ url: https://www.youtube.com/watch?v=5NrsB2FYBlQ
 media: video
 ---
 
-Marco Otte-Witte talks about optimizing JavaScript bundles and loading
-behaviour of Ember.js apps.
+Marco Otte-Witte talks about optimizing JavaScript bundles and loading behaviour
+of Ember.js apps.

--- a/_appearances/2018-10-29-reactiveconf-2018/appearances/crafting-web-comics-with-ember.md
+++ b/_appearances/2018-10-29-reactiveconf-2018/appearances/crafting-web-comics-with-ember.md
@@ -5,5 +5,5 @@ url: https://www.youtube.com/watch?v=cljehgyxOSQ
 media: video
 ---
 
-Jessica Jordan shares how to build comics for the web using Ember.js and the
-Web Animation API.
+Jessica Jordan shares how to build comics for the web using Ember.js and the Web
+Animation API.

--- a/_appearances/2019-03-16-emberconf-2019/channel.md
+++ b/_appearances/2019-03-16-emberconf-2019/channel.md
@@ -4,5 +4,5 @@ image: '/assets/images/talks/2019-03-16-emberconf-2019/logo.png'
 url: https://emberconf.com
 ---
 
-EmberConf is the main yearly conference around all things Ember in Portland,
-OR, USA.
+EmberConf is the main yearly conference around all things Ember in Portland, OR,
+USA.

--- a/_appearances/2019-06-01-jsconf-eu-2019/appearances/crafting-comics-for-literally-everyone.md
+++ b/_appearances/2019-06-01-jsconf-eu-2019/appearances/crafting-comics-for-literally-everyone.md
@@ -5,4 +5,5 @@ url: https://www.youtube.com/watch?v=BPmuR4mAQaw
 media: video
 ---
 
-Jessica Jordan demonstrates how to create an immersive web comic experience that is not only engaging for sighted users but accessible for everyone.
+Jessica Jordan demonstrates how to create an immersive web comic experience that
+is not only engaging for sighted users but accessible for everyone.

--- a/_appearances/2019-06-01-jsconf-eu-2019/channel.md
+++ b/_appearances/2019-06-01-jsconf-eu-2019/channel.md
@@ -4,4 +4,5 @@ image: '/assets/images/talks/2019-06-01-jsconf-eu-2019/logo.png'
 url: https://2019.jsconf.eu
 ---
 
-JSConf EU is a major conference for the JavaScript community in Europe, annually taking place in Berlin, Germany.
+JSConf EU is a major conference for the JavaScript community in Europe, annually
+taking place in Berlin, Germany.

--- a/_appearances/2019-06-22-commit-porto-2019/appearances/thriving-through-the-hype-cycle.md
+++ b/_appearances/2019-06-22-commit-porto-2019/appearances/thriving-through-the-hype-cycle.md
@@ -5,5 +5,5 @@ url: https://www.youtube.com/watch?v=ECkbVa0iC4k
 media: video
 ---
 
-Ricardo Mendes goes through the history of Ember.js as a project and
-how it braves the fads of front-end development.
+Ricardo Mendes goes through the history of Ember.js as a project and how it
+braves the fads of front-end development.

--- a/_appearances/2019-06-22-commit-porto-2019/channel.md
+++ b/_appearances/2019-06-22-commit-porto-2019/channel.md
@@ -4,4 +4,5 @@ image: '/assets/images/talks/2019-06-22-commit-porto-2019/logo.png'
 url: https://commitporto.com/
 ---
 
-Commit Porto is a tech conference organized by AlumniEI-FEUP, annually taking place in Porto, Portugal.
+Commit Porto is a tech conference organized by AlumniEI-FEUP, annually taking
+place in Porto, Portugal.

--- a/_appearances/2019-10-17-emberfest-2019/channel.md
+++ b/_appearances/2019-10-17-emberfest-2019/channel.md
@@ -4,4 +4,5 @@ image: '/assets/images/talks/2019-10-17-emberfest-2019/logo.png'
 url: https://emberfest.eu
 ---
 
-EmberFest is the European Community Ember Conference and took place in Copenhagen, Denmark in 2019.
+EmberFest is the European Community Ember Conference and took place in
+Copenhagen, Denmark in 2019.

--- a/_posts/2013-06-15-authentication-in-emberjs.md
+++ b/_posts/2013-06-15-authentication-in-emberjs.md
@@ -5,24 +5,46 @@ github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
 topic: ember
-description: 'Marco Otte-Witte describes an approach for implementing a session mechanism, authentication and authorization in Ember.js applications.'
+description:
+  'Marco Otte-Witte describes an approach for implementing a session mechanism,
+  authentication and authorization in Ember.js applications.'
 ---
 
-**Update:**_I released an Ember.js plugin that makes it very easy to implement an authentication system as described in this post: [Ember.SimpleAuth](/blog/2013/10/09/embersimpleauth)._
+**Update:**_I released an Ember.js plugin that makes it very easy to implement
+an authentication system as described in this post:
+[Ember.SimpleAuth](/blog/2013/10/09/embersimpleauth)._
 
-**Update:** _After I wrote this I found out that it’s actually not the best approach to implement authentication in Ember.js… There are some things missing and some other things can be done in a much simpler way. [I wrote a summary of the (better) authentication mechanism we moved to.](/blog/2013/08/08/better-authentication-in-emberjs '(better) authnetication with ember.js')_
+**Update:** _After I wrote this I found out that it’s actually not the best
+approach to implement authentication in Ember.js… There are some things missing
+and some other things can be done in a much simpler way.
+[I wrote a summary of the (better) authentication mechanism we moved to.](/blog/2013/08/08/better-authentication-in-emberjs '(better) authnetication with ember.js')_
 
-_I’m using the latest (as of mid June 2013) [ember](https://github.com/emberjs/ember.js)/[ember-data](https://github.com/emberjs/data)/[handlebars](https://github.com/wycats/handlebars.js) code directly from the respective github repositories in this example._
+_I’m using the latest (as of mid June 2013)
+[ember](https://github.com/emberjs/ember.js)/[ember-data](https://github.com/emberjs/data)/[handlebars](https://github.com/wycats/handlebars.js)
+code directly from the respective github repositories in this example._
 
 <!--break-->
 
-When we started our first project with [ember.js](http://emberjs.com), **the first thing we came across was how to implement authentication**. While all of us had implemented authentication in "normal" [Rails](http://rubyonrails.org) apps several times we initially weren’t sure how to do it in ember.js. Also information on the internet was scarce and hard to find.
+When we started our first project with [ember.js](http://emberjs.com), **the
+first thing we came across was how to implement authentication**. While all of
+us had implemented authentication in "normal" [Rails](http://rubyonrails.org)
+apps several times we initially weren’t sure how to do it in ember.js. Also
+information on the internet was scarce and hard to find.
 
-The only more elaborate sample project I found was the [ember-auth](https://github.com/heartsentwined/ember-auth) plugin. While that seemed to be very complete and high quality it is also very heavy weight and I didn’t want to add such a big thing to our codebase only to implement simple authentication into our app. So I rolled my own implementation.
+The only more elaborate sample project I found was the
+[ember-auth](https://github.com/heartsentwined/ember-auth) plugin. While that
+seemed to be very complete and high quality it is also very heavy weight and I
+didn’t want to add such a big thing to our codebase only to implement simple
+authentication into our app. So I rolled my own implementation.
 
 ## The basics
 
-The general route to go with authentication in ember.js is to use **token based authentication** where the client submits the regular username/password credentials to the server once and if those are valid receives an authentication token in response. That token is then sent along with every request the client makes to the server. Having understood this the first thing to do is to implement a regular login form with username and password fields:
+The general route to go with authentication in ember.js is to use **token based
+authentication** where the client submits the regular username/password
+credentials to the server once and if those are valid receives an authentication
+token in response. That token is then sent along with every request the client
+makes to the server. Having understood this the first thing to do is to
+implement a regular login form with username and password fields:
 
 ```hbs
 <form>
@@ -34,7 +56,10 @@ The general route to go with authentication in ember.js is to use **token based 
 </form>
 ```
 
-That template is backed by a route that handles the submission event and posts the data to the /session route on the server - which then responds with either status 401 or 200 and a JSON containing the authentication token and the id of the authenticated user:
+That template is backed by a route that handles the submission event and posts
+the data to the /session route on the server - which then responds with either
+status 401 or 200 and a JSON containing the authentication token and the id of
+the authenticated user:
 
 <!-- prettier-ignore -->
 ```js
@@ -63,9 +88,13 @@ App.SessionsNewRoute = Ember.Route.extend({
 });
 ```
 
-I’m using a route instead of a controller here as redirecting should only be done from routes and not controllers. See e.g. [this SO post](http://stackoverflow.com/questions/11552417/emberjs-how-to-transition-to-a-router-from-a-controllers-action/11555014#11555014) for more info.
+I’m using a route instead of a controller here as redirecting should only be
+done from routes and not controllers. See e.g.
+[this SO post](http://stackoverflow.com/questions/11552417/emberjs-how-to-transition-to-a-router-from-a-controllers-action/11555014#11555014)
+for more info.
 
-The response JSON from the server would look somehow like this in the successful login case:
+The response JSON from the server would look somehow like this in the successful
+login case:
 
 ```json
 {
@@ -76,7 +105,11 @@ The response JSON from the server would look somehow like this in the successful
 }
 ```
 
-At this point the client has the authentication data necessary to authenticate itself against the server. As tat authentication data would be lost every time the application on the client reloads and we don’t want to force a new login every time the user reloads the page we can simply **store that data in a cookie (of course you could use local storage etc.)**:
+At this point the client has the authentication data necessary to authenticate
+itself against the server. As tat authentication data would be lost every time
+the application on the client reloads and we don’t want to force a new login
+every time the user reloads the page we can simply **store that data in a cookie
+(of course you could use local storage etc.)**:
 
 ```js
 $.cookie('auth_token', App.Auth.get('authToken'));
@@ -85,7 +118,13 @@ $.cookie('auth_account', App.Auth.get('accountId'));
 
 ## Making authenticated requests
 
-The next step is to actually send the authentication token to the server. As the only point point of interaction between client and server in an ember.js app is **when the store adapter reads or writes data, the token has to be integrated in that adapter somehow**. As there’s not (yet) any out-off-the-box support for authentication in the [DS.RESTAdapter](https://github.com/emberjs/data/blob/v3.9.0/addon/adapters/rest.js), I simply added it myself:
+The next step is to actually send the authentication token to the server. As the
+only point point of interaction between client and server in an ember.js app is
+**when the store adapter reads or writes data, the token has to be integrated in
+that adapter somehow**. As there’s not (yet) any out-off-the-box support for
+authentication in the
+[DS.RESTAdapter](https://github.com/emberjs/data/blob/v3.9.0/addon/adapters/rest.js),
+I simply added it myself:
 
 ```js
 App.AuthenticatedRESTAdapter = DS.RESTAdapter.extend({
@@ -98,7 +137,12 @@ App.AuthenticatedRESTAdapter = DS.RESTAdapter.extend({
 });
 ```
 
-Now the adapter will pass along the authentication token with every request to the server. One thing that should be made sure though is that whenever the adapter sees **a [401](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#401) response which would mean that for some reason the authentication token became invalid, the session data on the client is deleted** and we require a fresh login:
+Now the adapter will pass along the authentication token with every request to
+the server. One thing that should be made sure though is that whenever the
+adapter sees **a
+[401](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#401) response
+which would mean that for some reason the authentication token became invalid,
+the session data on the client is deleted** and we require a fresh login:
 
 ```js
 DS.rejectionHandler = function(reason) {
@@ -111,19 +155,31 @@ DS.rejectionHandler = function(reason) {
 
 ## Enforcing authentication on the client
 
-Now that the general authentication mechanism is in place it would be cool to have a way of enforcing authentication on the client for specific routes so the user never gets to see any pages that they aren’t allowed to. This can be done by simply **introducing a custom route class that will check for the presence of a session and if none is present redirects to the login screen**. Any other routes that require authentication can then inherit from that one instead if the regular [`Ember.Route`](http://emberjs.com/api/classes/Ember.Route.html)
+Now that the general authentication mechanism is in place it would be cool to
+have a way of enforcing authentication on the client for specific routes so the
+user never gets to see any pages that they aren’t allowed to. This can be done
+by simply **introducing a custom route class that will check for the presence of
+a session and if none is present redirects to the login screen**. Any other
+routes that require authentication can then inherit from that one instead if the
+regular [`Ember.Route`](http://emberjs.com/api/classes/Ember.Route.html)
 
 ```js
 App.AuthenticatedRoute = Ember.Route.extend({
   enter: function() {
-    if (!Ember.isEmpty(App.Auth.get('authToken')) && !Ember.isEmpty(App.Auth.get('accountId'))) {
+    if (
+      !Ember.isEmpty(App.Auth.get('authToken')) &&
+      !Ember.isEmpty(App.Auth.get('accountId'))
+    ) {
       this.transitionTo('sessions.new');
     }
   },
 });
 ```
 
-This is actually very similar to the concept of an `AuthController` in Rails with a [`before_filter`](http://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-before_filter) that enforces authentication:
+This is actually very similar to the concept of an `AuthController` in Rails
+with a
+[`before_filter`](http://api.rubyonrails.org/classes/AbstractController/Callbacks/ClassMethods.html#method-i-before_filter)
+that enforces authentication:
 
 ```rb
 class AuthenticatedController < ApplicationController
@@ -135,7 +191,8 @@ end
 
 ## Cleanup
 
-As the code is now spread up into a number of files and classes, I added a `Session` model:
+As the code is now spread up into a number of files and classes, I added a
+`Session` model:
 
 ```js
 App.Session = DS.Model.extend({
@@ -144,7 +201,8 @@ App.Session = DS.Model.extend({
 });
 ```
 
-alongside an `App.AuthManager` accompanied by a custom initializer to clean it up:
+alongside an `App.AuthManager` accompanied by a custom initializer to clean it
+up:
 
 <!-- prettier-ignore -->
 ```js

--- a/_posts/2013-06-27-excellent-172.md
+++ b/_posts/2013-06-27-excellent-172.md
@@ -4,7 +4,9 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte announces excellent 1.7.2 with 3 new checks and a more forgiving and stable parser mechanism.'
+description:
+  'Marco Otte-Witte announces excellent 1.7.2 with 3 new checks and a more
+  forgiving and stable parser mechanism.'
 topic: ruby
 ---
 
@@ -13,6 +15,8 @@ We just released excellent 1.7.2 which includes the following fixes:
 <!--break-->
 
 - fixed `Simplabs::Excellent::Checks::Rails::CustomInitializeMethodCheck`
-- fixed `Simplabs::Excellent::Checks::MethodNameCheck` so it allows method names that exist in Ruby itself
-- fixed `Simplabs::Excellent::Checks::GlobalVariableCheck` so it doesn't report false positives for rescue bodies
+- fixed `Simplabs::Excellent::Checks::MethodNameCheck` so it allows method names
+  that exist in Ruby itself
+- fixed `Simplabs::Excellent::Checks::GlobalVariableCheck` so it doesn't report
+  false positives for rescue bodies
 - made the parser more forgiving/stable in some situations

--- a/_posts/2013-06-28-excellent-200.md
+++ b/_posts/2013-06-28-excellent-200.md
@@ -4,7 +4,9 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte announces excellent 2.0.0 with support for a configuration file, a whitelist of allowed global variables and re-enabled standard checks.'
+description:
+  'Marco Otte-Witte announces excellent 2.0.0 with support for a configuration
+  file, a whitelist of allowed global variables and re-enabled standard checks.'
 topic: ruby
 ---
 
@@ -12,8 +14,13 @@ We just released excellent 2.0.0 which has some big improvements:
 
 <!--break-->
 
-- now supporting config file `.excellent.yml` in current working directory to configure which specs to run/ not to run with thresholds, patterns etc.
-- predefined globals will not be reported anymore (`$!`, `$@`, `$&`, ` $```, `\$’`,`\$+`,`\$1`,`\$2..`,`\$~`,`\$=`,`\$/`,`\$\`,`\$,`,`\$;`,`\$.`,`\$`,`\$\_`,`\$0`,`\$\*`,`\$\$`,`\$?`,`\$:`,`\$"`,`\$DEBUG`,`\$FILENAME`,`\$LOAD_PATH`,`\$stdin`,`\$stdout`,`\$stderr`,`\$VERBOSE`,`\$-0`,`\$-a`,`\$-d`,`\$-F`,`\$-i`,`\$-I`,`\$-l`,`\$-p`,`\$-v`)
-- enabled previously disable checks again: `AbcMetricMethodCheck`, `ControlCouplingCheck`, `CyclomaticComplexityBlockCheck`, `CyclomaticComplexityMethodCheck`, `ForLoopCheck`, `FlogBlockCheck`, `FlogClassCheck`, `FlogMethodCheck`
+- now supporting config file `.excellent.yml` in current working directory to
+  configure which specs to run/ not to run with thresholds, patterns etc.
+- predefined globals will not be reported anymore (`$!`, `$@`, `$&`,
+  ` $```, `\$’`,`\$+`,`\$1`,`\$2..`,`\$~`,`\$=`,`\$/`,`\$\`,`\$,`,`\$;`,`\$.`,`\$`,`\$\_`,`\$0`,`\$\*`,`\$\$`,`\$?`,`\$:`,`\$"`,`\$DEBUG`,`\$FILENAME`,`\$LOAD_PATH`,`\$stdin`,`\$stdout`,`\$stderr`,`\$VERBOSE`,`\$-0`,`\$-a`,`\$-d`,`\$-F`,`\$-i`,`\$-I`,`\$-l`,`\$-p`,`\$-v`)
+- enabled previously disable checks again: `AbcMetricMethodCheck`,
+  `ControlCouplingCheck`, `CyclomaticComplexityBlockCheck`,
+  `CyclomaticComplexityMethodCheck`, `ForLoopCheck`, `FlogBlockCheck`,
+  `FlogClassCheck`, `FlogMethodCheck`
 - testing now uses Rspec 2
 - internal cleanups/simplifications

--- a/_posts/2013-08-08-better-authentication-in-emberjs.md
+++ b/_posts/2013-08-08-better-authentication-in-emberjs.md
@@ -4,29 +4,56 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte introduces an update to the mechanism for implementing a session, authentication and authorization in Ember.js applications.'
+description:
+  'Marco Otte-Witte introduces an update to the mechanism for implementing a
+  session, authentication and authorization in Ember.js applications.'
 topic: ember
 ---
 
-**Update:**_I released an Ember.js plugin that makes it very easy to implement an authentication system as described in this post: [Ember.SimpleAuth](/blog/2013/06/15/authentication-in-emberjs)._
+**Update:**_I released an Ember.js plugin that makes it very easy to implement
+an authentication system as described in this post:
+[Ember.SimpleAuth](/blog/2013/06/15/authentication-in-emberjs)._
 
-When we started our first [ember.js](http://emberjs.com) project in June 2013, one of the first things we implemented was authentication. Now, almost 2 months later, **it has become clear that our initial approach was not really the best and had some shortcomings. So I implemented a better authentication** (mostly based on the embercasts on authentication).
+When we started our first [ember.js](http://emberjs.com) project in June 2013,
+one of the first things we implemented was authentication. Now, almost 2 months
+later, **it has become clear that our initial approach was not really the best
+and had some shortcomings. So I implemented a better authentication** (mostly
+based on the embercasts on authentication).
 
 <!--break-->
 
-_I’m using the latest (as of early August 2013) [ember.js](http://emberjs.com) and [handlebars](http://handlebarsjs.com) releases in this example._
+_I’m using the latest (as of early August 2013) [ember.js](http://emberjs.com)
+and [handlebars](http://handlebarsjs.com) releases in this example._
 
-_**Update:**I changed the section on actually using the token to use [\$.ajaxPrefilter](http://api.jquery.com/jQuery.ajaxPrefilter/) instead of a custom ember-data adapter_
+_**Update:**I changed the section on actually using the token to use
+[\$.ajaxPrefilter](http://api.jquery.com/jQuery.ajaxPrefilter/) instead of a
+custom ember-data adapter_
 
 ## The basics
 
-The basic approach is still the same as in our initial implementation - we have a **`/session` route in our Rails app that the client `POST`s its credentials to and if those are valid gets back an authentication token** together with an id that identifies the user’s account on the server side.
+The basic approach is still the same as in our initial implementation - we have
+a **`/session` route in our Rails app that the client `POST`s its credentials to
+and if those are valid gets back an authentication token** together with an id
+that identifies the user’s account on the server side.
 
-This data is stored in a _"session"_ object on the client side (while technically there is no session in this stateless authentication mechanism, I still call it session in absence of an idea for a better name). The **authentication token is then sent in a header** with every request the client makes.
+This data is stored in a _"session"_ object on the client side (while
+technically there is no session in this stateless authentication mechanism, I
+still call it session in absence of an idea for a better name). The
+**authentication token is then sent in a header** with every request the client
+makes.
 
 ## The client _"session"_
 
-The _"session"_ object on the client side is a **plain `Ember.Object` that simply keeps the data that is received from the server** on session creation. It also stores the authentication token and the user’s account ID in cookies so the user doesn’t have to login again after a page reload (As Ed points out in a comment on the old post it’s a security issue to store the authentication token in a cookie without the user’s permission - I think using a session cookie like I do should be ok as it’s deleted when the browser window is closed. Of course you could also use sth. like localStorage like Marc points out. I’m creating this object in an initializer so I can be sure it exists (of course it might be empty) when the application starts.
+The _"session"_ object on the client side is a **plain `Ember.Object` that
+simply keeps the data that is received from the server** on session creation. It
+also stores the authentication token and the user’s account ID in cookies so the
+user doesn’t have to login again after a page reload (As Ed points out in a
+comment on the old post it’s a security issue to store the authentication token
+in a cookie without the user’s permission - I think using a session cookie like
+I do should be ok as it’s deleted when the browser window is closed. Of course
+you could also use sth. like localStorage like Marc points out. I’m creating
+this object in an initializer so I can be sure it exists (of course it might be
+empty) when the application starts.
 
 <!-- prettier-ignore -->
 ```js
@@ -57,21 +84,36 @@ Ember.Application.initializer({
 });
 ```
 
-When this has run I can always access the current _"session"_ information as `App.Session`. Notice the `.create()` at the end of the initializer that creates an instance of the `Ember.Object` right away. When we need to **check whether a user is authenticated we can simply check for presence of the `authToken` property**. Of course we could add a `isAuthenticated()` method that could perform additional checks but we didn’t have the need for that yet.
+When this has run I can always access the current _"session"_ information as
+`App.Session`. Notice the `.create()` at the end of the initializer that creates
+an instance of the `Ember.Object` right away. When we need to **check whether a
+user is authenticated we can simply check for presence of the `authToken`
+property**. Of course we could add a `isAuthenticated()` method that could
+perform additional checks but we didn’t have the need for that yet.
 
-This _"session"_ object will also load the actual account record from the server if the `authAccountId` is set (`this.set('authAccount', App.Account.find(authAccountId));`. This allows us to e.g. use `App.Session.authAccount.fullName` in our templates to display the user’s name or similar data.)
+This _"session"_ object will also load the actual account record from the server
+if the `authAccountId` is set
+(`this.set('authAccount', App.Account.find(authAccountId));`. This allows us to
+e.g. use `App.Session.authAccount.fullName` in our templates to display the
+user’s name or similar data.)
 
-To actually use the `authToken` when making server requests, **we register an [AJAX prefilter](http://api.jquery.com/jQuery.ajaxPrefilter/) that adds the authentication token in a header as long as the request is sent to our domain**:
+To actually use the `authToken` when making server requests, **we register an
+[AJAX prefilter](http://api.jquery.com/jQuery.ajaxPrefilter/) that adds the
+authentication token in a header as long as the request is sent to our domain**:
 
 ```js
 Ember.$.ajaxPrefilter(function(options, originalOptions, jqXHR) {
   if (!jqXHR.crossDomain) {
-    jqXHR.setRequestHeader('X-AUTHENTICATION-TOKEN', App.Session.get('authToken'));
+    jqXHR.setRequestHeader(
+      'X-AUTHENTICATION-TOKEN',
+      App.Session.get('authToken'),
+    );
   }
 });
 ```
 
-The Rails server can then find the authenticated user by the token in the header:
+The Rails server can then find the authenticated user by the token in the
+header:
 
 ```rb
 class ApplicationController < ActionController::Base
@@ -88,7 +130,11 @@ end
 
 ## Logging in
 
-As described above, the login API is a simple `/session` route on the server side that accepts the user’s login and password and **responds with either HTTP status 401 when the credentials are invalid or a session JSON when the authentication was successful**. On the client side we have routes for creating and destroying the session:
+As described above, the login API is a simple `/session` route on the server
+side that accepts the user’s login and password and **responds with either HTTP
+status 401 when the credentials are invalid or a session JSON when the
+authentication was successful**. On the client side we have routes for creating
+and destroying the session:
 
 <!-- prettier-ignore -->
 ```js
@@ -100,7 +146,14 @@ App.Router.map(function() {
 });
 ```
 
-The `SessionNewController` only needs one action `login` that sends the entered credentials and acts according to the server’s response - if the server responds successfully **it reads the session data from the response and updates the `App.Session` object accordingly**. It also checks whether there is an attempted transition that was intercepted due to missing authentication and retries that if it exists (This is the case where the user tries to access a certain page without having authenticated, is redirected to the login form, logs in and is redirected again to the initially requested page).
+The `SessionNewController` only needs one action `login` that sends the entered
+credentials and acts according to the server’s response - if the server responds
+successfully **it reads the session data from the response and updates the
+`App.Session` object accordingly**. It also checks whether there is an attempted
+transition that was intercepted due to missing authentication and retries that
+if it exists (This is the case where the user tries to access a certain page
+without having authenticated, is redirected to the login form, logs in and is
+redirected again to the initially requested page).
 
 <!-- prettier-ignore -->
 ```js
@@ -129,9 +182,12 @@ App.SessionNewController = Ember.Controller.extend({
 });
 ```
 
-Notice that we do not handle the error case here. To have a better user experience you would probably want to define a `.fail` handler as well that display an error message.
+Notice that we do not handle the error case here. To have a better user
+experience you would probably want to define a `.fail` handler as well that
+display an error message.
 
-The template is just a simple form (actual elements, classes etc. of course depend on your specific application):
+The template is just a simple form (actual elements, classes etc. of course
+depend on your specific application):
 
 ```hbs
 <form {{action login on="submit"}}>
@@ -143,7 +199,11 @@ The template is just a simple form (actual elements, classes etc. of course depe
 
 ## Logging out
 
-Logging out is actually pretty simple as well. The **client just sends a `DELETE` to the same `/session` route** that makes the server reset the authentication token in the database so that the token on the client side is invalidated. The client also deletes the saved session information in `App.Session` so there’s no stale data.
+Logging out is actually pretty simple as well. The **client just sends a
+`DELETE` to the same `/session` route** that makes the server reset the
+authentication token in the database so that the token on the client side is
+invalidated. The client also deletes the saved session information in
+`App.Session` so there’s no stale data.
 
 <!-- prettier-ignore -->
 ```js
@@ -164,7 +224,9 @@ App.SessionDestroyController = Ember.Controller.extend({
 });
 ```
 
-As this action should be triggered as soon as the user enters the `/#/session/destroy` route, we have a simple route implementation that **triggers the action upon route activation**:
+As this action should be triggered as soon as the user enters the
+`/#/session/destroy` route, we have a simple route implementation that
+**triggers the action upon route activation**:
 
 <!-- prettier-ignore -->
 ```js
@@ -177,7 +239,9 @@ App.SessionDestroyRoute = Ember.Route.extend({
 
 ## Authenticated routes
 
-To easily enable authentication for any route in the application, I created an **`App.AuthenticatedRoute` that extends `Ember.Route`** and that all routes that need to enforce user authentication can extend again:
+To easily enable authentication for any route in the application, I created an
+**`App.AuthenticatedRoute` that extends `Ember.Route`** and that all routes that
+need to enforce user authentication can extend again:
 
 <!-- prettier-ignore -->
 ```js
@@ -195,6 +259,8 @@ App.AuthenticatedRoute = Ember.Route.extend({
 });
 ```
 
-Notice that `redirectToLogin` sets the `attemptedTransition` of `App.Session` so that the user will be redirected to the initially requested page after successfulyl logging in.
+Notice that `redirectToLogin` sets the `attemptedTransition` of `App.Session` so
+that the user will be redirected to the initially requested page after
+successfulyl logging in.
 
 This is better authentication with ember.js - enjoy!

--- a/_posts/2013-10-09-embersimpleauth.md
+++ b/_posts/2013-10-09-embersimpleauth.md
@@ -4,21 +4,40 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte announces Ember.SimpleAuth, an addon for implementing a session mechanism, authentication and authorization for Ember.js applications.'
+description:
+  'Marco Otte-Witte announces Ember.SimpleAuth, an addon for implementing a
+  session mechanism, authentication and authorization for Ember.js applications.'
 topic: ember
 ---
 
-**Update: [Ember.SimpleAuth 0.1.0 has been released!](/blog/2014/01/20/embersimpleauth-010)** The information in this is (partially) outdated.
+**Update:
+[Ember.SimpleAuth 0.1.0 has been released!](/blog/2014/01/20/embersimpleauth-010)**
+The information in this is (partially) outdated.
 
-After I wrote 2 [blog](/blog/2013/06/15/authentication-in-emberjs 'the initial post') [posts](/blog/2013/08/08/better-authentication-in-emberjs 'the second post with a refined implementation') on implementing token based authentication in [Ember.js](http://emberjs.com) applications and got quite some feedback, good suggestions etc., I thought it **would be nice to pack all these ideas in an Ember.js plugin** so everybody could easily integrate that into their applications. Now **I finally managed to release version 0.0.1 of that plugin**: [Ember.SimpleAuth](https://github.com/simplabs/ember-simple-auth).
+After I wrote 2
+[blog](/blog/2013/06/15/authentication-in-emberjs 'the initial post')
+[posts](/blog/2013/08/08/better-authentication-in-emberjs 'the second post with a refined implementation')
+on implementing token based authentication in [Ember.js](http://emberjs.com)
+applications and got quite some feedback, good suggestions etc., I thought it
+**would be nice to pack all these ideas in an Ember.js plugin** so everybody
+could easily integrate that into their applications. Now **I finally managed to
+release version 0.0.1 of that plugin**:
+[Ember.SimpleAuth](https://github.com/simplabs/ember-simple-auth).
 
 <!--break-->
 
-Instead of providing a heavyweight out-of-the-box solution with predefined routes, controllers etc., Ember.SimpleAuth defines lightweight mixins that the application code implements. It also **does not dictate anything with respect to application structure, routing etc**. However, setting up Ember.SimpleAuth is **very straight forward** and it can be **completely customized**. The requirements on the server interface are minimal ([see the README for more information on the server side](https://github.com/simplabs/ember-simple-auth#the-server-side)).
+Instead of providing a heavyweight out-of-the-box solution with predefined
+routes, controllers etc., Ember.SimpleAuth defines lightweight mixins that the
+application code implements. It also **does not dictate anything with respect to
+application structure, routing etc**. However, setting up Ember.SimpleAuth is
+**very straight forward** and it can be **completely customized**. The
+requirements on the server interface are minimal
+([see the README for more information on the server side](https://github.com/simplabs/ember-simple-auth#the-server-side)).
 
 ## Using Ember.SimpleAuth
 
-Using Ember.SimpleAuth in an application only requires a few simple steps. First, it must be enabled which is best done in a custom initializer:
+Using Ember.SimpleAuth in an application only requires a few simple steps.
+First, it must be enabled which is best done in a custom initializer:
 
 ```js
 Ember.Application.initializer({
@@ -38,10 +57,13 @@ App.Router.map(function() {
 });
 ```
 
-Then, the generated **controller and route must implement the mixins provided by Ember.SimpleAuth**:
+Then, the generated **controller and route must implement the mixins provided by
+Ember.SimpleAuth**:
 
 ```js
-App.LoginController = Ember.Controller.extend(Ember.SimpleAuth.LoginControllerMixin);
+App.LoginController = Ember.Controller.extend(
+  Ember.SimpleAuth.LoginControllerMixin,
+);
 App.LogoutRoute = Ember.Route.extend(Ember.SimpleAuth.LogoutRouteMixin);
 ```
 
@@ -57,14 +79,25 @@ Of course the application also needs a template that renders the login form:
 </form>
 ```
 
-At this point, everything that’s necessary for users to log in and out is set up. Also, every AJAX request (unless it’s a cross domain request) that the application makes will send the authentication token that is obtained when the user logs in. **To actually protect routes so that they are only accessible for authenticated users, simply implement the respective Ember.SimpleAuth mixin** in the route classes:
+At this point, everything that’s necessary for users to log in and out is set
+up. Also, every AJAX request (unless it’s a cross domain request) that the
+application makes will send the authentication token that is obtained when the
+user logs in. **To actually protect routes so that they are only accessible for
+authenticated users, simply implement the respective Ember.SimpleAuth mixin** in
+the route classes:
 
 ```js
-App.ProtectedRoute = Ember.Route.extend(Ember.SimpleAuth.AuthenticatedRouteMixin);
+App.ProtectedRoute = Ember.Route.extend(
+  Ember.SimpleAuth.AuthenticatedRouteMixin,
+);
 ```
 
 ## More
 
-There is more documentation as well as examples in the [repository on github](https://github.com/simplabs/ember-simple-auth). Also the **code base is quite small so I suggest to read through it** to better understand what’s going on internally.
+There is more documentation as well as examples in the
+[repository on github](https://github.com/simplabs/ember-simple-auth). Also the
+**code base is quite small so I suggest to read through it** to better
+understand what’s going on internally.
 
-Patches, bug reports etc. are highly appreciated of course - [get started by forking the project on github](https://github.com/simplabs/ember-simple-auth)!
+Patches, bug reports etc. are highly appreciated of course -
+[get started by forking the project on github](https://github.com/simplabs/ember-simple-auth)!

--- a/_posts/2013-10-28-embersimpleauth-implements-rfc-6749-oauth-20.md
+++ b/_posts/2013-10-28-embersimpleauth-implements-rfc-6749-oauth-20.md
@@ -4,21 +4,46 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte announces support for OAuth 2.0 in Ember.SimpleAuth, the addon for implementing a session and authentication/authorization for Ember.js.'
+description:
+  'Marco Otte-Witte announces support for OAuth 2.0 in Ember.SimpleAuth, the
+  addon for implementing a session and authentication/authorization for
+  Ember.js.'
 topic: ember
 ---
 
-**Update: [Ember.SimpleAuth 0.1.0 has been released!](/blog/2014/01/20/embersimpleauth-010)** The information in this is (partially) outdated.
+**Update:
+[Ember.SimpleAuth 0.1.0 has been released!](/blog/2014/01/20/embersimpleauth-010)**
+The information in this is (partially) outdated.
 
-With the [release of Ember.SimpleAuth 0.0.4](https://github.com/simplabs/ember-simple-auth/releases/tag/0.0.4) **the library is compliant with OAuth 2.0** - specifically it implements the _"Resource Owner Password Credentials Grant Type"_ as defined in [RFC 6749](http://tools.ietf.org/html/rfc6749) (thanks [adamlc](https://github.com/adamlc) for the suggestion). While this is only a minor change in terms of functionality and data flow, used headers etc. it makes everyone’s life a lot easier as instead of implementing your own server endpoints you can now utilize [one of several OAuth 2.0 middlewares that already implement the spec](https://github.com/search?q=oauth%20middleware).
+With the
+[release of Ember.SimpleAuth 0.0.4](https://github.com/simplabs/ember-simple-auth/releases/tag/0.0.4)
+**the library is compliant with OAuth 2.0** - specifically it implements the
+_"Resource Owner Password Credentials Grant Type"_ as defined in
+[RFC 6749](http://tools.ietf.org/html/rfc6749) (thanks
+[adamlc](https://github.com/adamlc) for the suggestion). While this is only a
+minor change in terms of functionality and data flow, used headers etc. it makes
+everyone’s life a lot easier as instead of implementing your own server
+endpoints you can now utilize
+[one of several OAuth 2.0 middlewares that already implement the spec](https://github.com/search?q=oauth%20middleware).
 
 <!--break-->
 
-With the OAuth 2.0 support also comes **support for access token expiration and [refresh tokens](http://tools.ietf.org/html/rfc6749#section-6)**. Using expiring access tokens improves overall security as replay attacks are less likely while with refresh tokens **Ember.SimpleAuth can automatically obtain new access tokens** before they expire so that the user doesn’t recognize the token actually changes.
+With the OAuth 2.0 support also comes **support for access token expiration and
+[refresh tokens](http://tools.ietf.org/html/rfc6749#section-6)**. Using expiring
+access tokens improves overall security as replay attacks are less likely while
+with refresh tokens **Ember.SimpleAuth can automatically obtain new access
+tokens** before they expire so that the user doesn’t recognize the token
+actually changes.
 
 ## Other changes
 
-Other smaller additions include **support for [external OAuth/OpenID providers](https://github.com/simplabs/ember-simple-auth#external-oauthopenid-providers)** and [manipulation of the request used to obtain the access token](https://github.com/simplabs/ember-simple-auth#custom-server-protocols). Also the API was simplified and the `login` and `logout` actions were moved to the `ApplicationControllerMixin` and the `/logout` route has been removed. The new API now looks like this:
+Other smaller additions include **support for
+[external OAuth/OpenID providers](https://github.com/simplabs/ember-simple-auth#external-oauthopenid-providers)**
+and
+[manipulation of the request used to obtain the access token](https://github.com/simplabs/ember-simple-auth#custom-server-protocols).
+Also the API was simplified and the `login` and `logout` actions were moved to
+the `ApplicationControllerMixin` and the `/logout` route has been removed. The
+new API now looks like this:
 
 ```js
 Ember.Application.initializer({
@@ -33,10 +58,20 @@ App.Router.map(function() {
   this.route('protected');
 });
 
-App.ApplicationRoute = Ember.Route.extend(Ember.SimpleAuth.ApplicationRouteMixin);
-App.LoginController = Ember.Controller.extend(Ember.SimpleAuth.LoginControllerMixin);
+App.ApplicationRoute = Ember.Route.extend(
+  Ember.SimpleAuth.ApplicationRouteMixin,
+);
+App.LoginController = Ember.Controller.extend(
+  Ember.SimpleAuth.LoginControllerMixin,
+);
 ```
 
 ## Future plans
 
-Currently I’m working on adding API documentation within the source together with a means of generating some nice HTML out of that. I don’t currently see that there is much else missing in the library so **I’d like to release a 1.0.0 version soon**. Of course I’d like to make sure that Ember.SimpleAuth is actually being used and working so [please submit bug reports, patches etc.](https://github.com/simplabs/ember-simple-auth) or **provide general feedback/ideas!**
+Currently I’m working on adding API documentation within the source together
+with a means of generating some nice HTML out of that. I don’t currently see
+that there is much else missing in the library so **I’d like to release a 1.0.0
+version soon**. Of course I’d like to make sure that Ember.SimpleAuth is
+actually being used and working so
+[please submit bug reports, patches etc.](https://github.com/simplabs/ember-simple-auth)
+or **provide general feedback/ideas!**

--- a/_posts/2014-01-20-embersimpleauth-010.md
+++ b/_posts/2014-01-20-embersimpleauth-010.md
@@ -4,31 +4,59 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte announces Ember.SimpleAuth 0.1.0 with an improved architecture that allows for arbitrary authentication and authorization strategies.'
+description:
+  'Marco Otte-Witte announces Ember.SimpleAuth 0.1.0 with an improved
+  architecture that allows for arbitrary authentication and authorization
+  strategies.'
 topic: ember
 ---
 
-Since [Ember.SimpleAuth](https://github.com/simplabs/ember-simple-auth) was released in October 2013, there were lots of issues reported, pull requests submitted and merged etc. **Now all this feedback together with some fundamental design improvements results in the [release of the 0.1.0 version of Ember.SimpleAuth](https://github.com/simplabs/ember-simple-auth/releases/tag/0.1.0).** This is hopefully paving the way for a soon-to-be-released version 1.0.
+Since [Ember.SimpleAuth](https://github.com/simplabs/ember-simple-auth) was
+released in October 2013, there were lots of issues reported, pull requests
+submitted and merged etc. **Now all this feedback together with some fundamental
+design improvements results in the
+[release of the 0.1.0 version of Ember.SimpleAuth](https://github.com/simplabs/ember-simple-auth/releases/tag/0.1.0).**
+This is hopefully paving the way for a soon-to-be-released version 1.0.
 
 <!--break-->
 
 ## What changed?
 
-The most significant change is the **extraction of everything specific to specific authentication/authorization mechanisms (e.g. the default OAuth 2.0 implementation) into strategy classes** which significantly improves customizability and extensibility. Instead of having to override parts of the library, using e.g. a custom authentication method is now as simple as specifying the class in the respective controller:
+The most significant change is the **extraction of everything specific to
+specific authentication/authorization mechanisms (e.g. the default OAuth 2.0
+implementation) into strategy classes** which significantly improves
+customizability and extensibility. Instead of having to override parts of the
+library, using e.g. a custom authentication method is now as simple as
+specifying the class in the respective controller:
 
 ```js
-App.LoginController = Ember.Controller.extend(Ember.SimpleAuth.LoginControllerMixin, {
-  authenticator: App.CustomAuthenticator,
-});
+App.LoginController = Ember.Controller.extend(
+  Ember.SimpleAuth.LoginControllerMixin,
+  {
+    authenticator: App.CustomAuthenticator,
+  },
+);
 ```
 
-This **makes implementations cleaner and also helps defining the public API that Ember.SimpleAuth** will settle on in the long term.
+This **makes implementations cleaner and also helps defining the public API that
+Ember.SimpleAuth** will settle on in the long term.
 
-Other changes include the introduction of store strategies (Ember.SimpleAuth comes with a cookie store that is equivalent to the old store, a store that uses the browser’s localStorage API and which is the new default as well as an in-memory store which is mainly useful for testing) as well as error handling/token invalidation, added callback actions like `sessionInvalidationSucceeded` etc. See the [README](https://github.com/simplabs/ember-simple-auth#readme) and the [API docs](http://ember-simple-auth.com/api/) for complete documentation.
+Other changes include the introduction of store strategies (Ember.SimpleAuth
+comes with a cookie store that is equivalent to the old store, a store that uses
+the browser’s localStorage API and which is the new default as well as an
+in-memory store which is mainly useful for testing) as well as error
+handling/token invalidation, added callback actions like
+`sessionInvalidationSucceeded` etc. See the
+[README](https://github.com/simplabs/ember-simple-auth#readme) and the
+[API docs](http://ember-simple-auth.com/api/) for complete documentation.
 
 ## Upgrading
 
-Upgrading will be pretty straight forward in most cases. The main change that could bite you is probably the change in `Ember.SimpleAuth.setup`’s signature. While it used to expect the `container` as well as the application instance, **the `container` argument was dropped** as it wasn’t actually needed. So in the initializer, change this:
+Upgrading will be pretty straight forward in most cases. The main change that
+could bite you is probably the change in `Ember.SimpleAuth.setup`’s signature.
+While it used to expect the `container` as well as the application instance,
+**the `container` argument was dropped** as it wasn’t actually needed. So in the
+initializer, change this:
 
 ```js
 Ember.Application.initializer({
@@ -50,7 +78,9 @@ Ember.Application.initializer({
 });
 ```
 
-Also, as the **`login` and `logout` actions in `ApplicationRouteMixin` were renamed to `authenticateSession` and `invalidateSession`**, in your templates change this:
+Also, as the **`login` and `logout` actions in `ApplicationRouteMixin` were
+renamed to `authenticateSession` and `invalidateSession`**, in your templates
+change this:
 
 ```hbs
 {{#if session.isAuthenticated}}
@@ -70,7 +100,8 @@ to this:
 {{/if}}
 ```
 
-Also the **`LoginControllerMixin`’s `login` action was renamed to `authenticate`** so in your login template change this:
+Also the **`LoginControllerMixin`’s `login` action was renamed to
+`authenticate`** so in your login template change this:
 
 ```hbs
 <form {{action login on='submit'}}>
@@ -82,8 +113,17 @@ to this:
 <form {{action authenticate on='submit'}}>
 ```
 
-These are really the only changes needed if your application is using Ember.SimpleAuth’s default settings, the default OAuth 2.0 mechanism etc. For other scenarios, see the [README](https://github.com/simplabs/ember-simple-auth#readme), [API docs](http://ember-simple-auth.com/api/) and also the examples provided in the repository.
+These are really the only changes needed if your application is using
+Ember.SimpleAuth’s default settings, the default OAuth 2.0 mechanism etc. For
+other scenarios, see the
+[README](https://github.com/simplabs/ember-simple-auth#readme),
+[API docs](http://ember-simple-auth.com/api/) and also the examples provided in
+the repository.
 
 ## Outlook
 
-**I hope that this release can pave the way towards a stable API for Ember.SimpleAuth.** It would also be great of course if many people came up with authenticator and authorizer implementations for all kinds of backends to prove the design of Ember.SimpleAuth’s strategy approach as well as to build a library of ready-to-use strategies for the most common setups.
+**I hope that this release can pave the way towards a stable API for
+Ember.SimpleAuth.** It would also be great of course if many people came up with
+authenticator and authorizer implementations for all kinds of backends to prove
+the design of Ember.SimpleAuth’s strategy approach as well as to build a library
+of ready-to-use strategies for the most common setups.

--- a/_posts/2014-03-11-embersimpleauth-020.md
+++ b/_posts/2014-03-11-embersimpleauth-020.md
@@ -4,7 +4,9 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte announces Ember.SimpleAuth 0.2.0 with a completely rebuilt build and testing infrastructure as well as important bug fixes.'
+description:
+  'Marco Otte-Witte announces Ember.SimpleAuth 0.2.0 with a completely rebuilt
+  build and testing infrastructure as well as important bug fixes.'
 topic: ember
 ---
 
@@ -12,4 +14,6 @@ We released Ember.SimpleAuth 0.2.0.
 
 <!--break-->
 
-Ember.SimpleAuth was released with a **completely rebuilt build and testing infrastructure as well as some important bug fixes. Find the [complete release notes on github](https://github.com/simplabs/ember-simple-auth/releases/tag/0.2.0).**
+Ember.SimpleAuth was released with a **completely rebuilt build and testing
+infrastructure as well as some important bug fixes. Find the
+[complete release notes on github](https://github.com/simplabs/ember-simple-auth/releases/tag/0.2.0).**

--- a/_posts/2014-04-06-embersimpleauth-021.md
+++ b/_posts/2014-04-06-embersimpleauth-021.md
@@ -4,7 +4,9 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte announces Ember.SimpleAuth 0.2.1 with some minor improvements.'
+description:
+  'Marco Otte-Witte announces Ember.SimpleAuth 0.2.1 with some minor
+  improvements.'
 topic: ember
 ---
 
@@ -12,4 +14,5 @@ We released Ember.SimpleAuth 0.2.1.
 
 <!--break-->
 
-Ember.SimpleAuth 0.2.1 was released with some minor improvements: [https://github.com/simplabs/ember-simple-auth/releases/tag/0.2.1](https://github.com/simplabs/ember-simple-auth/releases/tag/0.2.1)
+Ember.SimpleAuth 0.2.1 was released with some minor improvements:
+[https://github.com/simplabs/ember-simple-auth/releases/tag/0.2.1](https://github.com/simplabs/ember-simple-auth/releases/tag/0.2.1)

--- a/_posts/2014-04-10-embersimpleauth-030.md
+++ b/_posts/2014-04-10-embersimpleauth-030.md
@@ -4,23 +4,42 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte announces Ember.SimpleAuth 0.3.0, splitting the addon into a core and extensions for specific authentication/authorization mechanisms.'
+description:
+  'Marco Otte-Witte announces Ember.SimpleAuth 0.3.0, splitting the addon into a
+  core and extensions for specific authentication/authorization mechanisms.'
 topic: ember
 ---
 
-Ember.SimpleAuth 0.3.0 was just released. The **main change in this release is the split of Ember.SimpleAuth into one core library and a set of extension libraries**. These extension libraries include everything that’s not mandatorily required for Ember.SimpleAuth like authenticators, stores etc. so that every application would only have to load whatever it needs.
+Ember.SimpleAuth 0.3.0 was just released. The **main change in this release is
+the split of Ember.SimpleAuth into one core library and a set of extension
+libraries**. These extension libraries include everything that’s not mandatorily
+required for Ember.SimpleAuth like authenticators, stores etc. so that every
+application would only have to load whatever it needs.
 
 <!--break-->
 
 These extension libraries are:
 
-- **ember-simple-auth-oauth2**: includes the OAuth 2.0 authenticator and authorizer which are just one option out of many and probably not needed in many projects (e.g. when using a custom authenticator)
-- **ember-simple-auth-devise**: new authenticator/authorizer package that is compatible with the Ruby gem [devise](https://github.com/plataformatec/devise).
-- **ember-simple-auth-cookie-store**: The cookie store which is probably only used in few projects.
+- **ember-simple-auth-oauth2**: includes the OAuth 2.0 authenticator and
+  authorizer which are just one option out of many and probably not needed in
+  many projects (e.g. when using a custom authenticator)
+- **ember-simple-auth-devise**: new authenticator/authorizer package that is
+  compatible with the Ruby gem
+  [devise](https://github.com/plataformatec/devise).
+- **ember-simple-auth-cookie-store**: The cookie store which is probably only
+  used in few projects.
 
-There are hopefully more extension libraries to come as people start to provide more authenticators, authorizers and other components and now there’s a (more or less, pre 1.0) stable API for these libraries as well as a set of tasks to build and test them
+There are hopefully more extension libraries to come as people start to provide
+more authenticators, authorizers and other components and now there’s a (more or
+less, pre 1.0) stable API for these libraries as well as a set of tasks to build
+and test them
 
-Another bigger change in this release is that **having an authorizer is now optional**. As there are applications that are purely client side and don’t use a server backend expecting every application to use an authorizer was probably not so great in the first place. However, applications that do use an authorizer can simply configure one in Ember.SimpleAuth’s setup method and everything will behave as before:
+Another bigger change in this release is that **having an authorizer is now
+optional**. As there are applications that are purely client side and don’t use
+a server backend expecting every application to use an authorizer was probably
+not so great in the first place. However, applications that do use an authorizer
+can simply configure one in Ember.SimpleAuth’s setup method and everything will
+behave as before:
 
 ```js
 Ember.Application.initializer({
@@ -33,4 +52,5 @@ Ember.Application.initializer({
 });
 ```
 
-For more information about this release see the release notes at: [https://github.com/simplabs/ember-simple-auth/releases/tag/0.3.0](https://github.com/simplabs/ember-simple-auth/releases/tag/0.3.0)
+For more information about this release see the release notes at:
+[https://github.com/simplabs/ember-simple-auth/releases/tag/0.3.0](https://github.com/simplabs/ember-simple-auth/releases/tag/0.3.0)

--- a/_posts/2014-04-24-embersimpleauth-needs-a-logo.md
+++ b/_posts/2014-04-24-embersimpleauth-needs-a-logo.md
@@ -4,7 +4,9 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte posts a request for the community to contribute a logo to Ember.SimpleAuth.'
+description:
+  'Marco Otte-Witte posts a request for the community to contribute a logo to
+  Ember.SimpleAuth.'
 topic: ember
 ---
 
@@ -12,4 +14,8 @@ The project needs a logo.
 
 <!--break-->
 
-Every good open source project needs a nice and shiny logo these days. It would be great if Ember.SimpleAuth had one as well. As I’m not really an expert in these things it would be great if some of the more artistic advanced contributors/followers could [contribute something](https://github.com/simplabs/ember-simple-auth/issues/152)!
+Every good open source project needs a nice and shiny logo these days. It would
+be great if Ember.SimpleAuth had one as well. As I’m not really an expert in
+these things it would be great if some of the more artistic advanced
+contributors/followers could
+[contribute something](https://github.com/simplabs/ember-simple-auth/issues/152)!

--- a/_posts/2014-06-30-using-ember-simple-auth-with-ember-cli.md
+++ b/_posts/2014-06-30-using-ember-simple-auth-with-ember-cli.md
@@ -4,17 +4,26 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte announces the release of ember-cli-simple-auth as an Ember CLI addon.'
+description:
+  'Marco Otte-Witte announces the release of ember-cli-simple-auth as an Ember
+  CLI addon.'
 topic: ember
 ---
 
-With the latest release of [Ember Simple Auth](https://github.com/simplabs/ember-simple-auth), using the library with [ember-cli](https://github.com/ember-cli/ember-cli) has become much simpler. As ember-cli in general is still pretty new to many people though, **this post describes how to setup a project using Ember Simple Auth with ember-cli**.
+With the latest release of
+[Ember Simple Auth](https://github.com/simplabs/ember-simple-auth), using the
+library with [ember-cli](https://github.com/ember-cli/ember-cli) has become much
+simpler. As ember-cli in general is still pretty new to many people though,
+**this post describes how to setup a project using Ember Simple Auth with
+ember-cli**.
 
 <!--break-->
 
 ## Setting up the basic project
 
-First of all you need to install [PhantomJS](http://phantomjs.org), [bower](http://bower.io) and of course ember-cli (Ember Simple Auth requires **at least Ember CLI 0.0.44**):
+First of all you need to install [PhantomJS](http://phantomjs.org),
+[bower](http://bower.io) and of course ember-cli (Ember Simple Auth requires
+**at least Ember CLI 0.0.44**):
 
 ```bash
 npm install -g phantomjs
@@ -37,16 +46,22 @@ ember server
 
 ## Installing Ember Simple Auth
 
-Installing Ember Simple Auth in an ember-cli project is really easy now. All you have to do is install [the ember-cli addon from npm](https://www.npmjs.com/package/ember-cli-simple-auth):
+Installing Ember Simple Auth in an ember-cli project is really easy now. All you
+have to do is install
+[the ember-cli addon from npm](https://www.npmjs.com/package/ember-cli-simple-auth):
 
 ```bash
 npm install --save-dev ember-cli-simple-auth
 ember generate ember-cli-simple-auth
 ```
 
-This will install Ember Simple Auth’s [AMD](http://requirejs.org/docs/whyamd.html) distribution into the project, register the initializer so Ember Simple Auth automatically sets itself up and add itself as a dependency to the project’s `package.json`.
+This will install Ember Simple Auth’s
+[AMD](http://requirejs.org/docs/whyamd.html) distribution into the project,
+register the initializer so Ember Simple Auth automatically sets itself up and
+add itself as a dependency to the project’s `package.json`.
 
-You can add a login route and login/logout links to verify it all actually works:
+You can add a login route and login/logout links to verify it all actually
+works:
 
 ```js
 // app/router.js
@@ -80,14 +95,20 @@ export default Ember.Route.extend(ApplicationRouteMixin);
 
 ## Setting up authentication
 
-To actually give the user the option to login, we need to add an authentication package for Ember Simple Auth. Let’s assume you have an OAuth 2.0 compatible server running at `http://localhost:3000`. To use that, install the [OAuth 2.0 extension library](https://github.com/simplabs/ember-simple-auth/blob/master/addon/authenticators/oauth2-password-grant.js) which again is as easy as installing the [package from npm](https://www.npmjs.com/package/ember-cli-simple-auth-oauth2):
+To actually give the user the option to login, we need to add an authentication
+package for Ember Simple Auth. Let’s assume you have an OAuth 2.0 compatible
+server running at `http://localhost:3000`. To use that, install the
+[OAuth 2.0 extension library](https://github.com/simplabs/ember-simple-auth/blob/master/addon/authenticators/oauth2-password-grant.js)
+which again is as easy as installing the
+[package from npm](https://www.npmjs.com/package/ember-cli-simple-auth-oauth2):
 
 ```bash
 npm install --save-dev ember-cli-simple-auth-oauth2
 ember generate ember-cli-simple-auth-oauth2
 ```
 
-Like the ember-cli-simple-auth package this will setup itself so that nothing else has to be done in order to use the OAuth 2.0 functionality.
+Like the ember-cli-simple-auth package this will setup itself so that nothing
+else has to be done in order to use the OAuth 2.0 functionality.
 
 The OAuth 2.0 authentication mechanism needs a login form, so let’s create that:
 
@@ -102,7 +123,8 @@ The OAuth 2.0 authentication mechanism needs a login form, so let’s create tha
 </form>
 ```
 
-Then implement the `LoginControllerMixin` in the login controller and make that use the OAuth 2.0 authenticator to perform the actual authentication:
+Then implement the `LoginControllerMixin` in the login controller and make that
+use the OAuth 2.0 authenticator to perform the actual authentication:
 
 ```js
 // app/controllers/login.js
@@ -114,7 +136,9 @@ export default Ember.Controller.extend(LoginControllerMixin, {
 });
 ```
 
-As the OAuth 2.0 authenticator would by default use the same domain and port to send the authentication requests to that the Ember.js is loaded from you need to configure it to use `http://localhost:3000` instead:
+As the OAuth 2.0 authenticator would by default use the same domain and port to
+send the authentication requests to that the Ember.js is loaded from you need to
+configure it to use `http://localhost:3000` instead:
 
 ```js
 // config/environment.js
@@ -126,8 +150,15 @@ if (environment === 'development') {
   …
 ```
 
-You also need to make sure that your server allows cross origin requests by [enabling CORS](http://enable-cors.org) (e.g. with [rack-cors](https://github.com/cyu/rack-cors) if you’re using a rack based server).
+You also need to make sure that your server allows cross origin requests by
+[enabling CORS](http://enable-cors.org) (e.g. with
+[rack-cors](https://github.com/cyu/rack-cors) if you’re using a rack based
+server).
 
 ## Conclusion
 
-This is how you set up an ember-cli project with Ember Simple Auth. For further documentation and examples see the [github repository](https://github.com/simplabs/ember-simple-auth) and the [API docs for Ember Simple Auth](http://ember-simple-auth.com/api/) and the [OAuth 2.0 extension library](http://ember-simple-auth.com/api/).
+This is how you set up an ember-cli project with Ember Simple Auth. For further
+documentation and examples see the
+[github repository](https://github.com/simplabs/ember-simple-auth) and the
+[API docs for Ember Simple Auth](http://ember-simple-auth.com/api/) and the
+[OAuth 2.0 extension library](http://ember-simple-auth.com/api/).

--- a/_posts/2014-07-25-testing-with-ember-simple-auth-and-ember-cli.md
+++ b/_posts/2014-07-25-testing-with-ember-simple-auth-and-ember-cli.md
@@ -4,24 +4,34 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte explains how to test Ember CLI applications using ember-cli-simple-auth with the testing package ember-cli-simple-auth-testing.'
+description:
+  'Marco Otte-Witte explains how to test Ember CLI applications using
+  ember-cli-simple-auth with the testing package ember-cli-simple-auth-testing.'
 topic: ember
 ---
 
-[The last blog post](/blog/2014/06/30/using-ember-simple-auth-with-ember-cli 'Using Ember Simple Auth with ember-cli') showed how to use [Ember Simple Auth](https://github.com/simplabs/ember-simple-auth) with [Ember CLI](https://github.com/ember-cli/ember-cli) to implement session handling and authentication. **This post shows how to test that code**.
+[The last blog post](/blog/2014/06/30/using-ember-simple-auth-with-ember-cli 'Using Ember Simple Auth with ember-cli')
+showed how to use
+[Ember Simple Auth](https://github.com/simplabs/ember-simple-auth) with
+[Ember CLI](https://github.com/ember-cli/ember-cli) to implement session
+handling and authentication. **This post shows how to test that code**.
 
 <!--break-->
 
 ## The testing package
 
-First of all **install the new [ember-cli-simple-auth-testing package](https://www.npmjs.com/package/ember-cli-simple-auth-testing)**:
+First of all **install the new
+[ember-cli-simple-auth-testing package](https://www.npmjs.com/package/ember-cli-simple-auth-testing)**:
 
 ```bash
 npm install --save-dev ember-cli-simple-auth-testing
 ember generate ember-cli-simple-auth-testing
 ```
 
-**This package adds test helpers to the application** (unless it’s running with the `production` environment) that make it easy to authenticate and invalidate the session in tests without having to stub server responses etc. To make these helpers available to all tests, import them in `tests/helpers/start-app.js`:
+**This package adds test helpers to the application** (unless it’s running with
+the `production` environment) that make it easy to authenticate and invalidate
+the session in tests without having to stub server responses etc. To make these
+helpers available to all tests, import them in `tests/helpers/start-app.js`:
 
 ```js
 tests/helpers/start-app.js:
@@ -34,7 +44,13 @@ export default function startApp(attrs) {
 
 ## Configuring the `test` environment
 
-The next step is to configure the `test` environment. As the tests should be isolated and leave no traces of any kind so that subsequent tests don’t have implicit dependencies on the ones that have run earlier, Ember Simple Auth’s default `localStorage` store cannot be used as that would leave data in the `localStorage`. **Instead configure the [ephemeral store](http://ember-simple-auth.com/api/classes/EphemeralStore.html) to be used in the `test` environment**:
+The next step is to configure the `test` environment. As the tests should be
+isolated and leave no traces of any kind so that subsequent tests don’t have
+implicit dependencies on the ones that have run earlier, Ember Simple Auth’s
+default `localStorage` store cannot be used as that would leave data in the
+`localStorage`. **Instead configure the
+[ephemeral store](http://ember-simple-auth.com/api/classes/EphemeralStore.html)
+to be used in the `test` environment**:
 
 ```js
 // config/environment.js
@@ -45,11 +61,15 @@ if (environment === 'test') {
 }
 ```
 
-The ephemeral store stores data in memory and thus will be completely fresh for every test so that tests cannot influence each other.
+The ephemeral store stores data in memory and thus will be completely fresh for
+every test so that tests cannot influence each other.
 
 ## Adding the Tests
 
-Now everything is set up and a test can be added. To e.g. test that a certain route can only be accessed when the session is authenticated, add tests like these (notice the use of the test helpers `authenticateSession` and `invalidateSession`):
+Now everything is set up and a test can be added. To e.g. test that a certain
+route can only be accessed when the session is authenticated, add tests like
+these (notice the use of the test helpers `authenticateSession` and
+`invalidateSession`):
 
 ```js
 test('a protected route is accessible when the session is authenticated', function() {
@@ -73,4 +93,6 @@ test('a protected route is not accessible when the session is not authenticated'
 });
 ```
 
-This is how easy it is to test session handling and authentication with Ember Simple Auth and Ember CLI. The full example project can be [found on github](https://github.com/simplabs/ember-simple-auth-example)
+This is how easy it is to test session handling and authentication with Ember
+Simple Auth and Ember CLI. The full example project can be
+[found on github](https://github.com/simplabs/ember-simple-auth-example)

--- a/_posts/2014-10-15-the-most-important-command-when-working-with-xcode-6.md
+++ b/_posts/2014-10-15-the-most-important-command-when-working-with-xcode-6.md
@@ -4,7 +4,9 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: "Marco Otte-Witte shows how to disable XCode 6's crash reporter dialog for a less annoying development experience."
+description:
+  "Marco Otte-Witte shows how to disable XCode 6's crash reporter dialog for a
+  less annoying development experience."
 topic: misc
 ---
 
@@ -16,4 +18,6 @@ Switching off XCode's Crash Reporter saved my day.
 defaults write com.apple.CrashReporter DialogType none
 ```
 
-This disables the Crash Reporter window that shows when SourceKitService crashes (which is all the time). So while it doesn’t prevent SourceKitService from crashing at least you don’t have to click that window away anymore.
+This disables the Crash Reporter window that shows when SourceKitService crashes
+(which is all the time). So while it doesn’t prevent SourceKitService from
+crashing at least you don’t have to click that window away anymore.

--- a/_posts/2015-06-03-emberjs-workshop-in-munich.md
+++ b/_posts/2015-06-03-emberjs-workshop-in-munich.md
@@ -4,11 +4,15 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: "Marco Otte-Witte announces simplabs' 3-day Ember.js workshop in Munich, introducing participants to all aspects of the framework."
+description:
+  "Marco Otte-Witte announces simplabs' 3-day Ember.js workshop in Munich,
+  introducing participants to all aspects of the framework."
 topic: ember
 ---
 
-We are organizing a [three day Ember.js Workshop in Munich from July 22nd to 24th](http://ember-workshop.simplabs.com), **taking participants through building a full Ember.js application**.
+We are organizing a
+[three day Ember.js Workshop in Munich from July 22nd to 24th](http://ember-workshop.simplabs.com),
+**taking participants through building a full Ember.js application**.
 
 <!--break-->
 
@@ -29,4 +33,7 @@ The topics we will cover are:
 - Animations and Effects with Liquid Fire
 - Realtime Data with Websockets
 
-**There will also be a Welcome Party** at the first evening and luch served at the Workshop Venue! [Register now](http://ember-workshop.simplabs.com 'Ember.js Workshop in Munich, July 22nd-24th') as we only have limited capacities.
+**There will also be a Welcome Party** at the first evening and luch served at
+the Workshop Venue!
+[Register now](http://ember-workshop.simplabs.com 'Ember.js Workshop in Munich, July 22nd-24th')
+as we only have limited capacities.

--- a/_posts/2015-07-29-ember-simple-auth-10-a-first-look.md
+++ b/_posts/2015-07-29-ember-simple-auth-10-a-first-look.md
@@ -4,21 +4,32 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte gives an outlook on Ember Simple Auth 1.0 with Ember.js 2.0 support, a session service and discontinued support for non-Ember CLI projects.'
+description:
+  'Marco Otte-Witte gives an outlook on Ember Simple Auth 1.0 with Ember.js 2.0
+  support, a session service and discontinued support for non-Ember CLI
+  projects.'
 topic: ember
 ---
 
-The **first beta of Ember Simple Auth 1.0 will be released soon** and this post provides a first look at the changes that come with it.
+The **first beta of Ember Simple Auth 1.0 will be released soon** and this post
+provides a first look at the changes that come with it.
 
 <!--break-->
 
 ## Ember 2.0 Compatibility
 
-The biggest improvement of course is that the **library will be compatible with Ember 2.0** (which is mainly due to the fact that it now uses instance initializers for a majority of its setup work). Also when using Ember 1.13 you shouldn’t be seeing any deprecations triggered by Ember Simple Auth anymore so that the upgrade path to 2.0 is clean.
+The biggest improvement of course is that the **library will be compatible with
+Ember 2.0** (which is mainly due to the fact that it now uses instance
+initializers for a majority of its setup work). Also when using Ember 1.13 you
+shouldn’t be seeing any deprecations triggered by Ember Simple Auth anymore so
+that the upgrade path to 2.0 is clean.
 
 ## Session as a Service
 
-While previous versions of Ember Simple Auth injected the session into routes, controllers and components, **Ember Simple Auth 1.0 drops that and instead provides a new `Session` service** that encapsulates all access to the actual session and can simply be injected wherever necessary, e.g.:
+While previous versions of Ember Simple Auth injected the session into routes,
+controllers and components, **Ember Simple Auth 1.0 drops that and instead
+provides a new `Session` service** that encapsulates all access to the actual
+session and can simply be injected wherever necessary, e.g.:
 
 <!-- prettier-ignore -->
 ```js
@@ -40,9 +51,17 @@ export default Ember.Component.extend({
 });
 ```
 
-It provides a similar UI as the old session object, including `authenticate` and `invalidate` methods. Instead of reading the session content directly from the session as was the case in old versions of the library, the session provides a `content` property that can be used to read and write date from and to the session.
+It provides a similar UI as the old session object, including `authenticate` and
+`invalidate` methods. Instead of reading the session content directly from the
+session as was the case in old versions of the library, the session provides a
+`content` property that can be used to read and write date from and to the
+session.
 
-Also support for defining a custom session class has been dropped in favor of defining a service that uses the session service to provide functionality based on that. E.g. the typical use case of providing access to the authenticated account can now easily be implemented with a `SessionAccount` service that in turn uses the `Session` service:
+Also support for defining a custom session class has been dropped in favor of
+defining a service that uses the session service to provide functionality based
+on that. E.g. the typical use case of providing access to the authenticated
+account can now easily be implemented with a `SessionAccount` service that in
+turn uses the `Session` service:
 
 <!-- prettier-ignore -->
 ```js
@@ -66,19 +85,45 @@ export default Ember.Service.extend({
 
 ## Ember CLI only
 
-While previous versions of Ember Simple Auth provided 3 different versions (AMD, globals and the Ember CLI addons) where the Ember CLI addon was also split up into several sub addons, **1.0 will come as one single Ember CLI addon**. This offers 3 main advantages:
+While previous versions of Ember Simple Auth provided 3 different versions (AMD,
+globals and the Ember CLI addons) where the Ember CLI addon was also split up
+into several sub addons, **1.0 will come as one single Ember CLI addon**. This
+offers 3 main advantages:
 
-- The project structure is the standard Ember CLI addon structure and no longer a custom set of grunt tasks etc. This not only makes the development and release process much simpler but also promotes contributions from others.
-- It is now much simpler to install Ember CLI as it’s now only `ember install ember-simple-auth` command instead of install at least 2 packages or potentially more.
-- Since all the source is now transpiled with Babel as part of the Ember CLI build process, all the source code has been updated to use thinks like template strings, function literals, deconstruction etc., making the code far more concise and readable.
+- The project structure is the standard Ember CLI addon structure and no longer
+  a custom set of grunt tasks etc. This not only makes the development and
+  release process much simpler but also promotes contributions from others.
+- It is now much simpler to install Ember CLI as it’s now only
+  `ember install ember-simple-auth` command instead of install at least 2
+  packages or potentially more.
+- Since all the source is now transpiled with Babel as part of the Ember CLI
+  build process, all the source code has been updated to use thinks like
+  template strings, function literals, deconstruction etc., making the code far
+  more concise and readable.
 
 ## Getting to 1.0
 
-1.0 is still not fully finished and ready for release. While I plan to release a first beta until next week latest, getting to the final release still requires some work:
+1.0 is still not fully finished and ready for release. While I plan to release a
+first beta until next week latest, getting to the final release still requires
+some work:
 
-- The docs need to be updated to fit the new API and modules. Existing documentation is still based on classes and namespaces and we need to find a way to convert that so we document modules instead.
-- The docs are also not complete for new features like the **Session** service and existing documentation needs to be reviewed for whether it’s actually still correct.
-- The code should be reviewed and cleaned up before the final 1.0 release - much of it is still what I wrote almost 2 years ago when I was still relatively new to Ember and could probably be greatly improved.
-- The setup of the AJAX prefilter should be decoupled from the library so that it’s opt-in and could be replaced with a different approach (e.g. sth. that sets a property on the application’s Ember Data adapter instead) - see [#522](https://github.com/simplabs/ember-simple-auth/pull/522) and [#270](https://github.com/simplabs/ember-simple-auth/issues/270). A compatibility Addon should be extracted that implements the current behavior of setting up the prefilter automatically.
+- The docs need to be updated to fit the new API and modules. Existing
+  documentation is still based on classes and namespaces and we need to find a
+  way to convert that so we document modules instead.
+- The docs are also not complete for new features like the **Session** service
+  and existing documentation needs to be reviewed for whether it’s actually
+  still correct.
+- The code should be reviewed and cleaned up before the final 1.0 release - much
+  of it is still what I wrote almost 2 years ago when I was still relatively new
+  to Ember and could probably be greatly improved.
+- The setup of the AJAX prefilter should be decoupled from the library so that
+  it’s opt-in and could be replaced with a different approach (e.g. sth. that
+  sets a property on the application’s Ember Data adapter instead) - see
+  [#522](https://github.com/simplabs/ember-simple-auth/pull/522) and
+  [#270](https://github.com/simplabs/ember-simple-auth/issues/270). A
+  compatibility Addon should be extracted that implements the current behavior
+  of setting up the prefilter automatically.
 
-You can track the progress in the `jj-abrams` branch and if you want to submit a PR for any of the above mentioned tasks that would be greatly appreciated of course!
+You can track the progress in the `jj-abrams` branch and if you want to submit a
+PR for any of the above mentioned tasks that would be greatly appreciated of
+course!

--- a/_posts/2015-08-07-rails-api-auth.md
+++ b/_posts/2015-08-07-rails-api-auth.md
@@ -4,30 +4,70 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte announces rails_api_auth, a Rails engine that implements the "Resource Owner Password Credentials Grant" OAuth 2.0 flow.'
+description:
+  'Marco Otte-Witte announces rails_api_auth, a Rails engine that implements the
+  "Resource Owner Password Credentials Grant" OAuth 2.0 flow.'
 topic: ruby
 ---
 
-We are happy to announce the first public release of the [rails_api_auth gem](https://github.com/simplabs/rails_api_auth). rails*api_auth is a \*\*lightweight Rails Engine that implements the *"Resource Owner Password Credentials Grant"\_ OAuth 2.0 flow** as well as Facebook authentication and is **built for usage in API projects\*\*. If you’re building a client side application with e.g. a browser MVC like [Ember.js](http://emberjs.com) (where you might be using [Ember Simple Auth](https://github.com/simplabs/ember-simple-auth) which works great with rails_api_auth of course), a mobile app or anything else that’s backed by a Rails-based API, rails_api_auth is for you.
+We are happy to announce the first public release of the
+[rails_api_auth gem](https://github.com/simplabs/rails_api_auth). rails*api_auth
+is a \*\*lightweight Rails Engine that implements the *"Resource Owner Password
+Credentials Grant"\_ OAuth 2.0 flow** as well as Facebook authentication and is
+**built for usage in API projects\*\*. If you’re building a client side
+application with e.g. a browser MVC like [Ember.js](http://emberjs.com) (where
+you might be using
+[Ember Simple Auth](https://github.com/simplabs/ember-simple-auth) which works
+great with rails_api_auth of course), a mobile app or anything else that’s
+backed by a Rails-based API, rails_api_auth is for you.
 
 <!--break-->
 
 ## Why another Authentication Engine?
 
-Of course there are lots of authentication libraries for Rails already. While all of them are great and work well especially with traditional server rendered applications none of them are really lightweight and simple. In fact they are all pretty massive - all of them provide a lot more functionality than rails_api_auth does of course though. However, when you’re building an API and all you want is to provide a mechanism for users to exchange their login credentials for a token and then validate that incoming requests include a valid token in the `Authorization` header, you just don’t need most of that functionality and could use sth. much smaller, easier to understand and debug. In fact, rails_api_auth is basically just the controller and model plus a few helper methods that we use in most of our Rails-based API projects. When we realized we were reimplementing those in most projects we decided to extract them into an engine so they could be easily reused and also shared with others.
+Of course there are lots of authentication libraries for Rails already. While
+all of them are great and work well especially with traditional server rendered
+applications none of them are really lightweight and simple. In fact they are
+all pretty massive - all of them provide a lot more functionality than
+rails_api_auth does of course though. However, when you’re building an API and
+all you want is to provide a mechanism for users to exchange their login
+credentials for a token and then validate that incoming requests include a valid
+token in the `Authorization` header, you just don’t need most of that
+functionality and could use sth. much smaller, easier to understand and debug.
+In fact, rails_api_auth is basically just the controller and model plus a few
+helper methods that we use in most of our Rails-based API projects. When we
+realized we were reimplementing those in most projects we decided to extract
+them into an engine so they could be easily reused and also shared with others.
 
 ## The _"Resource Owner Password Credentials Grant"_
 
-The _"Resource Owner Password Credentials Grant"_ flow is really **just a formalization of the process where the users send their login credentials to the server and in return receive a token** (we’re using random Bearer tokens for now but will also support JSON Web Tokens (JWTs) soon). That **token will then be sent in the `Authorization` header** in subsequent requests so that the server can validate the user’s identity. The engine stores these credentials and tokens in `Login` models. Storing that data in a separate model instead of the application’s `User` model keeps the authentication code clearly separated from user profile data etc. and makes the engine easier to integrate. The `Login` model can be associated to the application’s `User` model by setting the `user_model_relation` configuration value ([see the README for more info on configuring the engine).](https://github.com/simplabs/rails_api_auth#configuration)
+The _"Resource Owner Password Credentials Grant"_ flow is really **just a
+formalization of the process where the users send their login credentials to the
+server and in return receive a token** (we’re using random Bearer tokens for now
+but will also support JSON Web Tokens (JWTs) soon). That **token will then be
+sent in the `Authorization` header** in subsequent requests so that the server
+can validate the user’s identity. The engine stores these credentials and tokens
+in `Login` models. Storing that data in a separate model instead of the
+application’s `User` model keeps the authentication code clearly separated from
+user profile data etc. and makes the engine easier to integrate. The `Login`
+model can be associated to the application’s `User` model by setting the
+`user_model_relation` configuration value
+([see the README for more info on configuring the engine).](https://github.com/simplabs/rails_api_auth#configuration)
 
-The _"Resource Owner Password Credentials Grant"_ flow defines 2 endpoints - one for obtaining a token and one for revoking it (the 2nd one is actually optional as users can be logged without any server interaction by simply deleting the token on the client):
+The _"Resource Owner Password Credentials Grant"_ flow defines 2 endpoints - one
+for obtaining a token and one for revoking it (the 2nd one is actually optional
+as users can be logged without any server interaction by simply deleting the
+token on the client):
 
 ```
 token  POST /token  oauth2#create
 revoke POST /revoke oauth2#destroy
 ```
 
-Both of these endpoints are already implemented in the engine. To validate that incoming requests include a valid Bearer token, the library defines the `authenticate!` method that is easily added as a `before_action` in authenticated-only controllers:
+Both of these endpoints are already implemented in the engine. To validate that
+incoming requests include a valid Bearer token, the library defines the
+`authenticate!` method that is easily added as a `before_action` in
+authenticated-only controllers:
 
 ```ruby
 class SecretThingsController < ApplicationController
@@ -39,14 +79,30 @@ class SecretThingsController < ApplicationController
 end
 ```
 
-When a valid token is present and a `Login` with that token exists, the method will save that in the `current_login` attribute so that it can be used in the controller. If no token is present or no `Login` exists for the token, it will respond with 401 and prevent the actual controller action from being executed. The `authenticate!` method can also be called with a block to add custom checks for the user’s authentication state.
+When a valid token is present and a `Login` with that token exists, the method
+will save that in the `current_login` attribute so that it can be used in the
+controller. If no token is present or no `Login` exists for the token, it will
+respond with 401 and prevent the actual controller action from being executed.
+The `authenticate!` method can also be called with a block to add custom checks
+for the user’s authentication state.
 
 ## Facebook Authentication
 
-Another common way of authenticating users that we’re using in many projects is Facebook authentication. The typical flow for this authentication type in web applications is opening a popup that displays Facebook’s login page and - after that - a page where the users grants your application access to their profile data. Once the user did that, Facebook will redirect to the web app and include an `auth_code` in the response that the web app then takes and sends to its API to validate it and exchange it for a Bearer token.
+Another common way of authenticating users that we’re using in many projects is
+Facebook authentication. The typical flow for this authentication type in web
+applications is opening a popup that displays Facebook’s login page and - after
+that - a page where the users grants your application access to their profile
+data. Once the user did that, Facebook will redirect to the web app and include
+an `auth_code` in the response that the web app then takes and sends to its API
+to validate it and exchange it for a Bearer token.
 
-rails_api_auth implements the API part of that in the `POST /token` route as well - [see the demo project for an example of how to use it](https://github.com/simplabs/rails_api_auth-demo#facebook-authentication).
+rails_api_auth implements the API part of that in the `POST /token` route as
+well -
+[see the demo project for an example of how to use it](https://github.com/simplabs/rails_api_auth-demo#facebook-authentication).
 
 ## Feedback and contributions welcome!
 
-As rails_api_auth is quite new and not yet widely used we’re happy to get feedback and suggestions for things we have missed. Also please **try the gem and report bugs** as you encounter them. **Contributions and pull requests are also appreciated** of course!
+As rails_api_auth is quite new and not yet widely used we’re happy to get
+feedback and suggestions for things we have missed. Also please **try the gem
+and report bugs** as you encounter them. **Contributions and pull requests are
+also appreciated** of course!

--- a/_posts/2015-11-27-updating-to-ember-simple-auth-1.0.md
+++ b/_posts/2015-11-27-updating-to-ember-simple-auth-1.0.md
@@ -4,19 +4,38 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte gives an update on the upcoming Ember Simple Auth 1.0 release and shows how to use it in Ember CLI applications.'
+description:
+  'Marco Otte-Witte gives an update on the upcoming Ember Simple Auth 1.0
+  release and shows how to use it in Ember CLI applications.'
 topic: ember
 ---
 
-With Ember Simple Auth 1.0.0 having been [released a few days ago](https://github.com/simplabs/ember-simple-auth/releases/tag/1.0.0), a lot of people will want to upgrade their applications to it so they can finally make the switch to Ember.js 2.0\. While quite a big part of the [public API](http://ember-simple-auth.com/api/) has been changed in 1.0.0, **updating an application from Ember Simple Auth 0.8.0 or earlier versions is actually not as hard as it might appear** at first glance. This post explains the steps that are necessary to bring an application to 1.0.0.
+With Ember Simple Auth 1.0.0 having been
+[released a few days ago](https://github.com/simplabs/ember-simple-auth/releases/tag/1.0.0),
+a lot of people will want to upgrade their applications to it so they can
+finally make the switch to Ember.js 2.0\. While quite a big part of the
+[public API](http://ember-simple-auth.com/api/) has been changed in 1.0.0,
+**updating an application from Ember Simple Auth 0.8.0 or earlier versions is
+actually not as hard as it might appear** at first glance. This post explains
+the steps that are necessary to bring an application to 1.0.0.
 
 <!--break-->
 
-As 1.0.0 marks the first stable release of Ember Simple Auth, upcoming versions will adhere to the [Semantic Versioning](http://semver.org) rule of not including breaking changes in patch level or minor releases. In fact, **Ember Simple Auth will follow Ember’s example and only make additive, backwards compatible changes in all 1.x releases** and only remove deprecated parts of the library in the next major release.
+As 1.0.0 marks the first stable release of Ember Simple Auth, upcoming versions
+will adhere to the [Semantic Versioning](http://semver.org) rule of not
+including breaking changes in patch level or minor releases. In fact, **Ember
+Simple Auth will follow Ember’s example and only make additive, backwards
+compatible changes in all 1.x releases** and only remove deprecated parts of the
+library in the next major release.
 
 ## Uninstall previous versions
 
-**Ember Simple Auth 1.0.0 is only distributed as an Ember CLI Addon** and drops the previous bower distribution as well as the individual `ember-cli-simple-auth-*` packages. The first step when upgrading to 1.0.0 is to uninstall these packages from the application. To do that simply remove the `ember-simple-auth` package from `bower.json` as well as all `ember-cli-simple-auth-*` packages from `packages.json`.
+**Ember Simple Auth 1.0.0 is only distributed as an Ember CLI Addon** and drops
+the previous bower distribution as well as the individual
+`ember-cli-simple-auth-*` packages. The first step when upgrading to 1.0.0 is to
+uninstall these packages from the application. To do that simply remove the
+`ember-simple-auth` package from `bower.json` as well as all
+`ember-cli-simple-auth-*` packages from `packages.json`.
 
 ## Install 1.0.0
 
@@ -28,7 +47,10 @@ ember install ember-simple-auth
 
 ## Fix the imports
 
-With 1.0.0 all modules that it defines now live in the `ember-simple-auth` namespace as opposed to the `simple-auth` namespace of previous versions. All the `import` statements that import code from Ember Simple Auth need to be updated accordingly, e.g.
+With 1.0.0 all modules that it defines now live in the `ember-simple-auth`
+namespace as opposed to the `simple-auth` namespace of previous versions. All
+the `import` statements that import code from Ember Simple Auth need to be
+updated accordingly, e.g.
 
 ```js
 import ApplicationRouteMixin from 'simple-auth/mixins/application-route-mixin';
@@ -40,11 +62,20 @@ becomes
 import ApplicationRouteMixin from 'ember-simple-auth/mixins/application-route-mixin';
 ```
 
-Also the modules for the OAuth 2.0 authenticator and authorizer have been renamed from just `oauth2` to `oauth2-password-grant` and `oauth2-bearer` respectively so that `'simple-auth/authenticators/oauth2'` is now `'ember-simple-auth/authenticators/oauth2-password-grant'` and `'simple-auth/authorizers/oauth2'` is now `'ember-simple-auth/authorizers/oauth2-bearer'`.
+Also the modules for the OAuth 2.0 authenticator and authorizer have been
+renamed from just `oauth2` to `oauth2-password-grant` and `oauth2-bearer`
+respectively so that `'simple-auth/authenticators/oauth2'` is now
+`'ember-simple-auth/authenticators/oauth2-password-grant'` and
+`'simple-auth/authorizers/oauth2'` is now
+`'ember-simple-auth/authorizers/oauth2-bearer'`.
 
 ## Inject the session service
 
-With Ember Simple Auth 1.0.0 the **session is no longer automatically injected into all routes, controllers and components** but instead is **now available as an [Ember.Service](http://emberjs.com/api/classes/Ember.Service.html)** so in all routes, controllers and components that use the session (or back a template that uses it), that session service needs to be injected, e.g.:
+With Ember Simple Auth 1.0.0 the **session is no longer automatically injected
+into all routes, controllers and components** but instead is **now available as
+an [Ember.Service](http://emberjs.com/api/classes/Ember.Service.html)** so in
+all routes, controllers and components that use the session (or back a template
+that uses it), that session service needs to be injected, e.g.:
 
 ```js
 import Ember from 'ember';
@@ -56,7 +87,12 @@ export default Ember.Controller.extend({
 
 ## Define Authenticators and Authorizers
 
-Ember Simple Auth 1.0.0 does not automatically merge all the predefined authenticators and authorizers into the application anymore but instead **requires authenticators and authorizers the application actually uses to be defined explicitly**. So if you e.g. were previously using the OAuth 2.0 authenticator simply define an authenticator that extends the OAuth 2.0 authenticator in `app/authenticators`:
+Ember Simple Auth 1.0.0 does not automatically merge all the predefined
+authenticators and authorizers into the application anymore but instead
+**requires authenticators and authorizers the application actually uses to be
+defined explicitly**. So if you e.g. were previously using the OAuth 2.0
+authenticator simply define an authenticator that extends the OAuth 2.0
+authenticator in `app/authenticators`:
 
 ```js
 // app/authenticators/oauth2.js
@@ -67,7 +103,9 @@ export default OAuth2PasswordGrant.extend({
 });
 ```
 
-In addition to the renamed module, the signature of the OAuth 2.0 authenticator has changed as well so that it now expects dedicated arguments for the user’s identification and password instead of one object containing both values, so
+In addition to the renamed module, the signature of the OAuth 2.0 authenticator
+has changed as well so that it now expects dedicated arguments for the user’s
+identification and password instead of one object containing both values, so
 
 ```js
 const credentials = this.getProperties('identification', 'password');
@@ -77,23 +115,45 @@ this.get('session').authenticate('authenticator:oauth2', credentials);
 becomes
 
 ```js
-const { identification, password } = this.getProperties('identification', 'password');
-this.get('session').authenticate('authenticator:oauth2', identification, password);
+const { identification, password } = this.getProperties(
+  'identification',
+  'password',
+);
+this.get('session').authenticate(
+  'authenticator:oauth2',
+  identification,
+  password,
+);
 ```
 
-Also authenticators and authorizers are not configured via `config/environment.js` anymore but instead the respective properties are simply overridden in the extended classes as for the `serverTokenRevocationEndpoint` property in the example above.
+Also authenticators and authorizers are not configured via
+`config/environment.js` anymore but instead the respective properties are simply
+overridden in the extended classes as for the `serverTokenRevocationEndpoint`
+property in the example above.
 
 ## Setup authorization
 
-Ember Simple Auth’s **old auto-authorization mechanism** was complex (especially when working with cross origin requests where configuring the `crossOriginWhitelist` was causing big problems for many people) and **has been removed in 1.0.0**. Instead authorization is now explicit. To authorize a block of code use the [session service’s `authorize` method](http://ember-simple-auth.com/api/classes/SessionService.html#method_authorize), e.g.:
+Ember Simple Auth’s **old auto-authorization mechanism** was complex (especially
+when working with cross origin requests where configuring the
+`crossOriginWhitelist` was causing big problems for many people) and **has been
+removed in 1.0.0**. Instead authorization is now explicit. To authorize a block
+of code use the
+[session service’s `authorize` method](http://ember-simple-auth.com/api/classes/SessionService.html#method_authorize),
+e.g.:
 
 ```js
-this.get('session').authorize('authorizer:oauth2-bearer', (headerName, headerValue) => {
-  xhr.setRequestHeader(headerName, headerValue);
-});
+this.get('session').authorize(
+  'authorizer:oauth2-bearer',
+  (headerName, headerValue) => {
+    xhr.setRequestHeader(headerName, headerValue);
+  },
+);
 ```
 
-If the application uses Ember Data, you can authorize all of the requests it sends to the API by using the new [`DataAdapterMixin`](http://ember-simple-auth.com/api/classes/DataAdapterMixin.html), e.g.:
+If the application uses Ember Data, you can authorize all of the requests it
+sends to the API by using the new
+[`DataAdapterMixin`](http://ember-simple-auth.com/api/classes/DataAdapterMixin.html),
+e.g.:
 
 ```js
 // app/adapters/application.js
@@ -107,11 +167,16 @@ export default DS.JSONAPIAdapter.extend(DataAdapterMixin, {
 
 ## Migrating custom sessions
 
-While previous versions of Ember Simple Auth allowed to configure a custom session class in order to add properties and methods to the session, Ember Simple Auth 1.0.0 makes the session private and only exposes the session service. In order to migrate a custom session class to work with the service there are 2 options.
+While previous versions of Ember Simple Auth allowed to configure a custom
+session class in order to add properties and methods to the session, Ember
+Simple Auth 1.0.0 makes the session private and only exposes the session
+service. In order to migrate a custom session class to work with the service
+there are 2 options.
 
 ### Extend the session service
 
-You can simply extend the session service and add custom properties and methods in the subclass, e.g.:
+You can simply extend the session service and add custom properties and methods
+in the subclass, e.g.:
 
 ```js
 // app/services/session.js
@@ -135,7 +200,8 @@ export default SessionService.extend({
 
 ### Create dedicated services
 
-You can also create dedicated services that use the session service internally, e.g.:
+You can also create dedicated services that use the session service internally,
+e.g.:
 
 ```js
 import Ember from 'ember';
@@ -156,13 +222,29 @@ export default Ember.Service.extend({
 });
 ```
 
-In this case the session service remains unchanged and whenever you need the currently authenticated account you’d use the `session-account` service to get that.
+In this case the session service remains unchanged and whenever you need the
+currently authenticated account you’d use the `session-account` service to get
+that.
 
-Both solutions work fine but **the latter results in cleaner code and better separation of concerns.**
+Both solutions work fine but **the latter results in cleaner code and better
+separation of concerns.**
 
 ## Session Stores
 
-Previous versions of Ember Simple Auth allowed the session store to be configured in `config/environment.js`. **Ember Simple Auth 1.0.0 removes that configuration setting and will always use the `'application'` session store**. If not overridden by the application that session store will be an instance of the new [`AdaptiveStore`](http://ember-simple-auth.com/api/classes/AdaptiveStore.html) that internally uses the [`LocalStorageStore`](http://ember-simple-auth.com/api/classes/LocalStorageStore.html) if `localStorage` storage is available and the [`CookieStore`](http://ember-simple-auth.com/api/classes/CookieStore.html) if it is not. To customize the application store, define it in `app/session-stores/application.js`, extend a predefined session store and customize properties (as done for authenticators and authorizers as described above) or implement a fully custom store, e.g.:
+Previous versions of Ember Simple Auth allowed the session store to be
+configured in `config/environment.js`. **Ember Simple Auth 1.0.0 removes that
+configuration setting and will always use the `'application'` session store**.
+If not overridden by the application that session store will be an instance of
+the new
+[`AdaptiveStore`](http://ember-simple-auth.com/api/classes/AdaptiveStore.html)
+that internally uses the
+[`LocalStorageStore`](http://ember-simple-auth.com/api/classes/LocalStorageStore.html)
+if `localStorage` storage is available and the
+[`CookieStore`](http://ember-simple-auth.com/api/classes/CookieStore.html) if it
+is not. To customize the application store, define it in
+`app/session-stores/application.js`, extend a predefined session store and
+customize properties (as done for authenticators and authorizers as described
+above) or implement a fully custom store, e.g.:
 
 ```js
 // app/session-store/application.js
@@ -173,14 +255,23 @@ export default CookieStore.extend({
 });
 ```
 
-**Ember Simple Auth 1.0.0 will also automatically use the [`EphemeralStore`](http://ember-simple-auth.com/api/classes/EphemeralStore.html) when running tests** so there is no need anymore to configure that for the test environment (in fact the configuration setting has been removed).
+**Ember Simple Auth 1.0.0 will also automatically use the
+[`EphemeralStore`](http://ember-simple-auth.com/api/classes/EphemeralStore.html)
+when running tests** so there is no need anymore to configure that for the test
+environment (in fact the configuration setting has been removed).
 
 ## Update acceptance tests
 
-While previous versions of Ember Simple Auth automatically injected the test helpers, version 1.0.0 requires them to be imported in the respective acceptance tests, e.g.:
+While previous versions of Ember Simple Auth automatically injected the test
+helpers, version 1.0.0 requires them to be imported in the respective acceptance
+tests, e.g.:
 
 ```js
-import { invalidateSession, authenticateSession, currentSession } from '../helpers/ember-simple-auth';
+import {
+  invalidateSession,
+  authenticateSession,
+  currentSession,
+} from '../helpers/ember-simple-auth';
 ```
 
 Also they now take the application instance as a first argument so instead of
@@ -197,8 +288,22 @@ authenticateSession(App);
 
 ## Update the application route if necessary
 
-The [`ApplicationRouteMixin`](http://ember-simple-auth.com/api/classes/ApplicationRouteMixin.html) in Ember Simple Auth 1.0.0 now only defines the two methods [`sessionAuthenticated`](http://ember-simple-auth.com/api/classes/ApplicationRouteMixin.html#method_sessionAuthenticated) and [`sessionInvalidated`](http://ember-simple-auth.com/api/classes/ApplicationRouteMixin.html#method_sessionInvalidated) as opposed to the previous four actions. If the application overrides any of these actions it would now have to override these methods.
+The
+[`ApplicationRouteMixin`](http://ember-simple-auth.com/api/classes/ApplicationRouteMixin.html)
+in Ember Simple Auth 1.0.0 now only defines the two methods
+[`sessionAuthenticated`](http://ember-simple-auth.com/api/classes/ApplicationRouteMixin.html#method_sessionAuthenticated)
+and
+[`sessionInvalidated`](http://ember-simple-auth.com/api/classes/ApplicationRouteMixin.html#method_sessionInvalidated)
+as opposed to the previous four actions. If the application overrides any of
+these actions it would now have to override these methods.
 
 ## Wrapping up
 
-I hope this gives a good overview of how upgrading an Ember application to Ember Simple Auth 1.0.0 works. **There is lots of documentation available** in the [README](https://github.com/simplabs/ember-simple-auth#readme) and the [API Docs](http://ember-simple-auth.com/api/index.html). You might also want to check out the [dummy application](https://github.com/simplabs/ember-simple-auth/tree/master/tests/dummy) in the github repo and the [intro video on the website](http://ember-simple-auth.com).
+I hope this gives a good overview of how upgrading an Ember application to Ember
+Simple Auth 1.0.0 works. **There is lots of documentation available** in the
+[README](https://github.com/simplabs/ember-simple-auth#readme) and the
+[API Docs](http://ember-simple-auth.com/api/index.html). You might also want to
+check out the
+[dummy application](https://github.com/simplabs/ember-simple-auth/tree/master/tests/dummy)
+in the github repo and the
+[intro video on the website](http://ember-simple-auth.com).

--- a/_posts/2015-12-3-ember-cli-deploy-notifications.md
+++ b/_posts/2015-12-3-ember-cli-deploy-notifications.md
@@ -4,29 +4,45 @@ author: 'Michael Klein'
 twitter: LevelbossMike
 github: LevelbossMike
 bio: 'Full-Stack Engineer, Ember CLI Deploy core team member'
-description: 'Michael Klein introduces ember-cli-deploy-notifications, an ember-cli-deploy plugin for invoking arbitrary webhooks during the deployment process.'
+description:
+  'Michael Klein introduces ember-cli-deploy-notifications, an ember-cli-deploy
+  plugin for invoking arbitrary webhooks during the deployment process.'
 topic: ember
 ---
 
-A few weeks ago a new version of the _"official"_ ember deployment solution [ember-cli-deploy](http://ember-cli-deploy.com/) was released:
+A few weeks ago a new version of the _"official"_ ember deployment solution
+[ember-cli-deploy](http://ember-cli-deploy.com/) was released:
 
 <blockquote class="tweet" lang="de"><p lang="en" dir="ltr">ember-cli-deploy 0.5 is now released and ready for use with a great docs site and already-rich plugin ecosystem: <a href="https://t.co/6yhjmjQrYD">https://t.co/6yhjmjQrYD</a></p>&mdash; Luke Melia (@lukemelia) <a href="https://twitter.com/lukemelia/status/659787938625134592">29. Oktober 2015</a></blockquote> <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
 
 <!--break-->
 
-Aaron Chambers and me gave detailed walkthroughs of the basic ideas behind the pipeline at the [Ember-London](https://vimeo.com/139125310) and [Ember.js-Munich](https://www.youtube.com/watch?v=d4xwIv_9Cg0) meetups respectively.
+Aaron Chambers and me gave detailed walkthroughs of the basic ideas behind the
+pipeline at the [Ember-London](https://vimeo.com/139125310) and
+[Ember.js-Munich](https://www.youtube.com/watch?v=d4xwIv_9Cg0) meetups
+respectively.
 
-The new release **encourages heavy use of [deploy plugins](http://emberobserver.com/categories/ember-cli-deploy-plugins) that all implement different parts of a deployment via [hooks](http://ember-cli-deploy.com/docs/v0.5.x/pipeline-hooks/)** and are themselves Ember CLI addons. What wasn’t available though was a plugin for notifying external webservices (e.g. an error-tracking service) during or after deployments so we decided to write one.
+The new release **encourages heavy use of
+[deploy plugins](http://emberobserver.com/categories/ember-cli-deploy-plugins)
+that all implement different parts of a deployment via
+[hooks](http://ember-cli-deploy.com/docs/v0.5.x/pipeline-hooks/)** and are
+themselves Ember CLI addons. What wasn’t available though was a plugin for
+notifying external webservices (e.g. an error-tracking service) during or after
+deployments so we decided to write one.
 
 ## Introducing ember-cli-deploy-notifications
 
-[ember-cli-deploy-notifications](https://github.com/simplabs/ember-cli-deploy-notifications) **makes it easy to notify external services** by adding them to a `notifications.services.<service>` property in `config/deploy.js`. First you have to install the addon:
+[ember-cli-deploy-notifications](https://github.com/simplabs/ember-cli-deploy-notifications)
+**makes it easy to notify external services** by adding them to a
+`notifications.services.<service>` property in `config/deploy.js`. First you
+have to install the addon:
 
 ```bash
 ember install ember-cli-deploy-notifications
 ```
 
-The second step is to configure the services that you want to notify while executing the deployment pipeline.
+The second step is to configure the services that you want to notify while
+executing the deployment pipeline.
 
 ```js
 // config/deploy.js
@@ -49,19 +65,30 @@ module.exports = function(deployTarget) {
 };
 ```
 
-Every time a new revision gets activated now by `ember-cli-deploy`, `ember-cli-deploy-notifications` will sent a `POST` request to the bugsnag service to notify it of the newly activated deployment revision.
+Every time a new revision gets activated now by `ember-cli-deploy`,
+`ember-cli-deploy-notifications` will sent a `POST` request to the bugsnag
+service to notify it of the newly activated deployment revision.
 
 ## Customization
 
-We figured out that there are a lot of different internal and external services that users of ember-cli-deploy wanted to notify when executing the deploy pipeline. Thus **we wanted to make `ember-cli-deploy-notifications` as flexible as possible but still keep things easy and simple** for the most basic use cases.
+We figured out that there are a lot of different internal and external services
+that users of ember-cli-deploy wanted to notify when executing the deploy
+pipeline. Thus **we wanted to make `ember-cli-deploy-notifications` as flexible
+as possible but still keep things easy and simple** for the most basic use
+cases.
 
-Based on that assumption we came up with the idea of _"preconfigured"_ and _"custom"_ services.
+Based on that assumption we came up with the idea of _"preconfigured"_ and
+_"custom"_ services.
 
 ### Custom services
 
-**Services need to be configured with values for `url`, `headers`, `method` and `body`**. We figured out that these are all the necessary parts of a webservice request that you need to be able to customize.
+**Services need to be configured with values for `url`, `headers`, `method` and
+`body`**. We figured out that these are all the necessary parts of a webservice
+request that you need to be able to customize.
 
-**Additionally you need to provide a property named the same as the hook that you want the service to be notified on** when running through the deploy pipeline (as we wouldn’t know when to notify a service otherwise):
+**Additionally you need to provide a property named the same as the hook that
+you want the service to be notified on** when running through the deploy
+pipeline (as we wouldn’t know when to notify a service otherwise):
 
 ```js
 // config/deploy.js
@@ -93,9 +120,16 @@ module.exports = function(deployTarget) {
 };
 ```
 
-`url`, `headers`, `method` and `body` are the basic ideas behind the service abstraction in ember-cli-deploy-notifications but to keep things simple you don’t have to provide `headers` and `method` for every custom service as these properties will default to `{}` and `'POST'` respectively.
+`url`, `headers`, `method` and `body` are the basic ideas behind the service
+abstraction in ember-cli-deploy-notifications but to keep things simple you
+don’t have to provide `headers` and `method` for every custom service as these
+properties will default to `{}` and `'POST'` respectively.
 
-As you can see service configuration properties can either be defined directly or generated dynamically based on the [deployment context](http://ember-cli-deploy.com/docs/v0.5.x/deployment-context/). `this` will always point to the service’s configuration itself in all of these functions which enables you to do things like this:
+As you can see service configuration properties can either be defined directly
+or generated dynamically based on the
+[deployment context](http://ember-cli-deploy.com/docs/v0.5.x/deployment-context/).
+`this` will always point to the service’s configuration itself in all of these
+functions which enables you to do things like this:
 
 ```js
 // config/deploy.js
@@ -123,7 +157,8 @@ module.exports = function(deployTarget) {
 };
 ```
 
-The configuration properties named the same as ember-cli-deploy’s pipeline-hooks can also be used to override configuration defaults on a per hook basis:
+The configuration properties named the same as ember-cli-deploy’s pipeline-hooks
+can also be used to override configuration defaults on a per hook basis:
 
 ```js
 // config/deploy.js
@@ -155,9 +190,15 @@ module.exports = function(deployTarget) {
 
 ### Preconfigured services
 
-As we wanted to make it as easy as possible to get started with ember-cli-deploy-notifications **there are already some preconfigured services**.
+As we wanted to make it as easy as possible to get started with
+ember-cli-deploy-notifications **there are already some preconfigured
+services**.
 
-Preconfigured services differ from custom services in the fact that the community has already provided a default configuration for these services. **For example the popular error tracking service [bugsnag](http://bugsnag.com) is already preconfigured which makes it easy to use out of the box** with ember-cli-deploy-notifications:
+Preconfigured services differ from custom services in the fact that the
+community has already provided a default configuration for these services. **For
+example the popular error tracking service [bugsnag](http://bugsnag.com) is
+already preconfigured which makes it easy to use out of the box** with
+ember-cli-deploy-notifications:
 
 ```js
 // config/deploy.js
@@ -183,6 +224,13 @@ There is also a preconfigured service for slack.
 
 ## Next Steps
 
-**We are excited to share this small ember-cli-deploy plugin with the ember community and would like to hear your feedback!** We are already using it in client projects and, though pretty small, found it to be a very useful addition to our deployment workflow.
+**We are excited to share this small ember-cli-deploy plugin with the ember
+community and would like to hear your feedback!** We are already using it in
+client projects and, though pretty small, found it to be a very useful addition
+to our deployment workflow.
 
-Please refer to the project’s [README](https://github.com/simplabs/ember-cli-deploy-notifications#readme) for more detailed information about the plugin and don’t hesitate to open issues or ask questions, we’re happy to support you in setting up a great deployment workflow for your Ember applications.
+Please refer to the project’s
+[README](https://github.com/simplabs/ember-cli-deploy-notifications#readme) for
+more detailed information about the plugin and don’t hesitate to open issues or
+ask questions, we’re happy to support you in setting up a great deployment
+workflow for your Ember applications.

--- a/_posts/2016-03-04-ember-test-selectors.md
+++ b/_posts/2016-03-04-ember-test-selectors.md
@@ -4,21 +4,33 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte announces the release of ember-test-selectors, an addon that enables better element selectors in Ember.js tests.'
+description:
+  'Marco Otte-Witte announces the release of ember-test-selectors, an addon that
+  enables better element selectors in Ember.js tests.'
 topic: ember
 ---
 
-We just released [ember-test-selectors](https://github.com/simplabs/ember-test-selectors), an **Ember Addon that enables better element selectors in Ember.js tests**. It removes all data attributes starting with `data-test-` from the application's templates in the `production` environment so that these attributes can be used to select elements with in acceptance and integration tests without polluting the markup that is delivered to the end user.
+We just released
+[ember-test-selectors](https://github.com/simplabs/ember-test-selectors), an
+**Ember Addon that enables better element selectors in Ember.js tests**. It
+removes all data attributes starting with `data-test-` from the application's
+templates in the `production` environment so that these attributes can be used
+to select elements with in acceptance and integration tests without polluting
+the markup that is delivered to the end user.
 
 <!--break-->
 
 ## Why even use `data` attributes as test selectors?
 
-Integration and acceptance tests usually **interact with and assert on the presence of certain elements** in the markup that an application renders. These elements are identified using CSS selectors. Most projects use one of three approaches for CSS selectors in tests:
+Integration and acceptance tests usually **interact with and assert on the
+presence of certain elements** in the markup that an application renders. These
+elements are identified using CSS selectors. Most projects use one of three
+approaches for CSS selectors in tests:
 
 ### Selectors based on HTML structure
 
-This approach simply selects elements by their position in the rendered HTML. For the following template:
+This approach simply selects elements by their position in the rendered HTML.
+For the following template:
 
 ```html
 <article>
@@ -27,7 +39,9 @@ This approach simply selects elements by their position in the rendered HTML. Fo
 </article>
 ```
 
-one might select the post's title with the selector `'article h1'`. Of course this breaks when changing the `<h1>` to a `<h2>` while the functionality being tested is probably not affected by that change.
+one might select the post's title with the selector `'article h1'`. Of course
+this breaks when changing the `<h1>` to a `<h2>` while the functionality being
+tested is probably not affected by that change.
 
 ### Selectors based on CSS classes
 
@@ -40,13 +54,19 @@ This approach selects elements by CSS classes. For the following template:
 </article>
 ```
 
-one might select the post title with the selector `'.post-title'`. This of course breaks when the CSS class is changed or renamed, although that would only be a visual change which shouldn't affect the tests at all.
+one might select the post title with the selector `'.post-title'`. This of
+course breaks when the CSS class is changed or renamed, although that would only
+be a visual change which shouldn't affect the tests at all.
 
-Many projects use CSS classes with special prefixes that are only used for testing to overcome this problem like `'js-post-title'`. While that approach is definitely more stable it is often hard to maintain. Also it doesn't easily allow to encode additional information like e.g. the post's id.
+Many projects use CSS classes with special prefixes that are only used for
+testing to overcome this problem like `'js-post-title'`. While that approach is
+definitely more stable it is often hard to maintain. Also it doesn't easily
+allow to encode additional information like e.g. the post's id.
 
 ### Selectors based on `data` attributes
 
-This approach uses HTML 5 `data` attributes to select elements. For the following template:
+This approach uses HTML 5 `data` attributes to select elements. For the
+following template:
 
 ```hbs
 <article>
@@ -55,7 +75,14 @@ This approach uses HTML 5 `data` attributes to select elements. For the followin
 </article>
 ```
 
-one would select the post's title with the selector `*[data-test-selector="post-title"]` (which selects any element with a `data-test-selector` attribute that has the value `"post-title"`). While the selector is arguably a bit longer this approach **clearly separates the test selectors from the rest of the markup and is resilient to change** as the attribute can be applied to any element rendering the post's title, regardless of the HTML structure, CSS classes etc. Also it easily allows encoding more data in the markup like e.g. the post's id:
+one would select the post's title with the selector
+`*[data-test-selector="post-title"]` (which selects any element with a
+`data-test-selector` attribute that has the value `"post-title"`). While the
+selector is arguably a bit longer this approach **clearly separates the test
+selectors from the rest of the markup and is resilient to change** as the
+attribute can be applied to any element rendering the post's title, regardless
+of the HTML structure, CSS classes etc. Also it easily allows encoding more data
+in the markup like e.g. the post's id:
 
 ```hbs
 <article>
@@ -64,7 +91,9 @@ one would select the post's title with the selector `*[data-test-selector="post-
 </article>
 ```
 
-`ember-test-selectors` makes sure to remove all these `data` attributes in the `production` environment so that **users will have perfectly clean HTML delivered**:
+`ember-test-selectors` makes sure to remove all these `data` attributes in the
+`production` environment so that **users will have perfectly clean HTML
+delivered**:
 
 ```html
 <article>
@@ -75,7 +104,16 @@ one would select the post's title with the selector `*[data-test-selector="post-
 
 ## Future Plans
 
-We have some future plans for ember-test-selectors to make working with data attributes as test selectors even more convenient:
+We have some future plans for ember-test-selectors to make working with data
+attributes as test selectors even more convenient:
 
-- custom test helpers that find elements by data attributes so that you don't have to write the quite long selectors yourselves; probably sth. like `findViaTestSelector('selector', 'post-title')`, [https://github.com/simplabs/ember-test-selectors/issues/8](https://github.com/simplabs/ember-test-selectors/issues/8)
-- template helpers that generate data attributes for elements, e.g. `<h1 {{test-selector="post-title"}}>{{post.title}}</h1>` which would result in `<h1 data-test-selector="post-title">{{post.title}}</h1>` or `<div {{test-selector post}}>…</div>` which would result in `<div data-test-selector="post-1">…</div>`, [https://github.com/simplabs/ember-test-selectors/issues/9](https://github.com/simplabs/ember-test-selectors/issues/9)
+- custom test helpers that find elements by data attributes so that you don't
+  have to write the quite long selectors yourselves; probably sth. like
+  `findViaTestSelector('selector', 'post-title')`,
+  [https://github.com/simplabs/ember-test-selectors/issues/8](https://github.com/simplabs/ember-test-selectors/issues/8)
+- template helpers that generate data attributes for elements, e.g.
+  `<h1 {{test-selector="post-title"}}>{{post.title}}</h1>` which would result in
+  `<h1 data-test-selector="post-title">{{post.title}}</h1>` or
+  `<div {{test-selector post}}>…</div>` which would result in
+  `<div data-test-selector="post-1">…</div>`,
+  [https://github.com/simplabs/ember-test-selectors/issues/9](https://github.com/simplabs/ember-test-selectors/issues/9)

--- a/_posts/2016-12-06-out-of-the-box-fastboot-support-in-ember-simple-auth.md
+++ b/_posts/2016-12-06-out-of-the-box-fastboot-support-in-ember-simple-auth.md
@@ -4,25 +4,67 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte announces out-of-the-box support for FastBoot in Ember Simple Auth and explains how it works using ember-cookies.'
+description:
+  'Marco Otte-Witte announces out-of-the-box support for FastBoot in Ember
+  Simple Auth and explains how it works using ember-cookies.'
 topic: ember
 ---
 
-Ever since <a href="https://www.youtube.com/watch?v=o12-90Dm-Qs">FastBoot was first announced at EmberConf 2015</a> it was clear to us that we wanted to have out-of-the-box support for it in Ember Simple Auth. Our goal was to make sure that Ember Simple Auth did not keep anyone from adopting FastBoot and adopting FastBoot would not result in people having to figure out their own authentication and authorization solutions. Today we're happy to announce the availability of <a href="https://github.com/simplabs/ember-simple-auth/releases/tag/1.2.0-beta.1">Ember Simple Auth 1.2.0-beta.1</a>, the <strong>first release with out-of-the-box support for FastBoot</strong>.
+Ever since <a href="https://www.youtube.com/watch?v=o12-90Dm-Qs">FastBoot was
+first announced at EmberConf 2015</a> it was clear to us that we wanted to have
+out-of-the-box support for it in Ember Simple Auth. Our goal was to make sure
+that Ember Simple Auth did not keep anyone from adopting FastBoot and adopting
+FastBoot would not result in people having to figure out their own
+authentication and authorization solutions. Today we're happy to announce the
+availability of
+<a href="https://github.com/simplabs/ember-simple-auth/releases/tag/1.2.0-beta.1">Ember
+Simple Auth 1.2.0-beta.1</a>, the <strong>first release with out-of-the-box
+support for FastBoot</strong>.
 
 <!--break-->
 
 ## Seamless Session Synchronization
 
-Ember Simple Auth 1.2 seamlessly <strong>synchronizes the session state between the browser and FastBoot server</strong>. When a user logs in to an Ember.js application and refreshes the page or comes back to the app later - triggering a request that's handled by the FastBoot server - Ember Simple Auth will send the session state along with that request, pick it up in the app instance that's running in the FastBoot server and <strong>make sure the Ember route is being loaded and rendered in the correct session context</strong>. If the session turns out to be invalid for some reason, the server will invalidate it and the user will be redirected to the login page via a proper HTTP redirect.
+Ember Simple Auth 1.2 seamlessly <strong>synchronizes the session state between
+the browser and FastBoot server</strong>. When a user logs in to an Ember.js
+application and refreshes the page or comes back to the app later - triggering a
+request that's handled by the FastBoot server - Ember Simple Auth will send the
+session state along with that request, pick it up in the app instance that's
+running in the FastBoot server and <strong>make sure the Ember route is being
+loaded and rendered in the correct session context</strong>. If the session
+turns out to be invalid for some reason, the server will invalidate it and the
+user will be redirected to the login page via a proper HTTP redirect.
 
 ## Under the hood
 
-Ember Simple Auth has always had the concept of session stores that persist the session state so that it survives page reloads (or users leaving the app and coming back later). <strong>One of these session stores turned out to be the perfect fit for the aforementioned session syncing mechanism – the cookie session store</strong>. Browsers will automatically send cookies for a particular origin along with any request to that origin. Also, servers can modify cookies sent by the browser and include updates in the response that the browser will automatically pick up - effectively enabling bidirectional state synchronization.
+Ember Simple Auth has always had the concept of session stores that persist the
+session state so that it survives page reloads (or users leaving the app and
+coming back later). <strong>One of these session stores turned out to be the
+perfect fit for the aforementioned session syncing mechanism – the cookie
+session store</strong>. Browsers will automatically send cookies for a
+particular origin along with any request to that origin. Also, servers can
+modify cookies sent by the browser and include updates in the response that the
+browser will automatically pick up - effectively enabling bidirectional state
+synchronization.
 
-The main challenge with enabling the cookie session store to run both in the browser as well as in Node though was that the APIs for cookie handling are obviously totally different in both environments. In the browser there is `document.cookie` while in server apps running in Node, cookies are being read and written via the `Cookie` and `Set-Cookie` headers. That meant we had to come up with a way to read and write cookies via a common interface that we could rely on in the cookie session store and that abstracted these environment specific APIs under the hood (much like what <a href="https://github.com/tomdale/ember-network">ember-network</a> does for the <a href="https://github.com/tomdale/ember-network">fetch API</a>). Therefore we created <strong><a href="https://github.com/simplabs/ember-cookies">ember-cookies</a> which is a cookies abstraction that works in the browser as well as in Node</strong> and that's now being used internally by the cookie session store.
+The main challenge with enabling the cookie session store to run both in the
+browser as well as in Node though was that the APIs for cookie handling are
+obviously totally different in both environments. In the browser there is
+`document.cookie` while in server apps running in Node, cookies are being read
+and written via the `Cookie` and `Set-Cookie` headers. That meant we had to come
+up with a way to read and write cookies via a common interface that we could
+rely on in the cookie session store and that abstracted these environment
+specific APIs under the hood (much like what
+<a href="https://github.com/tomdale/ember-network">ember-network</a> does for
+the <a href="https://github.com/tomdale/ember-network">fetch API</a>). Therefore
+we created
+<strong><a href="https://github.com/simplabs/ember-cookies">ember-cookies</a>
+which is a cookies abstraction that works in the browser as well as in
+Node</strong> and that's now being used internally by the cookie session store.
 
-ember-cookies exposes a cookies service with <a href="https://github.com/simplabs/ember-cookies#api">`read`, `write` and `clear` methods</a>:
+ember-cookies exposes a cookies service with
+<a href="https://github.com/simplabs/ember-cookies#api">`read`, `write` and
+`clear` methods</a>:
 
 <!-- prettier-ignore -->
 ```js
@@ -44,7 +86,9 @@ export default Ember.Controller.extend({
 
 ## Using Ember Simple Auth with FastBoot
 
-As most of Ember Simple Auth's support for FastBoot is based on the cookie session store, <strong>enabling FastBoot support is as easy as defining the application session store</strong> as:
+As most of Ember Simple Auth's support for FastBoot is based on the cookie
+session store, <strong>enabling FastBoot support is as easy as defining the
+application session store</strong> as:
 
 ```js
 // app/session-stores/application.js
@@ -53,25 +97,53 @@ import Cookie from 'ember-simple-auth/session-stores/cookie';
 export default Cookie.extend();
 ```
 
-If you're interested in learning more about the underlying concepts check out the <a href="https://www.youtube.com/watch?v=jcAgi7fpTw8&index=6&list=PL4eq2DPpyBbmrPasP06vK7cUkPUCNn_rW">talk about Authentication and Session Management in FastBoot</a> that I gave at <a href="http://embercamp.com">EmberCamp</a> in London in June.
+If you're interested in learning more about the underlying concepts check out
+the
+<a href="https://www.youtube.com/watch?v=jcAgi7fpTw8&index=6&list=PL4eq2DPpyBbmrPasP06vK7cUkPUCNn_rW">talk
+about Authentication and Session Management in FastBoot</a> that I gave at
+<a href="http://embercamp.com">EmberCamp</a> in London in June.
 
 ## Other Changes and Fixes
 
-Out-of-the-box support for FastBoot is likely the most prominent addition in this release but there are <strong>quite some other changes</strong> as well, including:
+Out-of-the-box support for FastBoot is likely the most prominent addition in
+this release but there are <strong>quite some other changes</strong> as well,
+including:
 
-- The default cookie names that the cookie session store uses are now compliant with RFC 2616, see <a href="https://github.com/simplabs/ember-simple-auth/pull/978">#978</a>
-- Server responses are now validated in authenticators, preventing successful logins when required data is actually missing, see <a href="https://github.com/simplabs/ember-simple-auth/pull/957">#957</a>
-- The OAuth 2.0 Password Grant authenticator can now send custom headers along with authentication requests, see <a href="https://github.com/simplabs/ember-simple-auth/pull/1018">#1018</a>
+- The default cookie names that the cookie session store uses are now compliant
+  with RFC 2616, see
+  <a href="https://github.com/simplabs/ember-simple-auth/pull/978">#978</a>
+- Server responses are now validated in authenticators, preventing successful
+  logins when required data is actually missing, see
+  <a href="https://github.com/simplabs/ember-simple-auth/pull/957">#957</a>
+- The OAuth 2.0 Password Grant authenticator can now send custom headers along
+  with authentication requests, see
+  <a href="https://github.com/simplabs/ember-simple-auth/pull/1018">#1018</a>
 
 In addition to these changes, fixed issues include:
 
-- Routes like the login route can now be configured inline in routes using the respective mixins as opposed to `config/environment.js`, see <a href="https://github.com/simplabs/ember-simple-auth/pull/1041">#1041</a>
-- The cookie session store will now rewrite its cookies when any of its configurable properties (like cookie name) change, see <a href="https://github.com/simplabs/ember-simple-auth/pull/1056">#1056</a>
+- Routes like the login route can now be configured inline in routes using the
+  respective mixins as opposed to `config/environment.js`, see
+  <a href="https://github.com/simplabs/ember-simple-auth/pull/1041">#1041</a>
+- The cookie session store will now rewrite its cookies when any of its
+  configurable properties (like cookie name) change, see
+  <a href="https://github.com/simplabs/ember-simple-auth/pull/1056">#1056</a>
 
 ## A Community Effort
 
-This certainly is one of the larger releases in Ember Simple Auth's history and <strong>a lot of people have helped to make it happen</strong>. We'd like to thank all of our (at the time of this writing) <a href="https://github.com/simplabs/ember-simple-auth/graphs/contributors">141 contributors</a>, with particular mention to <a href="https://github.com/stevenwu">Steven Wu</a>, <a href="https://github.com/kylemellander">Kyle Mellander</a>, <a href="https://github.com/arjansingh">Arjan Singh</a> and <a href="https://github.com/josemarluedke">Josemar Luedke</a> for awesome contributions to the Fastboot effort and ember-cookies.
+This certainly is one of the larger releases in Ember Simple Auth's history and
+<strong>a lot of people have helped to make it happen</strong>. We'd like to
+thank all of our (at the time of this writing)
+<a href="https://github.com/simplabs/ember-simple-auth/graphs/contributors">141
+contributors</a>, with particular mention to
+<a href="https://github.com/stevenwu">Steven Wu</a>,
+<a href="https://github.com/kylemellander">Kyle Mellander</a>,
+<a href="https://github.com/arjansingh">Arjan Singh</a> and
+<a href="https://github.com/josemarluedke">Josemar Luedke</a> for awesome
+contributions to the Fastboot effort and ember-cookies.
 
 ## Try it!
 
-As this is a beta release, <strong>there are probably some rough edges</strong>. We'd like everyone to try it, regardless of whether they're using Fastboot already or not and <strong>report bugs, outdated or bad documentation etc. on <a href="https://github.com/simplabs/ember-simple-auth/releases">github</a></strong>.
+As this is a beta release, <strong>there are probably some rough edges</strong>.
+We'd like everyone to try it, regardless of whether they're using Fastboot
+already or not and <strong>report bugs, outdated or bad documentation etc. on
+<a href="https://github.com/simplabs/ember-simple-auth/releases">github</a></strong>.

--- a/_posts/2017-01-13-ember-test-selectors.md
+++ b/_posts/2017-01-13-ember-test-selectors.md
@@ -4,7 +4,10 @@ author: 'Tobias Bieniek'
 github: Turbo87
 twitter: tobiasbieniek
 bio: 'Senior Frontend Engineer, Ember CLI core team member'
-description: 'Tobias Bieniek announces new features in ember-test-selectors such as automatic binding of data-test-* properties and how these are stripped in production.'
+description:
+  'Tobias Bieniek announces new features in ember-test-selectors such as
+  automatic binding of data-test-* properties and how these are stripped in
+  production.'
 topic: ember
 ---
 
@@ -16,17 +19,17 @@ While `0.1.0` does not sound like much has changed, the addon has actually
 gained a lot of new functionality and should be considered our release candidate
 for `1.0.0`.
 
-This blog post will highlight the major changes in this release, and will
-give you a short introduction into _how_ we have implemented these new
-features.
+This blog post will highlight the major changes in this release, and will give
+you a short introduction into _how_ we have implemented these new features.
 
 <!--break-->
 
 ## Automatic binding of `data-test-*` properties
 
-As you may know from our [previous blog post](/blog/2016/03/04/ember-test-selectors)
-on this topic, the goal of this addon is to let you use attributes starting
-with `data-test-` in your templates:
+As you may know from our
+[previous blog post](/blog/2016/03/04/ember-test-selectors) on this topic, the
+goal of this addon is to let you use attributes starting with `data-test-` in
+your templates:
 
 ```handlebars
 <article>
@@ -35,17 +38,18 @@ with `data-test-` in your templates:
 </article>
 ```
 
-... so that you can use these as selectors in your acceptance and integration tests:
+... so that you can use these as selectors in your acceptance and integration
+tests:
 
 ```js
 assert.equal(find(testSelector('post-title')).text(), 'my first blog post');
 //           find( '[data-test-post-title]' )
 ```
 
-While this worked well on HTML tags, using the same pattern on components was
-a little more complicated. The assigned `data-test-*` properties needed to be
-bound to HTML attributes by adding them to the `attributeBindings` array on
-the component class.
+While this worked well on HTML tags, using the same pattern on components was a
+little more complicated. The assigned `data-test-*` properties needed to be
+bound to HTML attributes by adding them to the `attributeBindings` array on the
+component class.
 
 One of the major changes in this new release is that modifying the
 `attributeBindings` array is now done automatically for you, so that you can
@@ -64,25 +68,29 @@ automatically appear on the `<div>` tag wrapping the component:
 
 ### How we implemented this
 
-Since we wanted to make this feature available on all components by default
-we had to `reopen()` the `Ember.Component` class, figure out the list of
+Since we wanted to make this feature available on all components by default we
+had to `reopen()` the `Ember.Component` class, figure out the list of
 `data-test-*` properties on the component, and then add them to the
 `attributeBindings` array.
 
-The natural way to do this within an addon is using an [initializer](https://guides.emberjs.com/v2.10.0/applications/initializers/),
-so that is what we [did](https://github.com/simplabs/ember-test-selectors/blob/v0.1.0/addon/initializers/ember-test-selectors.js#L5-L10).
-Instead of putting all the logic in the initializer itself, we have extracted
-it into a [`bindDataTestAttributes()`](https://github.com/simplabs/ember-test-selectors/blob/v0.1.0/addon/utils/bind-data-test-attributes.js)
-function, which we were now able to [unit test](https://github.com/simplabs/ember-test-selectors/blob/v0.1.0/tests/unit/utils/bind-data-test-attributes-test.js)
+The natural way to do this within an addon is using an
+[initializer](https://guides.emberjs.com/v2.10.0/applications/initializers/), so
+that is what we
+[did](https://github.com/simplabs/ember-test-selectors/blob/v0.1.0/addon/initializers/ember-test-selectors.js#L5-L10).
+Instead of putting all the logic in the initializer itself, we have extracted it
+into a
+[`bindDataTestAttributes()`](https://github.com/simplabs/ember-test-selectors/blob/v0.1.0/addon/utils/bind-data-test-attributes.js)
+function, which we were now able to
+[unit test](https://github.com/simplabs/ember-test-selectors/blob/v0.1.0/tests/unit/utils/bind-data-test-attributes-test.js)
 separately.
 
-As we are committed to not including any unnecessary code in your
-production builds, we also had to make sure to not include the
-initializer and utility function in there. Since both of those are part
-of our `addon` and `app` folders, which are included in your builds by
-default, we borrowed a ["trick"](https://github.com/ember-cli/ember-cli-chai/blob/master/index.js#L119-L123)
-from [ember-cli-chai](https://github.com/ember-cli/ember-cli-chai/) which
-only includes both folders if we are in [testing mode](#testing-in-production-mode).
+As we are committed to not including any unnecessary code in your production
+builds, we also had to make sure to not include the initializer and utility
+function in there. Since both of those are part of our `addon` and `app`
+folders, which are included in your builds by default, we borrowed a
+["trick"](https://github.com/ember-cli/ember-cli-chai/blob/master/index.js#L119-L123)
+from [ember-cli-chai](https://github.com/ember-cli/ember-cli-chai/) which only
+includes both folders if we are in [testing mode](#testing-in-production-mode).
 
 ```js
 module.exports = {
@@ -104,28 +112,28 @@ module.exports = {
 };
 ```
 
-**UPDATE:** After releasing `0.1.0` we were notified that this feature was
-not working for component integration tests, which was actually a pretty
-obvious problem as initializers are not running for these kinds of
-tests. After thinking about the issue for a few hours we came up with a
-solution that seems to work even better now. Instead of calling
-`Component.reopen()` in an initializer we are now doing it in a file in our
-`vendor` folder, which is always being run before any tests are executed.
+**UPDATE:** After releasing `0.1.0` we were notified that this feature was not
+working for component integration tests, which was actually a pretty obvious
+problem as initializers are not running for these kinds of tests. After thinking
+about the issue for a few hours we came up with a solution that seems to work
+even better now. Instead of calling `Component.reopen()` in an initializer we
+are now doing it in a file in our `vendor` folder, which is always being run
+before any tests are executed.
 
-We have released `0.1.1` including this change and are now also warning you
-if you try to use `data-test-*` attributes on tagless components.
+We have released `0.1.1` including this change and are now also warning you if
+you try to use `data-test-*` attributes on tagless components.
 
 ## Stripping out `data-test-*` attributes in templates
 
 Our initial goal with this library was stripping our `data-test-*` attributes
 from HTML tags in your templates. In the previous section we implemented
-automatic bindings for `data-test-*` properties on components now too, but
-these properties were not stripped from the template yet.
+automatic bindings for `data-test-*` properties on components now too, but these
+properties were not stripped from the template yet.
 
 To modify templates from within an addon our best bet was to use an
-<abbr title="Abstract Syntax Tree">AST</abbr> transform on the Handlebars
-AST, that we get from the template parser. This can be accomplished by
-registering a Handlebars AST plugin in the
+<abbr title="Abstract Syntax Tree">AST</abbr> transform on the Handlebars AST,
+that we get from the template parser. This can be accomplished by registering a
+Handlebars AST plugin in the
 [`setupPreprocessorRegistry()`](https://ember-cli.com/api/classes/Addon.html#method_setupPreprocessorRegistry)
 hook of the addon:
 
@@ -147,8 +155,8 @@ module.exports = {
 ```
 
 While this AST transform already existed in the previous releases, it was only
-able to handle `data-test-*` attributes on HTML tags (called `ElementNode`),
-but not on curly components yet:
+able to handle `data-test-*` attributes on HTML tags (called `ElementNode`), but
+not on curly components yet:
 
 ```js
 var TEST_SELECTOR_PREFIX = /data-test-.*/;
@@ -173,8 +181,8 @@ module.exports = class {
 You can try out what this transform does in the
 [AST explorer](https://astexplorer.net/#/5ZDpdTbKwL).
 
-Fortunately for us the code to make this AST transform work for curly
-components is very similar:
+Fortunately for us the code to make this AST transform work for curly components
+is very similar:
 
 ```js
 if (node.type === 'MustacheStatement' || node.type === 'BlockStatement') {
@@ -192,8 +200,8 @@ of the `some-component` invocation is now gone.
 ## Stripping out `data-test-*` properties in JS files
 
 While one way of assigning data attributes to a component is in the template,
-data attributes can also be defined as properties on the component class.
-So instead of assigning `data-test-comment-id` inside the loop:
+data attributes can also be defined as properties on the component class. So
+instead of assigning `data-test-comment-id` inside the loop:
 
 ```handlebars
 {{#each comments as |comment|}}
@@ -212,15 +220,15 @@ export default Ember.Component({
 ```
 
 Unfortunately we have now have a property that is not stripped by the AST
-transform described in the previous section. At this point we could have
-used a similar strategy as before and added a JavaScript preprocessor, that
-strips all those properties from the code, but instead we hooked into the
-existing JavaScript processing pipeline using [Babel](http://babeljs.io/).
+transform described in the previous section. At this point we could have used a
+similar strategy as before and added a JavaScript preprocessor, that strips all
+those properties from the code, but instead we hooked into the existing
+JavaScript processing pipeline using [Babel](http://babeljs.io/).
 
-Fortunately for us the fantastic [AST explorer](https://astexplorer.net/)
-also supports prototyping Babel plugins and so we came up with a simple
-[plugin](https://astexplorer.net/#/xd5PB1rSD6) that basically just
-removes `data-test-*` properties from all the objects in your code:
+Fortunately for us the fantastic [AST explorer](https://astexplorer.net/) also
+supports prototyping Babel plugins and so we came up with a simple
+[plugin](https://astexplorer.net/#/xd5PB1rSD6) that basically just removes
+`data-test-*` properties from all the objects in your code:
 
 ```js
 var TEST_SELECTOR_PREFIX = /data-test-.*/;
@@ -238,10 +246,10 @@ module.exports = function(babel) {
 };
 ```
 
-With the Babel plugin done, all we had left to do was making sure that your
-app actually uses that plugin at build time. While this is not quite public
-API and may change in the future we have found a way to accomplish that in the
-official [ember-cli-htmlbars-inline-precompile](https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile/blob/v0.3.6/index.js#L64-L69)
+With the Babel plugin done, all we had left to do was making sure that your app
+actually uses that plugin at build time. While this is not quite public API and
+may change in the future we have found a way to accomplish that in the official
+[ember-cli-htmlbars-inline-precompile](https://github.com/ember-cli/ember-cli-htmlbars-inline-precompile/blob/v0.3.6/index.js#L64-L69)
 addon:
 
 ```js
@@ -258,7 +266,9 @@ module.exports = {
       app.options.babel = app.options.babel || {};
       app.options.babel.plugins = app.options.babel.plugins || [];
 
-      app.options.babel.plugins.push(require('./strip-data-test-properties-plugin'));
+      app.options.babel.plugins.push(
+        require('./strip-data-test-properties-plugin'),
+      );
     }
   },
 };
@@ -272,23 +282,23 @@ default of this option was set to `['production']`, which made sense at the
 time.
 
 Since then we had discovered though that this will keep you from running your
-tests in `production` mode using `ember test --environment=production`.
-Instead of just checking the `environment` we are now making use of the
+tests in `production` mode using `ember test --environment=production`. Instead
+of just checking the `environment` we are now making use of the
 ([not yet documented](https://github.com/ember-cli/ember-cli/issues/6656))
 `tests` property on the `EmberApp` class in Ember CLI.
 
 This property will be `true` when using the `development` environment with
-either `ember build`, `ember serve` or `ember test`, or it will be `true`
-when using `ember test --environment=production`. That makes sure that we
-still strip all the `data-test-*` attributes from your code in production
-builds, but you should now again be able to also test your production builds
-using test selectors.
+either `ember build`, `ember serve` or `ember test`, or it will be `true` when
+using `ember test --environment=production`. That makes sure that we still strip
+all the `data-test-*` attributes from your code in production builds, but you
+should now again be able to also test your production builds using test
+selectors.
 
 Since we previously offered an option to override our defaults, we were
 committed to doing the same for the new defaults. For this we have deprecated
-this existing `environments` option, and introduced a new `strip` option,
-which can be set to `true` or `false`, but defaults to the `tests` property
-described above:
+this existing `environments` option, and introduced a new `strip` option, which
+can be set to `true` or `false`, but defaults to the `tests` property described
+above:
 
 ```js
 var app = new EmberApp({
@@ -305,18 +315,20 @@ will be removed by the time we release `1.0.0`.
 
 The `testSelector()` helper function can be used to simplify building the
 CSS/jQuery selector strings used for `find()` or `this.$()` in your tests.
-Previously you had to import that function from `<app-name>/tests/helpers/ember-test-selectors`,
-but since our `addon` folder is now removed from the build in production
-we were able to simplify that import to just this:
+Previously you had to import that function from
+`<app-name>/tests/helpers/ember-test-selectors`, but since our `addon` folder is
+now removed from the build in production we were able to simplify that import to
+just this:
 
 ```js
 import testSelector from 'ember-test-selectors';
 ```
 
-We hope you enjoyed reading about our progress on this project and we would
-love to get feedback on what else we can improve. Feel free to
+We hope you enjoyed reading about our progress on this project and we would love
+to get feedback on what else we can improve. Feel free to
 [reach out](https://github.com/simplabs/ember-test-selectors/issues/new)!
 
 **Note:** The code examples in this blog posts are simplified to be easier to
-digest. Please refer to the [actual implementation](https://github.com/simplabs/ember-test-selectors)
-if you want to see all the glory details.
+digest. Please refer to the
+[actual implementation](https://github.com/simplabs/ember-test-selectors) if you
+want to see all the glory details.

--- a/_posts/2017-02-01-class-based-computed-properties.md
+++ b/_posts/2017-02-01-class-based-computed-properties.md
@@ -4,39 +4,66 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte introduces a mechanism for class based computed properties in Ember.js and how those can be used instead of helpers.'
+description:
+  'Marco Otte-Witte introduces a mechanism for class based computed properties
+  in Ember.js and how those can be used instead of helpers.'
 topic: ember
 ---
 
-We think Computed Properties in Ember are awesome. We also think they [are in many cases the better alternative to template helpers](https://speakerdeck.com/marcoow/templates-and-logic-in-ember) as they allow for cleaner separation of where a computation is triggered and the implementation of that computation. In some cases though it is currently very hard to do things in Computed Properties (and Computed Property macros in particular) that are possible with Class based helpers. With the **introduction of Class based Computed Properties** we're aiming at making these scenarios solvable easily.
+We think Computed Properties in Ember are awesome. We also think they
+[are in many cases the better alternative to template helpers](https://speakerdeck.com/marcoow/templates-and-logic-in-ember)
+as they allow for cleaner separation of where a computation is triggered and the
+implementation of that computation. In some cases though it is currently very
+hard to do things in Computed Properties (and Computed Property macros in
+particular) that are possible with Class based helpers. With the **introduction
+of Class based Computed Properties** we're aiming at making these scenarios
+solvable easily.
 
 <!--break-->
 
 ## Computed Properties and Computed Property Macros
 
-Computed Properties are among the first things developers new to Ember learn. They are a great way of defining dependencies between data points in the application and **ensuring the UI stays consistent as these data points change**.
+Computed Properties are among the first things developers new to Ember learn.
+They are a great way of defining dependencies between data points in the
+application and **ensuring the UI stays consistent as these data points
+change**.
 
-Ember comes with a set of macros that implement property logic that most applications need and allow for short and expressive definitions like
+Ember comes with a set of macros that implement property logic that most
+applications need and allow for short and expressive definitions like
 
 ```js
 isActive: Ember.computed.equal('state', 'isActive');
 ```
 
-There are addons that provide even more macros for common use cases like [ember-cpm](https://github.com/cibernox/ember-cpm) or [ember-awesome-macros](https://github.com/kellyselden/ember-awesome-macros).
+There are addons that provide even more macros for common use cases like
+[ember-cpm](https://github.com/cibernox/ember-cpm) or
+[ember-awesome-macros](https://github.com/kellyselden/ember-awesome-macros).
 
 ## Where Computed Property Macros fall short today
 
-**Computed Properties are very similar to template helpers** in the way that both are [pure functions](https://en.wikipedia.org/wiki/Pure_function) that can only depend on their inputs. While a template helpers receives its inputs as arguments, **Computed Properties define their inputs as dependent keys**.
+**Computed Properties are very similar to template helpers** in the way that
+both are [pure functions](https://en.wikipedia.org/wiki/Pure_function) that can
+only depend on their inputs. While a template helpers receives its inputs as
+arguments, **Computed Properties define their inputs as dependent keys**.
 
-In some cases pure functions are not sufficient though as the computation in the template helper or computed property also depends on global state or the inputs cannot statically be listed in the helper or property definition. This is the case for example for computations on collections when it is unknown upfront on which property of each element in the collection the computation depends, e.g.
+In some cases pure functions are not sufficient though as the computation in the
+template helper or computed property also depends on global state or the inputs
+cannot statically be listed in the helper or property definition. This is the
+case for example for computations on collections when it is unknown upfront on
+which property of each element in the collection the computation depends, e.g.
 
 ```js
 filteredUsers: filterByProperty('users' 'filter')
 ```
 
-Here what we would like to do is filter the `users` array by the value of the `filter` property of the context. E.g. when `filter` is `'isActive'` we'd expect `filteredUsers` to contain all active users, when `filter` is `'isBlocked'` we'd expect it to contain all blocked users and so on.
+Here what we would like to do is filter the `users` array by the value of the
+`filter` property of the context. E.g. when `filter` is `'isActive'` we'd expect
+`filteredUsers` to contain all active users, when `filter` is `'isBlocked'` we'd
+expect it to contain all blocked users and so on.
 
-With template helpers and the [ember-composable-helpers](https://github.com/DockYard/ember-composable-helpers) addon, we're be able to write something like this in the template:
+With template helpers and the
+[ember-composable-helpers](https://github.com/DockYard/ember-composable-helpers)
+addon, we're be able to write something like this in the template:
 
 ```hbs
 {{#each (filter-by filter users) as |user|}}
@@ -44,13 +71,25 @@ With template helpers and the [ember-composable-helpers](https://github.com/Dock
 {{/each}}
 ```
 
-and because the [`filter-by` helper is a Class based helper](https://github.com/DockYard/ember-composable-helpers/blob/master/addon/helpers/filter-by.js) this actually works and the DOM updates correctly whenever the value of the `filter` property or e.g. the `isActive` property of any user changes.
+and because the
+[`filter-by` helper is a Class based helper](https://github.com/DockYard/ember-composable-helpers/blob/master/addon/helpers/filter-by.js)
+this actually works and the DOM updates correctly whenever the value of the
+`filter` property or e.g. the `isActive` property of any user changes.
 
-With Computed Properties **it is not currently possible to implement something like this** (at least not as a reusable macro).
+With Computed Properties **it is not currently possible to implement something
+like this** (at least not as a reusable macro).
 
 ## Enter Class based Computed Properties
 
-With the Class based Computed Properties that [ember-classy-computed](https://github.com/simplabs/ember-classy-computed) introduces it is **actually possible now to implement something like the above mentioned `filterByProperty` macro**. The computed property returned by that macro can now correctly be invalidated when any of the user's `isActive`, `isBlocked` etc. properties change although it is not actually possible to know what these properties might be upfront. This **allows keeping the filtering logic in JavaScript as opposed to in the template** when using a Class based template helper:
+With the Class based Computed Properties that
+[ember-classy-computed](https://github.com/simplabs/ember-classy-computed)
+introduces it is **actually possible now to implement something like the above
+mentioned `filterByProperty` macro**. The computed property returned by that
+macro can now correctly be invalidated when any of the user's `isActive`,
+`isBlocked` etc. properties change although it is not actually possible to know
+what these properties might be upfront. This **allows keeping the filtering
+logic in JavaScript as opposed to in the template** when using a Class based
+template helper:
 
 ```js
 import filterByProperty from 'app/computeds/filter-by';
@@ -105,8 +144,21 @@ const DynamicFilterByComputed = ClassBasedComputedProperty.extend({
 export default ClassBasedComputedProperty.property(DynamicFilterByComputed);
 ```
 
-Comparing this code to the implementation of the [`filter-by` helper](https://github.com/DockYard/ember-composable-helpers/blob/master/addon/helpers/filter-by.js) mentioned above you will recognize that both are almost identical. This illustrates very well what Class based Computed Properties are: a way to **use the same mechanisms that are already established for Class based template helpers for Computed Properties** as well.
+Comparing this code to the implementation of the
+[`filter-by` helper](https://github.com/DockYard/ember-composable-helpers/blob/master/addon/helpers/filter-by.js)
+mentioned above you will recognize that both are almost identical. This
+illustrates very well what Class based Computed Properties are: a way to **use
+the same mechanisms that are already established for Class based template
+helpers for Computed Properties** as well.
 
 ## Notice
 
-**[ember-classy-computed](https://github.com/simplabs/ember-classy-computed) is currently at a very early stage** and we haven't thoroughly tested the implementation just yet. We have also not done any benchmarking to get a better understanding of what the performance implications are. That is to say, **while we encourage everyone to try this out, be aware you're currently doing so at your own risk** as this is most likely not production ready (yet). We have the feeling though that this will be a valuable addition to Computed Properties in the future and can close the gap that currently exists between Computed Properties and template helpers.
+**[ember-classy-computed](https://github.com/simplabs/ember-classy-computed) is
+currently at a very early stage** and we haven't thoroughly tested the
+implementation just yet. We have also not done any benchmarking to get a better
+understanding of what the performance implications are. That is to say, **while
+we encourage everyone to try this out, be aware you're currently doing so at
+your own risk** as this is most likely not production ready (yet). We have the
+feeling though that this will be a valuable addition to Computed Properties in
+the future and can close the gap that currently exists between Computed
+Properties and template helpers.

--- a/_posts/2017-02-13-npm-libs-in-ember-cli.md
+++ b/_posts/2017-02-13-npm-libs-in-ember-cli.md
@@ -4,7 +4,9 @@ author: 'Tobias Bieniek'
 github: Turbo87
 twitter: tobiasbieniek
 bio: 'Senior Frontend Engineer, Ember CLI core team member'
-description: 'Tobias Bieniek introduces a mechanism for using arbitrary npm libraries in Ember CLI applications and explains how that works under the hood.'
+description:
+  'Tobias Bieniek introduces a mechanism for using arbitrary npm libraries in
+  Ember CLI applications and explains how that works under the hood.'
 topic: ember
 og:
   image: /assets/images/posts/2017-02-13-npm-libs-in-ember-cli/og-image.png
@@ -16,8 +18,8 @@ With Ember 2.11 we are now using the [`ember-source`][ember-source] module and
 no longer the `ember` [Bower][bower] package. In the upcoming Ember CLI 2.12
 release, Bower will also no longer be installed by default and only install
 lazily when an addon requests it. All this indicates that from now on we should
-try to use npm packages instead of Bower whenever possible. This blog post
-will explain how we can do that and what options are available to us.
+try to use npm packages instead of Bower whenever possible. This blog post will
+explain how we can do that and what options are available to us.
 
 <!--break-->
 
@@ -39,12 +41,11 @@ app.import('bower_components/moment/moment.js');
 ```
 
 This `import()` call tells Ember CLI to add the `moment.js` file to the
-generated `vendor.js` file to make the `moment` global available to the
-app.
+generated `vendor.js` file to make the `moment` global available to the app.
 
 As we prefer to use ES6 imports instead of globals we will generate a so-called
-"vendor shim" which essentially just wraps the global and provides us with a
-way to import it as an ES6 module:
+"vendor shim" which essentially just wraps the global and provides us with a way
+to import it as an ES6 module:
 
 ```
 ember generate vendor-shim moment
@@ -68,13 +69,13 @@ like this:
 This looks a little cryptic at first, but once you understand the individual
 parts it starts to make sense.
 
-The files that the Ember CLI build pipeline generates use the
-[Asynchronous Module Definition][amd] (or shorter: AMD). The `define()` call in
-the code above defines a new AMD module with the name `moment` and the return
-value of the `vendorModule` function describes what the module exports, or
-what we can import from that module in our own code. In this case we export
-an object with a `default` property that contains the `moment` global. You can
-find more information on "default exports" and ES6 modules in general in the
+The files that the Ember CLI build pipeline generates use the [Asynchronous
+Module Definition][amd] (or shorter: AMD). The `define()` call in the code above
+defines a new AMD module with the name `moment` and the return value of the
+`vendorModule` function describes what the module exports, or what we can import
+from that module in our own code. In this case we export an object with a
+`default` property that contains the `moment` global. You can find more
+information on "default exports" and ES6 modules in general in the
 [Exploring ES6](http://exploringjs.com/es6/ch_modules.html) ebook.
 
 To use this vendor shim we will have to `app.import()` it like we did with the
@@ -89,10 +90,9 @@ We are now able to use `import moment from 'moment';` in our Ember code.
 ## App vs. Addon
 
 The above instructions work great for apps, but what about addons? The
-`ember-cli-build.js` file for addons is only relevant for building the dummy
-app of the addon, but not for any other app using the addon. That means we
-can't just call `app.import()` in the `ember-cli-build.js` file like we did
-above.
+`ember-cli-build.js` file for addons is only relevant for building the dummy app
+of the addon, but not for any other app using the addon. That means we can't
+just call `app.import()` in the `ember-cli-build.js` file like we did above.
 
 The solution to that is using the [`included()`][included-hook] in the
 `index.js` file of the addon:
@@ -105,27 +105,27 @@ included() {
 }
 ```
 
-Note that the `this.import()` method is only available starting with
-Ember CLI 2.7. You can easily polyfill it though if you want to support
-Ember CLI releases below that. Have a look at the
+Note that the `this.import()` method is only available starting with Ember CLI
+2.7. You can easily polyfill it though if you want to support Ember CLI releases
+below that. Have a look at the
 [ember-simple-auth](https://github.com/simplabs/ember-simple-auth/blob/1ca4ae678b7be9905076762220dcd9fcb0f27ac0/index.js#L24-L39)
 code to find out how to do it.
 
-This seems to work fine now if we are just looking at the dummy app, but
-in reality it will not work yet for any other apps. The reason for this is
-that the `bower_components` folder above refers to the `bower_components`
-folder of the "host app", not of the addon itself. That means we will have to
-`bower install --save moment` into the host app itself and there are two ways
-to do it:
+This seems to work fine now if we are just looking at the dummy app, but in
+reality it will not work yet for any other apps. The reason for this is that the
+`bower_components` folder above refers to the `bower_components` folder of the
+"host app", not of the addon itself. That means we will have to
+`bower install --save moment` into the host app itself and there are two ways to
+do it:
 
 - the lazy way: tell the users in the `README` file to install it like that
 - the comfortable way: install it automatically for them using an Ember CLI
   blueprint
 
 Since we want to make it as easy for our users as possible we will prefer the
-second solution, which is not actually that hard to implement either. First
-we will have to generate a blueprint that matches the package name of our
-addon. So if our addon was called `ember-moment` we would run:
+second solution, which is not actually that hard to implement either. First we
+will have to generate a blueprint that matches the package name of our addon. So
+if our addon was called `ember-moment` we would run:
 
 ```
 ember generate blueprint ember-moment
@@ -146,33 +146,31 @@ module.exports = {
 
 The `normalizeEntityName` hook is usually used to e.g. read the name of the
 route you want to generate with `ember generate route <routename>`. Since this
-is the default blueprint which will be executed automatically when the our
-addon is installed through `ember install ember-moment` we don't need this
-method and have to overwrite it to make sure it does not complain about a
-missing name.
+is the default blueprint which will be executed automatically when the our addon
+is installed through `ember install ember-moment` we don't need this method and
+have to overwrite it to make sure it does not complain about a missing name.
 
 The `afterInstall` hook is the important part. The
 [`addBowerPackageToProject()`](https://ember-cli.com/api/classes/Blueprint.html#method_addBowerPackageToProject)
-method installs the `moment` Bower package into the application by adding it
-to the host app `bower.json` file. That way the Moment.js files will be present
-in the top level `bower_components` folder of the application instead of being
+method installs the `moment` Bower package into the application by adding it to
+the host app `bower.json` file. That way the Moment.js files will be present in
+the top level `bower_components` folder of the application instead of being
 available only inside of the addon. Since the `addBowerPackageToProject()`
-method returns a `Promise` we have to return it from the `afterInstall` hook
-to make sure that Ember CLI waits for the installation to finish.
+method returns a `Promise` we have to return it from the `afterInstall` hook to
+make sure that Ember CLI waits for the installation to finish.
 
 ## npm vs. Bower
 
 <blockquote class="tweet" data-lang="de"><p lang="en" dir="ltr">&quot;What&#39;s bower?&quot;<br>&quot;A package manager, install it with npm.&quot;<br>&quot;What&#39;s npm?&quot;<br>&quot;A package manager, you can install it with brew&quot;<br>&quot;What&#39;s brew?&quot;<br>...</p>&mdash; Stefan Baumgartner (@ddprrt) <a href="https://twitter.com/ddprrt/status/529909875347030016">5. November 2014</a></blockquote>
 
-In an effort to simplify the situation the Ember team decided to focus on npm
-in the future. Bower support will still be available to support older addons
-for now, but might be deprecated at some point. That means that we should
-modify our `ember-moment` addon above to install Moment.js via npm instead of
-Bower.
+In an effort to simplify the situation the Ember team decided to focus on npm in
+the future. Bower support will still be available to support older addons for
+now, but might be deprecated at some point. That means that we should modify our
+`ember-moment` addon above to install Moment.js via npm instead of Bower.
 
 Fortunately for us Moment.js is also distributed on npm so we can just
-`npm install --save moment` instead of using Bower and we're done, right?
-Well, not quite. Unfortunately for the time being things are a little more
+`npm install --save moment` instead of using Bower and we're done, right? Well,
+not quite. Unfortunately for the time being things are a little more
 complicated, but the Ember CLI team has plans to make it easier in the future.
 
 Let's start with the simple part: Installing via npm instead of Bower. Instead
@@ -203,8 +201,8 @@ we tell Ember CLI to move it automatically as part of the build process.
 
 To implement this we will need the fundamental
 [broccoli-funnel](https://github.com/broccolijs/broccoli-funnel) and
-[broccoli-merge-trees](https://github.com/broccolijs/broccoli-merge-trees)
-npm packages:
+[broccoli-merge-trees](https://github.com/broccolijs/broccoli-merge-trees) npm
+packages:
 
 ```
 npm install --save broccoli-funnel broccoli-merge-trees
@@ -229,9 +227,12 @@ module.exports = {
   },
 
   treeForVendor(vendorTree) {
-    var momentTree = new Funnel(path.join(this.project.root, 'node_modules', 'moment'), {
-      files: ['moment.js'],
-    });
+    var momentTree = new Funnel(
+      path.join(this.project.root, 'node_modules', 'moment'),
+      {
+        files: ['moment.js'],
+      },
+    );
 
     return new MergeTrees([vendorTree, momentTree]);
   },
@@ -239,27 +240,27 @@ module.exports = {
 ```
 
 Let me explain what we did here. The `vendorTree` argument holds the actual
-content of our `vendor` folder as we can see it in our addon. Next we create
-a new `Funnel` tree, which is a fancy way of saying: import files into the
-build pipeline. Essentially we just lookup the `moment.js` file inside the
+content of our `vendor` folder as we can see it in our addon. Next we create a
+new `Funnel` tree, which is a fancy way of saying: import files into the build
+pipeline. Essentially we just lookup the `moment.js` file inside the
 `node_modules/moment` folder of the host app and wrap that in a Broccoli tree.
 The last step merges the `vendorTree` and the `momentTree` into a single tree
 which now contains the `moment.js` file and our vendor shim for the `vendor`
 folder.
 
-If you want to learn more about Broccoli and how the build pipeline works
-I recommend watching Estelle DeBlois explain it in her fantastic EmberConf
-talk: [Dissecting an Ember CLI Build](https://youtu.be/hNwgp9alwKg).
+If you want to learn more about Broccoli and how the build pipeline works I
+recommend watching Estelle DeBlois explain it in her fantastic EmberConf talk:
+[Dissecting an Ember CLI Build](https://youtu.be/hNwgp9alwKg).
 
 Now that we've imported the `moment.js` file into our `vendor` tree we can
 finally `import()` it in the `included()` hook and everything works again.
 
 ## npm dependencies
 
-As we are using npm now we can also take advantage of the way that npm
-resolves dependencies. That means instead of using a blueprint to install
-the npm package into the host app we declare `moment` as a dependency of
-the addon instead in our `package.json` file:
+As we are using npm now we can also take advantage of the way that npm resolves
+dependencies. That means instead of using a blueprint to install the npm package
+into the host app we declare `moment` as a dependency of the addon instead in
+our `package.json` file:
 
 ```json
 {
@@ -271,8 +272,8 @@ the addon instead in our `package.json` file:
 
 Since npm deduplicates packages during installation we can not be certain about
 the path where `moment` is actually installed though. We need to use a resolver
-algorithm to find the file inside the `node_modules` folder. Fortunately
-Node.js has that algorithm built-in and we can just use it through the
+algorithm to find the file inside the `node_modules` folder. Fortunately Node.js
+has that algorithm built-in and we can just use it through the
 `require.resolve()` function. All we have to do now is modify the `momentTree`
 code like this:
 
@@ -292,18 +293,18 @@ subdependency via `ember-moment`.
 If you want to see these things applied to a real addon visit the code of the
 [`ember-cli-moment-shim`](https://github.com/jasonmit/ember-cli-moment-shim)
 addon and have a look at their `index.js` file. They do support fastboot too
-though which makes the code a little more complicated compared to our
-simplified example here.
+though which makes the code a little more complicated compared to our simplified
+example here.
 
 ## App vs. Addon again
 
-Now that we have converted our `ember-moment` addon to use npm instead of
-Bower, how could we do the same if we wanted to use Moment.js in our app
-directly without an additional addon?
+Now that we have converted our `ember-moment` addon to use npm instead of Bower,
+how could we do the same if we wanted to use Moment.js in our app directly
+without an additional addon?
 
-Unfortunately there is currently no perfect solution for this and the best
-way is using an [in-repo-addon](https://ember-cli.com/extending/#in-repo-addons)
-for that. You could for example generate a `ember-moment` in-repo-addon:
+Unfortunately there is currently no perfect solution for this and the best way
+is using an [in-repo-addon](https://ember-cli.com/extending/#in-repo-addons) for
+that. You could for example generate a `ember-moment` in-repo-addon:
 
 ```
 ember generate in-repo-addon ember-moment
@@ -313,11 +314,11 @@ and use the same code as above inside the `lib/ember-moment/index.js` file.
 
 ## Next: CommonJS and ES6 modules
 
-Things get a little more complicated when you want to use npm packages that
-are not distributed in a prebuilt form like Moment.js. If they instead export
-only CommonJS modules or ES6 modules we will need to add a few more plugins
-to the build pipeline to make this work and we will explain how to do that in
-a future blog post.
+Things get a little more complicated when you want to use npm packages that are
+not distributed in a prebuilt form like Moment.js. If they instead export only
+CommonJS modules or ES6 modules we will need to add a few more plugins to the
+build pipeline to make this work and we will explain how to do that in a future
+blog post.
 
 [ember-source]: https://www.npmjs.com/package/ember-source
 [bower]: https://bower.io/

--- a/_posts/2017-03-21-on-computed-properties-vs-helpers.md
+++ b/_posts/2017-03-21-on-computed-properties-vs-helpers.md
@@ -4,7 +4,9 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte discusses differences between computed properties and helpers and explains pros and cons of each alternative.'
+description:
+  'Marco Otte-Witte discusses differences between computed properties and
+  helpers and explains pros and cons of each alternative.'
 topic: ember
 og:
   image: /assets/images/posts/2017-03-21-on-computed-properties-vs-helpers/og-image.png
@@ -13,8 +15,8 @@ og:
 Ember's computed properties are a great mechanism for encapsulating reactive
 logic and implementing consistent, auto-updating UIs. Since the past year or so
 though, there seems to be an increasing tendency in the community to use
-template helpers as the main tool for expressing this kind of logic right in
-the templates. Following up on a
+template helpers as the main tool for expressing this kind of logic right in the
+templates. Following up on a
 [talk I gave at last year's EmberFest](https://speakerdeck.com/marcoow/templates-and-logic-in-ember),
 I'll elaborate in this post why I think that is often not the best choice and
 what the drawbacks are.
@@ -23,9 +25,9 @@ what the drawbacks are.
 
 ## Computed Properties
 
-Computed Properties allow defining properties as functions of other
-properties. Ember automatically re-evaluates computed properties (lazily) when
-any of its dependents change so that they don't get out of sync.
+Computed Properties allow defining properties as functions of other properties.
+Ember automatically re-evaluates computed properties (lazily) when any of its
+dependents change so that they don't get out of sync.
 
 Here's a simple example of a computed property that is `true` when the `age`
 property is at least `65`:
@@ -80,12 +82,11 @@ and move the comparison into the template:
 ## What's the difference?
 
 Both alternatives are obviously very similar - both compare the user's `age`
-property with a comparison value and depending on the outcome of that
-comparison render some nodes to the DOM (or don't render them). The main
-difference is that **with the computed property that comparison lives in the
-template context** and is only invoked from the template (via the `isSenior`
-identifier) while **when using a helper the comparison is defined inline right
-in the template** itself.
+property with a comparison value and depending on the outcome of that comparison
+render some nodes to the DOM (or don't render them). The main difference is that
+**with the computed property that comparison lives in the template context** and
+is only invoked from the template (via the `isSenior` identifier) while **when
+using a helper the comparison is defined inline right in the template** itself.
 
 This might not seem like a big thing but there actually are some differences
 between the two alternatives that have consequences on certain aspects of the
@@ -94,22 +95,22 @@ application.
 ### Separation vs. Unification
 
 The main difference is that with the computed property solution, the logic and
-its internals are separated from the template. The **logic lives in the
-template context and appears as a black box to the template** which merely uses
-some named properties - this is actually quite **similar to a class exposing
-named methods** where the caller of these methods does not have to worry about
-their internals as long as it's clear what they are supposed to be used for.
+its internals are separated from the template. The **logic lives in the template
+context and appears as a black box to the template** which merely uses some
+named properties - this is actually quite **similar to a class exposing named
+methods** where the caller of these methods does not have to worry about their
+internals as long as it's clear what they are supposed to be used for.
 
 With the **template helpers solution though both the rendering as well as the
 logic are merged in the template**. That means that understanding and
 maintaining the template includes understanding all of the logic encoded in the
 helper invocations.
 
-While the complexity that's added to the template in the above example is
-fairly limited of course, this point gets more obvious when looking at a
-slightly more involved example. Assume there is a collection of users from
-which we want to select a random one with a `status` of `'active'`. A computed
-property returning such a user could look like this:
+While the complexity that's added to the template in the above example is fairly
+limited of course, this point gets more obvious when looking at a slightly more
+involved example. Assume there is a collection of users from which we want to
+select a random one with a `status` of `'active'`. A computed property returning
+such a user could look like this:
 
 ```js
 userToDisplay: computed('users.@each.state', function() {
@@ -141,11 +142,11 @@ property.
 
 ### Testability
 
-Another consequence of **moving logic into the template is that the logic
-itself becomes harder to test**. While logic that lives in the template context
-in the form of computed properties is easily unit-testable, **logic that lives
-in the template can only be tested by actually rendering the template** which
-again leads to a few other consequences:
+Another consequence of **moving logic into the template is that the logic itself
+becomes harder to test**. While logic that lives in the template context in the
+form of computed properties is easily unit-testable, **logic that lives in the
+template can only be tested by actually rendering the template** which again
+leads to a few other consequences:
 
 - Tests become slower to execute as it's obviously slower to render than not to
   render.
@@ -153,13 +154,13 @@ again leads to a few other consequences:
   of the computed property (e.g. `asser.equal(user.get('isSenior') true)`),
   (integration) tests for logic inside of templates have to assert on the
   presence or absence of DOM nodes (e.g.
-  `assert.ok(find(testSelector('senior-flag')))`) which obviously is a much
-  more indirect way of testing the same thing.
+  `assert.ok(find(testSelector('senior-flag')))`) which obviously is a much more
+  indirect way of testing the same thing.
 - Test cases (potentially) require more and unrelated context to be set up.
-  While unit tests for computed properties only require the dependent
-  properties of the computed property under test to be set up, rendering a
-  template requires the full context for that template to be set up which might
-  include elements that are unrelated to the current test case.
+  While unit tests for computed properties only require the dependent properties
+  of the computed property under test to be set up, rendering a template
+  requires the full context for that template to be set up which might include
+  elements that are unrelated to the current test case.
 
 ### Helpers don't always work as expected
 
@@ -167,11 +168,11 @@ One of the main reasons that we hear why people prefer template helpers over
 computed properties is the fact that computed properties need to list their
 dependent keys. **Especially newcomers to Ember.js are afraid of forgetting a
 key or making a mistake** (especially when it comes to collections) which can
-lead to hard to track down errors (see below for a potential fix for the need
-to specify dependent keys at all). **Template helpers instead don't need to
-list dependencies and are automatically re-executed** when any of their
-arguments change. While that is true in most cases there are some edge cases
-where **helpers might actually not work as expected**.
+lead to hard to track down errors (see below for a potential fix for the need to
+specify dependent keys at all). **Template helpers instead don't need to list
+dependencies and are automatically re-executed** when any of their arguments
+change. While that is true in most cases there are some edge cases where
+**helpers might actually not work as expected**.
 
 Consider a slightly modified version of the above example that compares the
 user's `age` property with a comparison value:
@@ -182,8 +183,8 @@ user's `age` property with a comparison value:
 {{/if}}
 ```
 
-Here, the internals of the comparison logic have been moved into the
-`is-senior` helper:
+Here, the internals of the comparison logic have been moved into the `is-senior`
+helper:
 
 ```js
 export default Ember.Helper.helper(function([user]) {
@@ -193,8 +194,8 @@ export default Ember.Helper.helper(function([user]) {
 
 The problem with this solution is that the DOM does not get updated when the
 user's `age` property changes. While arguments that are passed to helpers are
-observed by Ember automatically and the **helper will be re-executed when any
-of these arguments change to a different value, the same is not true when any
+observed by Ember automatically and the **helper will be re-executed when any of
+these arguments change to a different value, the same is not true when any
 property on any of the arguments changes**. In this case changes of the user's
 `age` property would go unnoticed and the DOM would get out of sync with the
 underlying data.
@@ -230,8 +231,7 @@ As the `&&` operator will actually short-circuit execution when
 `this.get('propA')` is false, `this.get('propB')` will never be evaluated in
 these cases while both properties will always be eagerly evaluated when using a
 helper. If calculating `propB` is a costly operation that is obviously not
-desirable but something that cannot actually be prevented with template
-helpers.
+desirable but something that cannot actually be prevented with template helpers.
 
 ## Pick one
 
@@ -274,8 +274,8 @@ pure function also has no side effects. While this is true for helpers it is
 obviously true for computed properties with the only distinction that **a
 computed property's inputs are called its dependent keys**. Of course there's
 also class based helpers whose whole purpose is to enable template helpers that
-can depend on global state and thus are not pure functions (and the same
-concept exists for computed properties with ember-classy-computed now).
+can depend on global state and thus are not pure functions (and the same concept
+exists for computed properties with ember-classy-computed now).
 
 ### Original concerns of the template layer
 
@@ -285,8 +285,8 @@ statement to make. **There are original concerns of the template layer that are
 best implemented in helpers** - typical examples being translating strings,
 formatting numbers or dates etc. We use template helpers almost exclusively for
 this kind of functionality which is usually only a small part part of any
-application though - we often only have a few helpers defined even in pretty
-big and involved applications.
+application though - we often only have a few helpers defined even in pretty big
+and involved applications.
 
 ### Missing a property context
 
@@ -295,8 +295,8 @@ easily be used instead of template helpers to achieve the same functionality.
 That is when there is **no context the computed property could be defined on or
 the context it would be needed on is unrelated to the template context**. One
 example for this is a component that renders a list of items and keeps track of
-which of these items is currently selected. The easiest way to do something
-like that using template helpers would look something like this:
+which of these items is currently selected. The easiest way to do something like
+that using template helpers would look something like this:
 
 ```hbs
 <ul>
@@ -309,8 +309,8 @@ like that using template helpers would look something like this:
 This isn't as straight forward to replace with a computed property as the
 previous examples. While defining an `isSelected` property on the template
 context isn't possible as the property is needed per item in the list, the
-property can also not be defined on the items as the items have no notion of
-the list component or how that keeps track of the selected element at all.
+property can also not be defined on the items as the items have no notion of the
+list component or how that keeps track of the selected element at all.
 
 The solution to this problem is to construct a new context that has access to
 both the item as well as the component:
@@ -349,8 +349,8 @@ suited for which use case and what the consequences and drawbacks are when
 picking either one is crucial for **preventing long term maintainability
 issues**.
 
-Computed properties are powerful already and will continue to improve with
-tools like [ember-cpm](https://github.com/cibernox/ember-cpm),
+Computed properties are powerful already and will continue to improve with tools
+like [ember-cpm](https://github.com/cibernox/ember-cpm),
 [ember-awesome-macros](https://github.com/kellyselden/ember-awesome-macros),
 [ember-macro-helpers](https://github.com/kellyselden/ember-macro-helpers) and
 eventually perhaps computed properties that automatically track their

--- a/_posts/2017-08-28-creating-web-components-with-glimmer.md
+++ b/_posts/2017-08-28-creating-web-components-with-glimmer.md
@@ -4,22 +4,40 @@ author: 'Jessica Jordan'
 github: jessica-jordan
 twitter: jjordan_dev
 bio: 'Senior Frontend Engineer, Ember Learning core team member'
-description: 'Jessica Jordan explains what web components (aka custom elements) are and shows how they can be built using Glimmer.js.'
+description:
+  'Jessica Jordan explains what web components (aka custom elements) are and
+  shows how they can be built using Glimmer.js.'
 topic: ember
 ---
 
-At [this year's EmberConf the Ember core team officially announced](https://youtu.be/TEuY4GqwrUE?t=58m43s) the release of [Glimmer](https://glimmerjs.com/) - a light-weight JavaScript library aimed to provide a useful toolset for **creating fast and reusable UI components**. Powered by the already battle-tested Ember-CLI, developers can build their Glimmer apps in an easy and efficient manner as they already came to love building applications in Ember.js before.
+At
+[this year's EmberConf the Ember core team officially announced](https://youtu.be/TEuY4GqwrUE?t=58m43s)
+the release of [Glimmer](https://glimmerjs.com/) - a light-weight JavaScript
+library aimed to provide a useful toolset for **creating fast and reusable UI
+components**. Powered by the already battle-tested Ember-CLI, developers can
+build their Glimmer apps in an easy and efficient manner as they already came to
+love building applications in Ember.js before.
 
 <!--break-->
 
-In addition to building standalone Glimmer applications, the library allows the creation of components **according to the Custom Elements v1 specification**, making it possible to build native web components which can be reused across all kinds of front end stacks.
+In addition to building standalone Glimmer applications, the library allows the
+creation of components **according to the Custom Elements v1 specification**,
+making it possible to build native web components which can be reused across all
+kinds of front end stacks.
 
 ## What's in the Custom Elements v1 specification
 
-The **Custom Elements spec** describes a technology which is - alongside of HTML templates, Shadow DOM and HTML imports - an integral part of the [current Web Component specification](https://www.w3.org/wiki/WebComponents/).
-The Custom Elements spec describes capabilities for creating custom HTML elements which can be used just like native HTML elements: `<my-customelement>`.
+The **Custom Elements spec** describes a technology which is - alongside of HTML
+templates, Shadow DOM and HTML imports - an integral part of the
+[current Web Component specification](https://www.w3.org/wiki/WebComponents/).
+The Custom Elements spec describes capabilities for creating custom HTML
+elements which can be used just like native HTML elements: `<my-customelement>`.
 
-The [current version of this specification](https://www.w3.org/TR/custom-elements/) defines a `CustomElementRegistry` interface global which is available as the `customElements` global in the browser. Custom elements are based on extensions of the native `HTMLElement` base class:
+The
+[current version of this specification](https://www.w3.org/TR/custom-elements/)
+defines a `CustomElementRegistry` interface global which is available as the
+`customElements` global in the browser. Custom elements are based on extensions
+of the native `HTMLElement` base class:
 
 ```js
 class CustomElementClass extends HTMLElement {
@@ -27,7 +45,9 @@ class CustomElementClass extends HTMLElement {
 }
 ```
 
-The `CustomElementRegistry`'s `define` method can subsequently be used to register custom elements, e.g. a custom element named `my-customelement`, would be registered as follows:
+The `CustomElementRegistry`'s `define` method can subsequently be used to
+register custom elements, e.g. a custom element named `my-customelement`, would
+be registered as follows:
 
 ```js
 class CustomElementClass extends HTMLElement {
@@ -37,7 +57,8 @@ class CustomElementClass extends HTMLElement {
 customElements.define('my-customelement', CustomElementClass);
 ```
 
-Finally, a custom element that has been registered via the `CustomElementRegistry` can simply be used anywhere in HTML like any other tag:
+Finally, a custom element that has been registered via the
+`CustomElementRegistry` can simply be used anywhere in HTML like any other tag:
 
 ```html
 <!DOCTYPE html>
@@ -52,42 +73,81 @@ Finally, a custom element that has been registered via the `CustomElementRegistr
 </html>
 ```
 
-Being able to encapsulate functionality this way and to be able to reuse it via HTML markup is powerful for several reasons:
+Being able to encapsulate functionality this way and to be able to reuse it via
+HTML markup is powerful for several reasons:
 
-First, it enables usage of these components **beyond the boundaries of a single front-end tech stack**, including the diverse set of client-side JavaScript frameworks out there.
-Imagine being able to develop a menu header once and to reuse it across all the different applications that are built in the scope of your project,
-no matter if these applications were built upon React or Ember. This also furthers even greater efforts to create well-maintained and highly flexible widgets, not only on a project's or company's scale, but also in terms of open-source as an even greater community of developers will be interested in creating and using that e.g. one well-built `date-picker` component. Imagine if the community behind the `ember-power-datepicker`, `react-datepicker`, `angular-datepicker` and others could funnel their work into creating one component that is of great benefit to all of these JavaScript communities at once.
+First, it enables usage of these components **beyond the boundaries of a single
+front-end tech stack**, including the diverse set of client-side JavaScript
+frameworks out there. Imagine being able to develop a menu header once and to
+reuse it across all the different applications that are built in the scope of
+your project, no matter if these applications were built upon React or Ember.
+This also furthers even greater efforts to create well-maintained and highly
+flexible widgets, not only on a project's or company's scale, but also in terms
+of open-source as an even greater community of developers will be interested in
+creating and using that e.g. one well-built `date-picker` component. Imagine if
+the community behind the `ember-power-datepicker`, `react-datepicker`,
+`angular-datepicker` and others could funnel their work into creating one
+component that is of great benefit to all of these JavaScript communities at
+once.
 
-Second, the **standalone and self-contained** nature of web components creates an API, that is not only straight-forward to use, but is also easy to reason about; a well-structured web component
-will bring in all the dependencies needed for its core functionality and will be configured - if needed at all - with string based HTML attributes alone - making the final **mark up** very **descriptive**. Advanced users will still be able to configure additional, more specific functionality, as e.g. event listeners, via JavaScript themselves on top of that.
+Second, the **standalone and self-contained** nature of web components creates
+an API, that is not only straight-forward to use, but is also easy to reason
+about; a well-structured web component will bring in all the dependencies needed
+for its core functionality and will be configured - if needed at all - with
+string based HTML attributes alone - making the final **mark up** very
+**descriptive**. Advanced users will still be able to configure additional, more
+specific functionality, as e.g. event listeners, via JavaScript themselves on
+top of that.
 
-Third, using web components is very easy as only **knowledge of the HTML markup language is required** to do so. Using the basic and likely most well-known language of the web alone, it **empowers an even larger community of developers** to build their websites and web apps with and upon web components.
+Third, using web components is very easy as only **knowledge of the HTML markup
+language is required** to do so. Using the basic and likely most well-known
+language of the web alone, it **empowers an even larger community of
+developers** to build their websites and web apps with and upon web components.
 
 Let’s now dive into how we can create our own custom elements using Glimmer.
 
 ## Glimmer Web Component Example: A Reusable Open Street Map
 
-A common use case for a reusable component is the interactive view of a street map which usually can be embedded into websites and apps quickly with some configuration using services like the Google Maps API or Leaflet. What if we could create our own custom element that can simply be shared and reused using HTML alone?
+A common use case for a reusable component is the interactive view of a street
+map which usually can be embedded into websites and apps quickly with some
+configuration using services like the Google Maps API or Leaflet. What if we
+could create our own custom element that can simply be shared and reused using
+HTML alone?
 
-In the following we will **create a simple street map** based on [Leaflet.js](http://leafletjs.com/) which can be re-used as such a custom element in any other application or static website:
+In the following we will **create a simple street map** based on
+[Leaflet.js](http://leafletjs.com/) which can be re-used as such a custom
+element in any other application or static website:
 
 ![Screenshot of Final Glimmer Map Component Example - Open Street Map View Centered on Munich](/assets/images/posts/2017-08-30-creating-web-components-with-glimmer/glimmer-map-screenshot-final.jpg#@1200-2400)
 
-You can also check out the project on [Github](https://github.com/jessica-jordan/glimmer-map).
+You can also check out the project on
+[Github](https://github.com/jessica-jordan/glimmer-map).
 
 ### Starting a new Glimmer Web Component Project
 
-To get started with an initial, running project setup, we will be using [Ember CLI](https://ember-cli.com/) for scaffolding and configuration of our Glimmer app. From `ember-cli@2.14.0` onwards, we can get started to create a Glimmer-backed web component by using the `ember new` generator, the [respective glimmer blueprint](https://github.com/glimmerjs/glimmer-blueprint) and the `--web-component` flag:
+To get started with an initial, running project setup, we will be using
+[Ember CLI](https://ember-cli.com/) for scaffolding and configuration of our
+Glimmer app. From `ember-cli@2.14.0` onwards, we can get started to create a
+Glimmer-backed web component by using the `ember new` generator, the
+[respective glimmer blueprint](https://github.com/glimmerjs/glimmer-blueprint)
+and the `--web-component` flag:
 
 ```bash
 ember new glimmer-map -b @glimmer/blueprint --web-component
 ```
 
-generating the needed scaffolding for our first Glimmer app. As soon as the Glimmer app is booted up via a simple `ember serve` and we navigate to the typical `http://localhost:4200`, we will find that our first component project is already rendered with a "Welcome to Glimmer!" headline:
+generating the needed scaffolding for our first Glimmer app. As soon as the
+Glimmer app is booted up via a simple `ember serve` and we navigate to the
+typical `http://localhost:4200`, we will find that our first component project
+is already rendered with a "Welcome to Glimmer!" headline:
 
 ![Screenshot of First Page of a New Glimmer App - Headline: Hello Glimmer!](/assets/images/posts/2017-08-30-creating-web-components-with-glimmer/glimmer-map-startup.png#@1200-2400)
 
-Let's have a look at our project's file structure as well; following the new folder structure planned out in the [module unification RFC](https://github.com/emberjs/rfcs/pull/143) we can already find our `component.ts` and `template.hbs` files for creating our component co-located in the same directory below the `src` directory:
+Let's have a look at our project's file structure as well; following the new
+folder structure planned out in the
+[module unification RFC](https://github.com/emberjs/rfcs/pull/143) we can
+already find our `component.ts` and `template.hbs` files for creating our
+component co-located in the same directory below the `src` directory:
 
 ```
 src
@@ -107,8 +167,13 @@ src
     └── test-helper.ts
 ```
 
-Having a closer look at the app setup in `glimmer-web-component/src/initialize-custom-elements.ts`, we can see how the Glimmer app is started up and rendered as a custom element.
-Under the hood, Glimmer’s `renderComponent` API is taking care of initial setup and rendering of the component into the aforementioned placeholder in the DOM and the `initializeCustomElements` API for registering the component as a native custom element:
+Having a closer look at the app setup in
+`glimmer-web-component/src/initialize-custom-elements.ts`, we can see how the
+Glimmer app is started up and rendered as a custom element. Under the hood,
+Glimmer’s `renderComponent` API is taking care of initial setup and rendering of
+the component into the aforementioned placeholder in the DOM and the
+`initializeCustomElements` API for registering the component as a native custom
+element:
 
 ```ts
 function initializeCustomElement(app: Application, name: string): void {
@@ -136,14 +201,21 @@ function initializeCustomElement(app: Application, name: string): void {
 }
 ```
 
-The final line makes use of the `CustomElementRegistry`'s `define` method to register the `GlimmerElement` class as a custom element, just as we expect it from the Custom Elements specification. Interesting to note here as well is the call to the `assignAttributes` method, ensuring that any top-level attributes defined on our custom element are later on also mapped to attributes on our rendered Glimmer component.
+The final line makes use of the `CustomElementRegistry`'s `define` method to
+register the `GlimmerElement` class as a custom element, just as we expect it
+from the Custom Elements specification. Interesting to note here as well is the
+call to the `assignAttributes` method, ensuring that any top-level attributes
+defined on our custom element are later on also mapped to attributes on our
+rendered Glimmer component.
 
-So, after having that quick dive into how our component is spun up in Glimmer, let’s get started developing it:
+So, after having that quick dive into how our component is spun up in Glimmer,
+let’s get started developing it:
 
 ### Developing a Web Component with Glimmer's API
 
-So far the blueprint for our main component module has already been setup by Ember CLI's generator.
-The class used for generating our `glimmer-map` component is now defined in `src/ui/components/glimmer-map/component.ts`:
+So far the blueprint for our main component module has already been setup by
+Ember CLI's generator. The class used for generating our `glimmer-map` component
+is now defined in `src/ui/components/glimmer-map/component.ts`:
 
 ```ts
 // src/ui/components/glimmer-map/component.ts
@@ -152,14 +224,21 @@ import Component from '@glimmer/component';
 export default class GlimmerMap extends Component {}
 ```
 
-As we would like to create a map based on `Leaflet.js`, let's also get that dependency installed in our project:
+As we would like to create a map based on `Leaflet.js`, let's also get that
+dependency installed in our project:
 
 ```bash
 yarn add --dev leaflet
 ```
 
-Similar to many other npm packages that you will find out there, the Leaflet dependency exports its internals via **the CommonJS module** syntax.
-Since the [glimmer-application-pipeline](https://github.com/glimmerjs/glimmer-application-pipeline) only supports the import of modules following the ES6 syntax out of the box, we can make ends meet by configuring rollup in our `ember-cli-build.js` as [also seen in the glimmer-application-pipeline documentation](https://github.com/glimmerjs/glimmer-application-pipeline#importing-commonjs-modules) and install the `rollup-plugin-node-resolve` and `rollup-plugin-commonjs` dependencies:
+Similar to many other npm packages that you will find out there, the Leaflet
+dependency exports its internals via **the CommonJS module** syntax. Since the
+[glimmer-application-pipeline](https://github.com/glimmerjs/glimmer-application-pipeline)
+only supports the import of modules following the ES6 syntax out of the box, we
+can make ends meet by configuring rollup in our `ember-cli-build.js` as
+[also seen in the glimmer-application-pipeline documentation](https://github.com/glimmerjs/glimmer-application-pipeline#importing-commonjs-modules)
+and install the `rollup-plugin-node-resolve` and `rollup-plugin-commonjs`
+dependencies:
 
 ```bash
 yarn add --dev rollup-plugin-node-resolve
@@ -178,7 +257,10 @@ const commonjs = require('rollup-plugin-commonjs');
 module.exports = function(defaults) {
   let app = new GlimmerApp(defaults, {
     rollup: {
-      plugins: [resolve({ jsnext: true, module: true, main: true }), commonjs()],
+      plugins: [
+        resolve({ jsnext: true, module: true, main: true }),
+        commonjs(),
+      ],
     },
   });
 
@@ -196,7 +278,9 @@ import L from 'leaflet';
 export default class GlimmerMap extends Component {}
 ```
 
-Now for creating and rendering the map, let's use the component's `didInsertElement` lifecycle hook to ensure that the Glimmer component has been inserted into the DOM already before the map instance is created and rendered:
+Now for creating and rendering the map, let's use the component's
+`didInsertElement` lifecycle hook to ensure that the Glimmer component has been
+inserted into the DOM already before the map instance is created and rendered:
 
 ```ts
 // src/ui/components/glimmer-map/component.ts
@@ -239,7 +323,11 @@ With this setup, our map already renders for the map points set intially:
 
 ![Screenshot of Open Street Map View of First Pass on the Glimmer Map Component](/assets/images/posts/2017-08-30-creating-web-components-with-glimmer/glimmer-map-screenshot.jpg#@1200-2400)
 
-We also aim to make our map respond to user input. Specifically, we would like to be able to set the marker to different locations on the map using a property for the longitude (`lon`) and the latitude (`lat`) easily. To allow any property changes to be reflected in the component's DOM, we can make use of the `@tracked` decorator:
+We also aim to make our map respond to user input. Specifically, we would like
+to be able to set the marker to different locations on the map using a property
+for the longitude (`lon`) and the latitude (`lat`) easily. To allow any property
+changes to be reflected in the component's DOM, we can make use of the
+`@tracked` decorator:
 
 ```ts
 // src/ui/components/glimmer-map/component.ts
@@ -253,8 +341,9 @@ export default class GlimmerMap extends Component {
 }
 ```
 
-Anytime there is a change to one of the tracked properties' values, a re-render of the component with a newly updated DOM will follow.
-And promote the changes to these properties via actions by updating our template
+Anytime there is a change to one of the tracked properties' values, a re-render
+of the component with a newly updated DOM will follow. And promote the changes
+to these properties via actions by updating our template
 
 ```hbs
 <!-- src/ui/components/glimmer-map/template.hbs -->
@@ -285,17 +374,27 @@ export default class GlimmerMap extends Component {
 }
 ```
 
-With this we are already done and can get started with distributing our component.
+With this we are already done and can get started with distributing our
+component.
 
 ## Reusing Glimmer components as custom elements
 
-As mentioned in the beginning of this article, the current blueprint for Glimmer web components comes with a wrapper for being able to package and reuse our Glimmer components as custom elements. To **create the assets** needed for reusage, let’s build those like we are already used to when building Ember apps:
+As mentioned in the beginning of this article, the current blueprint for Glimmer
+web components comes with a wrapper for being able to package and reuse our
+Glimmer components as custom elements. To **create the assets** needed for
+reusage, let’s build those like we are already used to when building Ember apps:
 
 ```bash
 ember build --production
 ```
 
-This will store all the assets needed for reusing our custom element in the `/dist` directory of the project. For our example, only the `app.js` file has to be copied to be reused in our target app where we would like to use the `glimmer-map` web component. Adding in the external stylesheet for the styles of our map, as well as a [polyfill for ensuring cross-browser support for all custom element features](https://github.com/webcomponents/webcomponentsjs) finalizes our example:
+This will store all the assets needed for reusing our custom element in the
+`/dist` directory of the project. For our example, only the `app.js` file has to
+be copied to be reused in our target app where we would like to use the
+`glimmer-map` web component. Adding in the external stylesheet for the styles of
+our map, as well as a
+[polyfill for ensuring cross-browser support for all custom element features](https://github.com/webcomponents/webcomponentsjs)
+finalizes our example:
 
 ```html
 // your/other/app/template/or/plain/html/page.html
@@ -318,7 +417,8 @@ This will store all the assets needed for reusing our custom element in the `/di
 </html>
 ```
 
-And finally, we can see our Glimmer-based street map being rendered just as seen below:
+And finally, we can see our Glimmer-based street map being rendered just as seen
+below:
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.0.8/webcomponents-lite.js"></script>
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.2.0/dist/leaflet.css"
@@ -328,4 +428,12 @@ And finally, we can see our Glimmer-based street map being rendered just as seen
 
 ## And the Glimmer Component story is not over yet
 
-Many more interesting developments are upcoming around Glimmer and the [glimmer-component](https://github.com/glimmerjs/glimmer-component) and [glimmer-web-component](https://github.com/glimmerjs/glimmer-web-component) modules specifically. For further reading, please check out another great discussion about the implementation of upcoming APIs according to the web component specification on [here](https://github.com/glimmerjs/glimmer-web-component/issues/19), check out [my talk on current state of web components and Glimmer’s place in it](https://www.youtube.com/watch?v=OzFgDBJcWuU) and stay tuned for our future blog post on testing Glimmer components.
+Many more interesting developments are upcoming around Glimmer and the
+[glimmer-component](https://github.com/glimmerjs/glimmer-component) and
+[glimmer-web-component](https://github.com/glimmerjs/glimmer-web-component)
+modules specifically. For further reading, please check out another great
+discussion about the implementation of upcoming APIs according to the web
+component specification on
+[here](https://github.com/glimmerjs/glimmer-web-component/issues/19), check out
+[my talk on current state of web components and Glimmer’s place in it](https://www.youtube.com/watch?v=OzFgDBJcWuU)
+and stay tuned for our future blog post on testing Glimmer components.

--- a/_posts/2017-09-17-magic-test-data.md
+++ b/_posts/2017-09-17-magic-test-data.md
@@ -4,15 +4,24 @@ author: 'Andy Brown'
 github: geekygrappler
 twitter: geekygrappler
 bio: 'Senior Frontend Engineer'
-description: 'Andy Brown explains the AAA principle for writing good tests and discusses what the negative consequences of not adhering to it are.'
+description:
+  'Andy Brown explains the AAA principle for writing good tests and discusses
+  what the negative consequences of not adhering to it are.'
 topic: misc
 ---
 
-Often when working on large codebases, my changes break some existing tests. While I would prefer my coding to be perfect, it's highly unlikely that I'll ever achieve the state of coding zen, so it's nice to know I have a test suite to catch me when I fall. Given that the codebase is large and in the majority not written by me, I tend to be introduced to code via the test files. One important principle I've started to follow when writing and refactoring tests is AAA.
+Often when working on large codebases, my changes break some existing tests.
+While I would prefer my coding to be perfect, it's highly unlikely that I'll
+ever achieve the state of coding zen, so it's nice to know I have a test suite
+to catch me when I fall. Given that the codebase is large and in the majority
+not written by me, I tend to be introduced to code via the test files. One
+important principle I've started to follow when writing and refactoring tests is
+AAA.
 
 <!--break-->
 
-The [AAA principle](http://wiki.c2.com/?ArrangeActAssert) for testing is Arrange Act Assert and it's Amazing. The TL;DR is:
+The [AAA principle](http://wiki.c2.com/?ArrangeActAssert) for testing is Arrange
+Act Assert and it's Amazing. The TL;DR is:
 
 - Setup the data/inputs for the code you're testing (Arrange)
 - Invoke the code you are testing (Act)
@@ -35,11 +44,13 @@ test('toLowerCase makes string all lower case', function(assert) {
 
 If you have a test that doesn't Arrange, your test may be brittle.
 
-Don't believe me? Lets go through a real life example. You are tasked with making a country/language picker for a website that looks something like this.
+Don't believe me? Lets go through a real life example. You are tasked with
+making a country/language picker for a website that looks something like this.
 
 ![Country picker component](/assets/images/posts/2017-09-25-magic-test-data/tl-country-picker.png)
 
-You will probably have a hardcoded list of countries that your website supports somewhere in your app.
+You will probably have a hardcoded list of countries that your website supports
+somewhere in your app.
 
 ```js
 // config/countries.js
@@ -59,9 +70,11 @@ export default [
 ];
 ```
 
-We need to write a function that adds a url pointing to an image of the country flag so that the component can display that flag image.
+We need to write a function that adds a url pointing to an image of the country
+flag so that the component can display that flag image.
 
-So we write a component, here we're using Ember, but the principle is similar for any JS framework or vanilla JS.
+So we write a component, here we're using Ember, but the principle is similar
+for any JS framework or vanilla JS.
 
 ```js
 import Component from '@ember/component';
@@ -98,7 +111,8 @@ I don't think it's a good test though.
 
 <strong>The test is brittle.</strong>
 
-Let's say our business development team have made inroads into Bulgaria and now we need to add it to the the list of countries and locales.
+Let's say our business development team have made inroads into Bulgaria and now
+we need to add it to the the list of countries and locales.
 
 ```js
 // config/countries.js
@@ -124,11 +138,19 @@ export default [
 ];
 ```
 
-The test will now fail without us having changed the code. No code change, no behaviour change, but failing tests. The definition of a brittle test. The test relies on magic data from an external file, namely `COUNTRIES`. It may only take the original writer of the test minutes to figure out why the test fails, but it might take any one new to the code unit a bit longer to figure out why.
+The test will now fail without us having changed the code. No code change, no
+behaviour change, but failing tests. The definition of a brittle test. The test
+relies on magic data from an external file, namely `COUNTRIES`. It may only take
+the original writer of the test minutes to figure out why the test fails, but it
+might take any one new to the code unit a bit longer to figure out why.
 
-What you should do is _Arrange_ the data. When you do this it becomes clear that the function is simply adding a key, and it won't break due to external data changes. All you care about is that given a starting set of data, after applying your function you get the resultant set of data, as clearly defined in the test.
+What you should do is _Arrange_ the data. When you do this it becomes clear that
+the function is simply adding a key, and it won't break due to external data
+changes. All you care about is that given a starting set of data, after applying
+your function you get the resultant set of data, as clearly defined in the test.
 
-First we need to stop using a constant directly in our component. This way we can override the `countries` property in the test and _arrange_ the data.
+First we need to stop using a constant directly in our component. This way we
+can override the `countries` property in the test and _arrange_ the data.
 
 ```js
 import Component from '@ember/component';
@@ -179,7 +201,8 @@ test('displayCountries will add a flag key to a country object', function(assert
 });
 ```
 
-I feel much better about this test. It is no longer brittle as it's not dependent on an external `JSON` file.
+I feel much better about this test. It is no longer brittle as it's not
+dependent on an external `JSON` file.
 
 And I get to commit GoT & LOTR to the code base.
 

--- a/_posts/2017-10-24-high-level-assertions-with-qunit-dom.md
+++ b/_posts/2017-10-24-high-level-assertions-with-qunit-dom.md
@@ -4,20 +4,23 @@ author: 'Tobias Bieniek'
 github: Turbo87
 twitter: tobiasbieniek
 bio: 'Senior Frontend Engineer, Ember CLI core team member'
-description: 'Tobias Bieniek introduces qunit-dom, an extension for qunit that allows writing more expressive and less complex UI tests using high level DOM assertions.'
+description:
+  'Tobias Bieniek introduces qunit-dom, an extension for qunit that allows
+  writing more expressive and less complex UI tests using high level DOM
+  assertions.'
 topic: javascript
 ---
 
 At [EmberFest](https://emberfest.eu/) this year we presented and released
 [`qunit-dom`](https://github.com/simplabs/qunit-dom). A plugin for
-[QUnit](https://qunitjs.com/) providing High Level DOM Assertions with the
-goal to reduce test complexity for all QUnit users. This blog post will show
-you how to write simpler tests using `async/await` and `qunit-dom`.
+[QUnit](https://qunitjs.com/) providing High Level DOM Assertions with the goal
+to reduce test complexity for all QUnit users. This blog post will show you how
+to write simpler tests using `async/await` and `qunit-dom`.
 
 <!--break-->
 
-As an introduction to what this means let's start with an example template
-for an Ember app that we will write a test for:
+As an introduction to what this means let's start with an example template for
+an Ember app that we will write a test for:
 
 ```handlebars
 <h1 class="title {{if username "has-username"}}">
@@ -30,8 +33,8 @@ for an Ember app that we will write a test for:
 </h1>
 ```
 
-From the template above you can see that we have essentially two states that
-we need to test: one with and one without a `username` property being set.
+From the template above you can see that we have essentially two states that we
+need to test: one with and one without a `username` property being set.
 
 ## Status Quo
 
@@ -49,7 +52,10 @@ test('frontpage should be welcoming', function(assert) {
   fillIn('input.username', 'John Doe');
 
   andThen(function() {
-    assert.equal(find('h1.title').textContent.trim(), 'Welcome to Ember,\n    John Doe!');
+    assert.equal(
+      find('h1.title').textContent.trim(),
+      'Welcome to Ember,\n    John Doe!',
+    );
     assert.ok(find('h1.title').classList.contains('has-username'));
   });
 });
@@ -82,16 +88,19 @@ test('frontpage should be welcoming', function(assert) {
       return fillIn('input.username', 'John Doe');
     })
     .then(function() {
-      assert.equal(find('h1.title').textContent.trim(), 'Welcome to Ember,\n    John Doe!');
+      assert.equal(
+        find('h1.title').textContent.trim(),
+        'Welcome to Ember,\n    John Doe!',
+      );
       assert.ok(find('h1.title').classList.contains('has-username'));
     });
 });
 ```
 
-While that code makes it more obvious that we are dealing with asynchronous
-code here, it also make the code a little harder to read. Which is one of the
-reasons why a lot of Ember developers still prefer the `andThen` blocks over
-using `Promise` chains.
+While that code makes it more obvious that we are dealing with asynchronous code
+here, it also make the code a little harder to read. Which is one of the reasons
+why a lot of Ember developers still prefer the `andThen` blocks over using
+`Promise` chains.
 
 ## async/await
 
@@ -120,28 +129,31 @@ test('frontpage should be welcoming', async function(assert) {
 
   await fillIn('input.username', 'John Doe');
 
-  assert.equal(find('h1.title').textContent.trim(), 'Welcome to Ember,\n    John Doe!');
+  assert.equal(
+    find('h1.title').textContent.trim(),
+    'Welcome to Ember,\n    John Doe!',
+  );
   assert.ok(find('h1.title').classList.contains('has-username'));
 });
 ```
 
-As you can see this looks a lot more readable than what we had before and
-almost like the synchronous code we usually write.
+As you can see this looks a lot more readable than what we had before and almost
+like the synchronous code we usually write.
 
-The assertions (the lines starting with `assert.`) however are still quite
-hard to read, and it takes a short while to figure out what the intent of that
+The assertions (the lines starting with `assert.`) however are still quite hard
+to read, and it takes a short while to figure out what the intent of that
 assertion was.
 
 ## chai and chai-dom
 
-If you're using [Mocha](https://mochajs.org/) and [Chai](http://chaijs.com/)
-to write your tests, you are already used to more readable assertions since
-Chai emphasizes an "expressive language and readable style" for their
-assertions.
+If you're using [Mocha](https://mochajs.org/) and [Chai](http://chaijs.com/) to
+write your tests, you are already used to more readable assertions since Chai
+emphasizes an "expressive language and readable style" for their assertions.
 
-Fortunately for Chai there is a plugin called [`chai-dom`](https://github.com/nathanboktae/chai-dom)
-which provides even better assertions so that we could rewrite our assertions
-above to something like:
+Fortunately for Chai there is a plugin called
+[`chai-dom`](https://github.com/nathanboktae/chai-dom) which provides even
+better assertions so that we could rewrite our assertions above to something
+like:
 
 ```js
 expect(find('h1.title')).to.have.text('Welcome to Ember!');
@@ -160,12 +172,11 @@ provides.
 
 ## qunit-dom
 
-While `ember-cli-chai` also works with QUnit it is essentially just a hack
-and not really supported properly by QUnit or Chai so be careful if you're
-using it.
+While `ember-cli-chai` also works with QUnit it is essentially just a hack and
+not really supported properly by QUnit or Chai so be careful if you're using it.
 
-As we were getting more and more annoyed by the hard-to-read assertions
-when using QUnit we were starting to wonder if it would be possible to build
+As we were getting more and more annoyed by the hard-to-read assertions when
+using QUnit we were starting to wonder if it would be possible to build
 something like `chai-dom` but for QUnit instead and how that would look like.
 After a bit of brainstorming we figured we would want our assertions to look
 roughly like this:
@@ -182,9 +193,8 @@ assert.dom('h1.title').hasClass('has-username');
 
 Compared to what we started with this:
 
-- automatically finds the correct element on the `document` (or
-  `#ember-testing` element) based on the selector passed into
-  the `dom()` function
+- automatically finds the correct element on the `document` (or `#ember-testing`
+  element) based on the selector passed into the `dom()` function
 - collapses whitespace according to the HTML spec to get rid of the irrelevant
   `\n` part of the expected string
 - provides readable high level assertions for the most common checks on DOM
@@ -197,16 +207,19 @@ One additional advantage for Ember.js users is that it automatically hooks
 itself into the build pipeline of your projects, so all you need to do is
 `ember install qunit-dom`, and then you can immediately start using it!
 
-You can find examples of what assertions are available in the [README](https://github.com/simplabs/qunit-dom#qunit-dom)
-of the project and even more information in the [API reference](https://github.com/simplabs/qunit-dom/blob/master/API.md).
+You can find examples of what assertions are available in the
+[README](https://github.com/simplabs/qunit-dom#qunit-dom) of the project and
+even more information in the
+[API reference](https://github.com/simplabs/qunit-dom/blob/master/API.md).
 
 ## qunit-dom-codemod
 
 During the EmberFest conference we realized that while a lot of people would
 probably appreciate what we had built, nobody would go over their thousands of
-existing assertions and rewrite them all to use `qunit-dom`. Since a lot
-of the existing assertions in our client projects followed similar patterns
-we figured it might be possible to build a [codemod](https://medium.com/airbnb-engineering/turbocharged-javascript-refactoring-with-codemods-b0cae8b326b9)
+existing assertions and rewrite them all to use `qunit-dom`. Since a lot of the
+existing assertions in our client projects followed similar patterns we figured
+it might be possible to build a
+[codemod](https://medium.com/airbnb-engineering/turbocharged-javascript-refactoring-with-codemods-b0cae8b326b9)
 that did most of the rewriting automatically for us.
 
 After that initial thought we started working and after only a few minutes we
@@ -228,8 +241,8 @@ jscodeshift -t https://raw.githubusercontent.com/simplabs/qunit-dom-codemod/mast
 
 ## Conclusion
 
-Moving the tests to `async/await` and `qunit-dom` makes them a lot more
-readable and easier to understand for new developers and is just a few
-keystrokes away if you're already using Ember.js for your frontend projects.
-If you need help refactoring your tests or even your production code to be
-more structured and understandable feel free to [contact us](/contact/).
+Moving the tests to `async/await` and `qunit-dom` makes them a lot more readable
+and easier to understand for new developers and is just a few keystrokes away if
+you're already using Ember.js for your frontend projects. If you need help
+refactoring your tests or even your production code to be more structured and
+understandable feel free to [contact us](/contact/).

--- a/_posts/2017-11-17-ember-test-selectors-road-to-1-0.md
+++ b/_posts/2017-11-17-ember-test-selectors-road-to-1-0.md
@@ -4,15 +4,17 @@ author: 'Tobias Bieniek'
 github: Turbo87
 twitter: tobiasbieniek
 bio: 'Senior Frontend Engineer, Ember CLI core team member'
-description: 'Tobias Bieniek goes through what happened in ember-test-selectors during the past year and what the roadmap towards a 1.0 release is.'
+description:
+  'Tobias Bieniek goes through what happened in ember-test-selectors during the
+  past year and what the roadmap towards a 1.0 release is.'
 topic: ember
 ---
 
 Back in January we wrote about the
-[latest changes](/blog/2017/01/13/ember-test-selectors)
-in [`ember-test-selectors`](https://github.com/simplabs/ember-test-selectors)
-and how we implemented them. Since then we adjusted a few things and this blog
-post should give you an idea what has happened so far and what else will happen
+[latest changes](/blog/2017/01/13/ember-test-selectors) in
+[`ember-test-selectors`](https://github.com/simplabs/ember-test-selectors) and
+how we implemented them. Since then we adjusted a few things and this blog post
+should give you an idea what has happened so far and what else will happen
 before we feel comfortable promoting the addon to v1.0.0.
 
 <!--break-->
@@ -25,8 +27,8 @@ In HTML it is possible to add attributes to an element that don't have a value:
 <h1 data-test-title>FourtyTwo</h1>
 ```
 
-In Ember.js templates the same is possible for HTML elements, but for
-components everything is a little different.
+In Ember.js templates the same is possible for HTML elements, but for components
+everything is a little different.
 
 ```handlebars
 {{user-list data-test-user-list users=users}}
@@ -52,10 +54,10 @@ work as expected, as you can see in the following template:
 {{user-list users=users data-test-user-list}}
 ```
 
-The issue here is that Handlebars expects positional parameters in front of
-any named parameters and will throw an error otherwise. It is common however to
-put the more important things first in a component invocation which conflicts
-with having to put the valueless `data-test-*` attributes first as seen above.
+The issue here is that Handlebars expects positional parameters in front of any
+named parameters and will throw an error otherwise. It is common however to put
+the more important things first in a component invocation which conflicts with
+having to put the valueless `data-test-*` attributes first as seen above.
 
 Due to these problems we believe it is best to be explicit about these
 attributes and always declare them with a value:
@@ -65,29 +67,29 @@ attributes and always declare them with a value:
 ```
 
 We will deprecate the usage of valueless `data-test-*` attributes on components
-in an upcoming release and remove the transform completely for the v1.0.0 release.
+in an upcoming release and remove the transform completely for the v1.0.0
+release.
 
 ## v0.3.0: Support for Babel 6
 
 This year (2017) the Ember ecosystem finally moved from Babel 5 to Babel 6,
-which happened mostly without issues for app developers as it was just
-a dependency upgrade from `ember-cli-babel@5` to `ember-cli-babel@6`. Some
-app developers might think they are still only using Babel 5 for their app,
-but it is very likely that some of their addons are already using Babel 6 under
-the hood since all Ember addons controls their own transpilation.
+which happened mostly without issues for app developers as it was just a
+dependency upgrade from `ember-cli-babel@5` to `ember-cli-babel@6`. Some app
+developers might think they are still only using Babel 5 for their app, but it
+is very likely that some of their addons are already using Babel 6 under the
+hood since all Ember addons controls their own transpilation.
 
-For addons that rely on Babel transforms the upgrade unfortunately was not
-quite as smooth, as the Babel transforms API had changed significantly with
-Babel 6.
+For addons that rely on Babel transforms the upgrade unfortunately was not quite
+as smooth, as the Babel transforms API had changed significantly with Babel 6.
 
-As `ember-test-selectors` relies on Babel transforms we needed to figure out
-a solution to this problem. We wanted to support both Babel 5 and Babel 6 in
-the same addon instead of having to publish two different variants of the addon
-each targeting a different Babel version.
+As `ember-test-selectors` relies on Babel transforms we needed to figure out a
+solution to this problem. We wanted to support both Babel 5 and Babel 6 in the
+same addon instead of having to publish two different variants of the addon each
+targeting a different Babel version.
 
 Fortunately at [EmberConf](http://emberconf.com/) in March we found a solution:
-The addon now checks the dependencies of your project and figures out
-which version of `ember-cli-babel` you use. Based on that information we inject
+The addon now checks the dependencies of your project and figures out which
+version of `ember-cli-babel` you use. Based on that information we inject
 different Babel transforms into the build pipeline so that we can support both
 major Babel versions with the same addon.
 
@@ -99,10 +101,10 @@ unconditionally. It turned out that if `ember-test-selectors` was used as a
 nested addon some of the build logic that we had in place was not working
 properly.
 
-A few days later Luke provided us with a repository that reproduced his
-problem. Using his reproduction we have been able to fix the issue and it is
-now possible to also use `ember-test-selectors` as a nested addon dependency
-and rely on correct test-selector stripping depending on the build environment.
+A few days later Luke provided us with a repository that reproduced his problem.
+Using his reproduction we have been able to fix the issue and it is now possible
+to also use `ember-test-selectors` as a nested addon dependency and rely on
+correct test-selector stripping depending on the build environment.
 
 ## v0.3.7: Deprecation of the `testSelector` helper function
 
@@ -125,17 +127,17 @@ let bar = '[data-test-bar="baz"]';
 ```
 
 After discussing back and forth and coming up with
-[alternative APIs](https://github.com/simplabs/ember-test-selectors/pull/122)
-we decided the best way forward was actually to not use any helpers at all.
-This has the advantage of not hiding the actual CSS selector that is being used
-and requiring less knowledge of how `ember-test-selectors` works to understand
-what any test code is doing.
+[alternative APIs](https://github.com/simplabs/ember-test-selectors/pull/122) we
+decided the best way forward was actually to not use any helpers at all. This
+has the advantage of not hiding the actual CSS selector that is being used and
+requiring less knowledge of how `ember-test-selectors` works to understand what
+any test code is doing.
 
 Following the discussion we have deprecated the `testSelector` helper function
 and will remove it before releasing v1.0.0. If you have used the function a lot
-there is a third-party [codemod](https://github.com/lorcan/test-selectors-codemod)
-that might be able to save you a few minutes or hours by converting the code
-for you automatically.
+there is a third-party
+[codemod](https://github.com/lorcan/test-selectors-codemod) that might be able
+to save you a few minutes or hours by converting the code for you automatically.
 
 ## v0.3.8: Support for Ember 1.11 and 1.12
 
@@ -144,19 +146,19 @@ as @pzuraq, approached us about supporting Ember 1.11 and 1.12 in
 `ember-test-selectors`. He was working on some projects that were started in the
 early days of Ember and to be able to upgrade them confidently to a newer Ember
 version he needed to write better tests. For those tests he wanted to use
-test-selectors, but since they required a newer Ember version he was stuck in
-a vicious circle.
+test-selectors, but since they required a newer Ember version he was stuck in a
+vicious circle.
 
-It seemed that the main issue with Ember 1.11/1.12 support was that our
-template AST transforms were failing and as a first attempt we simply disabled
-them completely which resolved the problem. Unfortunately that meant that
+It seemed that the main issue with Ember 1.11/1.12 support was that our template
+AST transforms were failing and as a first attempt we simply disabled them
+completely which resolved the problem. Unfortunately that meant that
 test-selectors were no longer stripped at all from the templates which did not
 seem like a good solution to us so we dug deeper.
 
 Thanks to [ember-try](https://github.com/ember-cli/ember-try) it was very fast
 and easy to try out our addon on many different Ember versions and we quickly
-discovered that the Handlebars AST had changed between Ember 1.12 and 1.13 in
-a way that caused our transforms to crash.
+discovered that the Handlebars AST had changed between Ember 1.12 and 1.13 in a
+way that caused our transforms to crash.
 
 The AST for a template like:
 
@@ -208,14 +210,13 @@ MustacheStatement {
 }
 ```
 
-As you can see the AST looks almost similar, but not exactly the same.
-In the end we figured out we could check if the `MustacheStatement` has
-a `sexpr` property, and in that case use the `hash` property inside of
-that instead.
+As you can see the AST looks almost similar, but not exactly the same. In the
+end we figured out we could check if the `MustacheStatement` has a `sexpr`
+property, and in that case use the `hash` property inside of that instead.
 
 Once we had that conditional in place all our tests were 🍏 again and we were
-able to adjust our range of supported Ember versions all the way down to
-Ember 1.11.
+able to adjust our range of supported Ember versions all the way down to Ember
+1.11.
 
 ## Conclusion
 

--- a/_posts/2017-12-04-enginification.md
+++ b/_posts/2017-12-04-enginification.md
@@ -4,15 +4,17 @@ author: 'Clemens Müller'
 github: pangratz
 twitter: pangratz
 bio: 'Full-Stack Engineer, Ember Data core team member'
-description: 'Clemens Müller gives an overview of Ember Engines and shows how they can be used to reduce the footprint of big applications for an improved startup time.'
+description:
+  'Clemens Müller gives an overview of Ember Engines and shows how they can be
+  used to reduce the footprint of big applications for an improved startup time.'
 topic: ember
 ---
 
 We recently improved the initial load time of an Ember.js app for mobile
-clients, by using [Ember Engines](http://ember-engines.com/) and leveraging
-that to lazily loaded parts of the app's code. In this blog post we're going to
-show how we extracted the engine out of the app and discuss some smaller issues
-we ran into along the way and how we solved them. So let's dive right in!
+clients, by using [Ember Engines](http://ember-engines.com/) and leveraging that
+to lazily loaded parts of the app's code. In this blog post we're going to show
+how we extracted the engine out of the app and discuss some smaller issues we
+ran into along the way and how we solved them. So let's dive right in!
 
 <!--break-->
 
@@ -20,9 +22,9 @@ we ran into along the way and how we solved them. So let's dive right in!
 
 The app is a mobile ticket counter for rail tickets. The basic flow through the
 app is as follows: a user enters an departure and arrival station and specifies
-the dates and passengers of the journey. After a search is initiated the
-results are shown, a specific trip is chosen, details like seating preference
-and passenger details are entered, the payment is processed and at the end, the
+the dates and passengers of the journey. After a search is initiated the results
+are shown, a specific trip is chosen, details like seating preference and
+passenger details are entered, the payment is processed and at the end, the
 details of the booked trip are shown and the purchased tickets can be
 downloaded.
 
@@ -35,7 +37,8 @@ components, 24 models which result in the following asset sizes:
 | `vendor.js` | 1.51 MB (342.87 KB gzipped)   |
 | `app.css`   | 104.31 KB (19.25 KB gzipped)  |
 
-Taken from the [Ember Engine RFC](https://github.com/emberjs/rfcs/blob/master/text/0010-engines.md):
+Taken from the
+[Ember Engine RFC](https://github.com/emberjs/rfcs/blob/master/text/0010-engines.md):
 
 > Engines allow multiple logical applications to be composed together into a
 > single application from the user's perspective.
@@ -44,18 +47,17 @@ As users need to fill in the search form - specify what kind of ticket they are
 looking for and for which connection - before they can even proceed to the next
 step, there is no reason to load all of the code that supports the subsequent
 booking flow on application startup. All of that code can be loaded lazily once
-the user proceeds to the next step by actually initiating a search or even
-while they are filling out the login form.
+the user proceeds to the next step by actually initiating a search or even while
+they are filling out the login form.
 
 ## Extract common functionality used in app into an addon
 
 One fundamental design principle of engines is that they are isolated from the
 hosting app. It is possible to pass in services from the hosting app but apart
 from that, engines don't have access to anything of the app which mounts the
-engine.
-In order for components, helpers and styles to be accessible from both the host
-app and the engine, those common elements need to be put into an addon, which
-then the app and the engine depend on.
+engine. In order for components, helpers and styles to be accessible from both
+the host app and the engine, those common elements need to be put into an addon,
+which then the app and the engine depend on.
 
 We're using an in repo addon for that:
 
@@ -82,7 +84,8 @@ git add lib/common/app/components/loading-indicator.js
 ```
 
 Since the component is now located within the `addon` folder, we need to modify
-`lib/common/addon/components/loading-indicator.js` so the correct layout is used:
+`lib/common/addon/components/loading-indicator.js` so the correct layout is
+used:
 
 ```js
 import layout from '../templates/components/loading-indicator';
@@ -116,8 +119,8 @@ git mv app/styles/components/loading-indicator.scss \
 ```
 
 Apart from this, we also need to create a file which includes all the styles
-from the common components and helpers. By this all the styles from the
-`common` addon are included in the hosting app:
+from the common components and helpers. By this all the styles from the `common`
+addon are included in the hosting app:
 
 ```scss
 // lib/common/app/styles/common.scss
@@ -149,8 +152,9 @@ engine as well:
 ember generate in-repo-addon booking-flow
 ```
 
-After that, setting up the in-repo engine according to [the guides](http://ember-engines.com/guide/creating-an-engine)
-is pretty straight forward. At the end of that we have an engine, located at
+After that, setting up the in-repo engine according to
+[the guides](http://ember-engines.com/guide/creating-an-engine) is pretty
+straight forward. At the end of that we have an engine, located at
 `lib/booking-flow`, so now it's time to move relevant routes, components,
 templates, ... out of `app/` into it.
 
@@ -175,14 +179,14 @@ can re-use the common elements within the engine. Let's take a look at
 
 After that we can start to move all the routes, components, services which are
 only used within the booking-flow engine into the corresponding folders within
-`lib/booking-flow/addon/`. The nice thing about Ember Engines is that they
-don't introduce any new concepts in terms of location of the files. So a simple
+`lib/booking-flow/addon/`. The nice thing about Ember Engines is that they don't
+introduce any new concepts in terms of location of the files. So a simple
 `git mv` does the trick.
 
-The booking-flow addon should use the same style definitions as the hosting
-app, so we'd like to import the common style definitions within the
-booking-flow engines styles. For the imports to work properly, we need to
-add the path to the `common` addon to the `sassOptions` of the engine:
+The booking-flow addon should use the same style definitions as the hosting app,
+so we'd like to import the common style definitions within the booking-flow
+engines styles. For the imports to work properly, we need to add the path to the
+`common` addon to the `sassOptions` of the engine:
 
 ```js
 // lib/booking-flow/index.js
@@ -226,9 +230,9 @@ nifty feature of Ember Engines…
 ## Make it lazy
 
 After we extracted the `common` addon and the `booking-flow` engine, we are
-ready to load the engine lazily to actually reduce the amount of JavaScript
-that needs to be loaded, parsed and compiled to boot up the application. This
-is as hard work as switching a boolean:
+ready to load the engine lazily to actually reduce the amount of JavaScript that
+needs to be loaded, parsed and compiled to boot up the application. This is as
+hard work as switching a boolean:
 
 ```js
 // lib/booking-flow/index.js
@@ -250,8 +254,8 @@ module.exports = EngineAddon.extend({
 
 And et voilà: we now have 3 new, separate assets, which are loaded on demand
 once we navigate into a route within the engine. Since the initial assets only
-contain the essential logic needed for the search, they have shrunken in size
-as well:
+contain the essential logic needed for the search, they have shrunken in size as
+well:
 
 | Asset                    | Before                        | After                        |
 | ------------------------ | ----------------------------- | ---------------------------- |

--- a/_posts/2018-01-24-ember-freestyle.md
+++ b/_posts/2018-01-24-ember-freestyle.md
@@ -4,18 +4,20 @@ author: 'Tobias Bieniek'
 github: Turbo87
 twitter: tobiasbieniek
 bio: 'Senior Frontend Engineer, Ember CLI core team member'
-description: 'Tobias Bieniek gives an overview of how ember-freestyle can be used in Ember.js applications for building and testing components in isolation.'
+description:
+  'Tobias Bieniek gives an overview of how ember-freestyle can be used in
+  Ember.js applications for building and testing components in isolation.'
 topic: ember
 ---
 
-A component playground is an application that you can use to test out and
-play around with your custom components in isolation from the rest of your
-project. In the React and Vue ecosystem [Storybook][storybook] is a quite popular project
+A component playground is an application that you can use to test out and play
+around with your custom components in isolation from the rest of your project.
+In the React and Vue ecosystem [Storybook][storybook] is a quite popular project
 that implements such a component playground as part of your app. In the Ember
 ecosystem we have the [`ember-freestyle`][ember-freestyle] addon that can be
 used for this purpose. This blog post will show you how to install
-`ember-freestyle` in your app and how to use it to build and test components
-in isolation.
+`ember-freestyle` in your app and how to use it to build and test components in
+isolation.
 
 [storybook]: https://storybook.js.org/
 [ember-freestyle]: http://ember-freestyle.com/
@@ -26,13 +28,12 @@ in isolation.
 
 You might be wondering "Why would would I need something like this? I can just
 test my components in the app!" and you're right. But imagine building a
-reasonably large application with dozens of routes, hundreds of components
-and thousands of possible component states. Checking all of these
-component states manually on the different routes that they are appearing on
-is a very time consuming task. A component playground solves this by allowing
-you to display multiple component states next to each other on a single page
-to give you a much better and quicker overview of how the component will look
-like in the end.
+reasonably large application with dozens of routes, hundreds of components and
+thousands of possible component states. Checking all of these component states
+manually on the different routes that they are appearing on is a very time
+consuming task. A component playground solves this by allowing you to display
+multiple component states next to each other on a single page to give you a much
+better and quicker overview of how the component will look like in the end.
 
 Another big advantage of using component playgrounds is that it forces you to
 build reusable components that are isolated from the app's business logic and
@@ -40,17 +41,19 @@ layout. That means they don't depend on any state or actions in your
 controllers, routes and ideally services, but only on the data and action
 handlers that are passed into them.
 
-If you want to know more about why component playgrounds are useful in general
-I recommend reading this great blog post ["UI component explorers — your new favorite tool"][ui-component-explorers]
-by Dominic Nguyen that explains the benefits very well.
+If you want to know more about why component playgrounds are useful in general I
+recommend reading this great blog post ["UI component explorers — your new
+favorite tool"][ui-component-explorers] by Dominic Nguyen that explains the
+benefits very well.
 
-[ui-component-explorers]: https://blog.hichroma.com/the-crucial-tool-for-modern-frontend-engineers-fb849b06187a
+[ui-component-explorers]:
+  https://blog.hichroma.com/the-crucial-tool-for-modern-frontend-engineers-fb849b06187a
 
 ## Installing `ember-freestyle`
 
-Installing and configuring `ember-freestyle` correctly is unfortunately a
-little complicated right now so if you want to take a look at the final
-outcome, you can skip forward to the ["Using `ember-freestyle`"](#using-ember-freestyle)
+Installing and configuring `ember-freestyle` correctly is unfortunately a little
+complicated right now so if you want to take a look at the final outcome, you
+can skip forward to the ["Using `ember-freestyle`"](#using-ember-freestyle)
 section for now.
 
 Before we start installing anything we should make sure we know what situation
@@ -91,8 +94,8 @@ condition:
 ```
 
 `onFreestyleRoute` is a property on the `application` controller that will be
-set to `true` once we visit the `/freestyle` route and and back to `false`
-once we leave it again. This can be implemented in the `app/routes/freestyle.js`
+set to `true` once we visit the `/freestyle` route and and back to `false` once
+we leave it again. This can be implemented in the `app/routes/freestyle.js`
 file, and since that does not exist yet, we can generate it using
 `ember generate route freestyle` (choose not to overwrite the existing
 template!) and then adjusting it like this:
@@ -126,7 +129,8 @@ the addon in the `ember-cli-build.js` file of our app:
 ```js
 module.exports = function(defaults) {
   let environment = process.env.EMBER_ENV;
-  let pluginsToBlacklist = environment === 'production' ? ['ember-freestyle'] : [];
+  let pluginsToBlacklist =
+    environment === 'production' ? ['ember-freestyle'] : [];
 
   let app = new EmberApp(defaults, {
     addons: {
@@ -143,26 +147,28 @@ still not quite back to what we had before. 🤔
 
 The code above only removes all the components from the build that
 `ember-freestyle` brings with it itself. That means components like
-`{{freestyle-guide}}` and `{{freestyle-usage}}`
-are no longer part of the production build, but the `freestyle` controller,
-route and template are still included.
+`{{freestyle-guide}}` and `{{freestyle-usage}}` are no longer part of the
+production build, but the `freestyle` controller, route and template are still
+included.
 
 The solution to this problem is moving the `freestyle` files into a dedicated
 `in-repo-addon` and then blacklisting that one too. First we generate a new
 `in-repo-addon` using `ember generate in-repo-addon freestyle`. After that we
-move `app/controllers/freestyle.js` to `lib/freestyle/app/controllers/freestyle.js`
-and do the same for the `freestyle` route and template.
+move `app/controllers/freestyle.js` to
+`lib/freestyle/app/controllers/freestyle.js` and do the same for the `freestyle`
+route and template.
 
 Next we will add our new `freestyle` in-repo-addon to the `pluginsToBlacklist`
 list above:
 
 ```js
-let pluginsToBlacklist = environment === 'production' ? ['ember-freestyle', 'freestyle'] : [];
+let pluginsToBlacklist =
+  environment === 'production' ? ['ember-freestyle', 'freestyle'] : [];
 ```
 
 Finally we need to adjust the paths that `ember-freestyle` uses to search for
-the code snippets that show how the component is used in a host application.
-For that we will add a `snippetSearchPaths` property in the `ember-cli-build.js`
+the code snippets that show how the component is used in a host application. For
+that we will add a `snippetSearchPaths` property in the `ember-cli-build.js`
 file:
 
 ```js
@@ -174,13 +180,13 @@ let app = new EmberApp(defaults, {
 });
 ```
 
-If you now restart the development server and check the `/freestyle` route
-you should see that everything is working as before, but if instead you run
-`ember serve -prod` you will notice that you only see a blank page because
-the `freestyle` controller, route and template are no longer available.
-If you would like to use your default 404 page instead you can put the
-`this.route('freestyle');` call in the `router.js` file in a condition
-that checks `if (config.environment === 'development')`.
+If you now restart the development server and check the `/freestyle` route you
+should see that everything is working as before, but if instead you run
+`ember serve -prod` you will notice that you only see a blank page because the
+`freestyle` controller, route and template are no longer available. If you would
+like to use your default 404 page instead you can put the
+`this.route('freestyle');` call in the `router.js` file in a condition that
+checks `if (config.environment === 'development')`.
 
 This leaves us with only the single condition in the `application` template and
 the `this.route('freestyle');` call in the `router.js` file that we ship to
@@ -190,12 +196,12 @@ component playground! 🎉
 
 ## Using `ember-freestyle`
 
-The good news is that **using** `ember-freestyle` is much easier than setting
-it up correctly!
+The good news is that **using** `ember-freestyle` is much easier than setting it
+up correctly!
 
-Let's pretend we are writing a component called `styled-button`. We can create
-a new file at `app/components/styled-button.js` and put the following content
-in it:
+Let's pretend we are writing a component called `styled-button`. We can create a
+new file at `app/components/styled-button.js` and put the following content in
+it:
 
 ```js
 import Component from '@ember/component';
@@ -243,21 +249,21 @@ Finally we will add the button to our component playground by editing the
 {{/freestyle-guide}}
 ```
 
-If we now visit `http://localhost:4200/freestyle` we will see a new
-"Components" section in the sidebar on the left that includes our
-"styled-button" subsection. Once we click on that we will see our
-`styled-button` usage examples including the snippets there were used to
-display them:
+If we now visit `http://localhost:4200/freestyle` we will see a new "Components"
+section in the sidebar on the left that includes our "styled-button" subsection.
+Once we click on that we will see our `styled-button` usage examples including
+the snippets there were used to display them:
 
 ![Screenshot](/assets/images/posts/2017-12-07-ember-freestyle/styled-button.png#@900-1800)
 
-As this blog post has gotten much longer than intended already I'll leave it
-up to your imagination what other things you can put into such a component
+As this blog post has gotten much longer than intended already I'll leave it up
+to your imagination what other things you can put into such a component
 playground. In a follow-up post we will soon discuss how to extract subsections
 into components and how to automatically discover and inject them into the main
 template.
 
-Finally I would like to thank [Chris LoPresto][chris-lopresto] and the other contributors for
-working on `ember-freestyle` and would encourage you to give it a try!
+Finally I would like to thank [Chris LoPresto][chris-lopresto] and the other
+contributors for working on `ember-freestyle` and would encourage you to give it
+a try!
 
 [chris-lopresto]: https://github.com/chrislopresto

--- a/_posts/2018-02-14-handling-webhooks-in-phoenix.md
+++ b/_posts/2018-02-14-handling-webhooks-in-phoenix.md
@@ -4,21 +4,32 @@ author: 'Niklas Long'
 github: niklaslong
 twitter: niklas_long
 bio: 'Backend Engineer, author of Breethe API'
-description: 'Niklas Long introduces an effective and simple approach for handling incoming webhook requests in Phoenix applications with advanced routing.'
+description:
+  'Niklas Long introduces an effective and simple approach for handling incoming
+  webhook requests in Phoenix applications with advanced routing.'
 topic: elixir
 ---
 
-I recently had to implement a controller, which took care of receiving and processing webhooks. The thing is, the application had to handle webhooks which often contained very different information, and they were all going to one route and one controller action. This didn't really seem to fit with my goal of keeping controller actions concise and focused. So I set out to find a better solution.
+I recently had to implement a controller, which took care of receiving and
+processing webhooks. The thing is, the application had to handle webhooks which
+often contained very different information, and they were all going to one route
+and one controller action. This didn't really seem to fit with my goal of
+keeping controller actions concise and focused. So I set out to find a better
+solution.
 
 <!--break-->
 
 ## tl;dr
 
-Use `forward` on `MyApp.Router` to forward the request (`%Conn{}`) to a custom plug (`MyApp.Plugs.WebhookShunt`) which maps `%Conn{}` to a route (and thus a controller action) defined on `MyApp.WebhookRouter`, based on the data in the request body.
+Use `forward` on `MyApp.Router` to forward the request (`%Conn{}`) to a custom
+plug (`MyApp.Plugs.WebhookShunt`) which maps `%Conn{}` to a route (and thus a
+controller action) defined on `MyApp.WebhookRouter`, based on the data in the
+request body.
 
 I.e.,
 
-`%Conn{}` -> `Router` -> `WebhookShunt` -> `WebhookRouter` -> `WebhookController`
+`%Conn{}` -> `Router` -> `WebhookShunt` -> `WebhookRouter` ->
+`WebhookController`
 
 ## lv;e (long version; enjoy!)
 
@@ -28,9 +39,12 @@ Let's restate the problem:
 - there are many different possible request payloads
 - application requires different computation depending on payload
 
-Let's say we're receiving webhooks which contain an `event` key in the request body. It describes the event which triggered the webhook and we can use it to determine what code we are going to run.
+Let's say we're receiving webhooks which contain an `event` key in the request
+body. It describes the event which triggered the webhook and we can use it to
+determine what code we are going to run.
 
-Below was my first and somewhat naïve implementation. This is what the router looked like:
+Below was my first and somewhat naïve implementation. This is what the router
+looked like:
 
 ```elixir
 scope "/", MyAppWeb do
@@ -51,9 +65,12 @@ def hook(conn, params) do
 end
 ```
 
-All incoming webhooks go to the same route and therefore, the same controller action.
+All incoming webhooks go to the same route and therefore, the same controller
+action.
 
-It took three refactors to get to a satisfactory solution. I will, however, explain each one in this post, as they are logical steps in reaching the final solution and proved interesting learning opportunities:
+It took three refactors to get to a satisfactory solution. I will, however,
+explain each one in this post, as they are logical steps in reaching the final
+solution and proved interesting learning opportunities:
 
 1. Multiple function clauses for controller action
 2. Plug called from endpoint
@@ -61,7 +78,11 @@ It took three refactors to get to a satisfactory solution. I will, however, expl
 
 ## Multiple function clauses
 
-Let's start separating the computation into smaller fragments by moving the pattern matching from the `case` statement to the function's definition. We are still using only one route and only one controller action, but we write multiple clauses of that function to match a certain value of the `event` key in the params.
+Let's start separating the computation into smaller fragments by moving the
+pattern matching from the `case` statement to the function's definition. We are
+still using only one route and only one controller action, but we write multiple
+clauses of that function to match a certain value of the `event` key in the
+params.
 
 Here's our controller with the multiple clauses:
 
@@ -72,11 +93,18 @@ def hook(conn, %{"event" => "multiplication"} = params), do: multiply(params)
 def hook(conn, %{"event" => "division"} = params), do: divide(params)
 ```
 
-The request payload will match the clauses for the `hook/2` function and execute different functions depending on what `event` was passed in. This refactor is a step in the right direction, but it still doesn't fit well with the idea that a controller action should handle one specific request. The router serves no real purpose, as there is still only one route, and our code has the potential to get very messy.
+The request payload will match the clauses for the `hook/2` function and execute
+different functions depending on what `event` was passed in. This refactor is a
+step in the right direction, but it still doesn't fit well with the idea that a
+controller action should handle one specific request. The router serves no real
+purpose, as there is still only one route, and our code has the potential to get
+very messy.
 
 ## Shunting incoming connections
 
-What if we could interfere with the incoming webhook before it hits the router? We could then modify the path of the request depending on the params, match a route and execute the corresponding controller action.
+What if we could interfere with the incoming webhook before it hits the router?
+We could then modify the path of the request depending on the params, match a
+route and execute the corresponding controller action.
 
 The router would look something like this:
 
@@ -98,11 +126,25 @@ def multiply(conn, params), do: #handle multiplication
 def divide(conn, params), do: #handle division
 ```
 
-In this case, each controller action serves a specific function, the router maps each incoming request to these actions and the code is easily maintainable, well-structured and won't become jumbled over time. To achieve this, however, we need to change a couple of things.
+In this case, each controller action serves a specific function, the router maps
+each incoming request to these actions and the code is easily maintainable,
+well-structured and won't become jumbled over time. To achieve this, however, we
+need to change a couple of things.
 
-First off, we need to interfere with the incoming request before it hits the router so it will match our new routes. This is because the webhook callback url is always the same and doesn't depend on what event triggered it e.g., `"my_app_url/webhook"`. You would think we could create a plug for this and simply add it to a custom pipeline for the routes. The problem with this, is the router will invoke the pipeline **after** it matches a route. Therefore, we cannot modify the request's path in this pipeline and expect it to match our `addition`, `subtraction`, `multiplication` or `division` routes. If we want our new routes to match, we need to intercept the `%Conn{}` in a plug called in the endpoint. The endpoint handles starting the web server and transforming requests through several defined plugs before calling the router.
+First off, we need to interfere with the incoming request before it hits the
+router so it will match our new routes. This is because the webhook callback url
+is always the same and doesn't depend on what event triggered it e.g.,
+`"my_app_url/webhook"`. You would think we could create a plug for this and
+simply add it to a custom pipeline for the routes. The problem with this, is the
+router will invoke the pipeline **after** it matches a route. Therefore, we
+cannot modify the request's path in this pipeline and expect it to match our
+`addition`, `subtraction`, `multiplication` or `division` routes. If we want our
+new routes to match, we need to intercept the `%Conn{}` in a plug called in the
+endpoint. The endpoint handles starting the web server and transforming requests
+through several defined plugs before calling the router.
 
-Let's add a plug called `MyApp.WebhookShunt` to the endpoint, just before the router.
+Let's add a plug called `MyApp.WebhookShunt` to the endpoint, just before the
+router.
 
 ```elixir
 defmodule MyApp.Endpoint do
@@ -112,7 +154,8 @@ defmodule MyApp.Endpoint do
 end
 ```
 
-And let's create a file called `webhook_shunt.ex` and add it to our `plugs` folder:
+And let's create a file called `webhook_shunt.ex` and add it to our `plugs`
+folder:
 
 ```elixir
 defmodule MyAppWeb.Plug.WebhookShunt do
@@ -124,14 +167,22 @@ defmodule MyAppWeb.Plug.WebhookShunt do
 end
 ```
 
-The core components of a Phoenix application are plugs. This includes endpoints, routers and controllers. There are two flavors of `Plug`, function plugs and module plugs. We'll be using the latter in this example, but I highly suggest checking out the [docs](https://hexdocs.pm/plug/readme.html).
+The core components of a Phoenix application are plugs. This includes endpoints,
+routers and controllers. There are two flavors of `Plug`, function plugs and
+module plugs. We'll be using the latter in this example, but I highly suggest
+checking out the [docs](https://hexdocs.pm/plug/readme.html).
 
-Let's examine the code above, you'll notice there are two functions already defined:
+Let's examine the code above, you'll notice there are two functions already
+defined:
 
-- `init/1` which initializes any arguments or options to be passed to `call/2` (executed at compile time)
-- `call/2` which transforms the connection (it's actually a simple function plug and is executed at run time)
+- `init/1` which initializes any arguments or options to be passed to `call/2`
+  (executed at compile time)
+- `call/2` which transforms the connection (it's actually a simple function plug
+  and is executed at run time)
 
-Both of these need to be implemented in a module plug. Let's modify `call/2` to match the `addition` event in the request payload and change the request path to the route we defined for addition:
+Both of these need to be implemented in a module plug. Let's modify `call/2` to
+match the `addition` event in the request payload and change the request path to
+the route we defined for addition:
 
 ```elixir
 defmodule MyAppWeb.Plug.WebhookShunt do
@@ -151,30 +202,48 @@ defmodule MyAppWeb.Plug.WebhookShunt do
 end
 ```
 
-`change_path_info/2` changes the `path_info` property on the `%Conn{}`, based on the request payload matched in `call/2`, in this case to `"webhook/addition"`. You'll notice I also added a no-op function clause for `call/2`. If other routes are added and don't need to be manipulated in the same way as the ones above, we need to make sure the request gets through to the router unmodified.
+`change_path_info/2` changes the `path_info` property on the `%Conn{}`, based on
+the request payload matched in `call/2`, in this case to `"webhook/addition"`.
+You'll notice I also added a no-op function clause for `call/2`. If other routes
+are added and don't need to be manipulated in the same way as the ones above, we
+need to make sure the request gets through to the router unmodified.
 
-This strategy isn't great, however. We are placing code in the endpoint, which will be executed no matter what the request path is. Furthermore, the endpoint is only supposed to (from the [docs](https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#content)):
+This strategy isn't great, however. We are placing code in the endpoint, which
+will be executed no matter what the request path is. Furthermore, the endpoint
+is only supposed to (from the
+[docs](https://hexdocs.pm/phoenix/Phoenix.Endpoint.html#content)):
 
-- provide a wrapper for starting and stopping the endpoint as part of a supervision tree
+- provide a wrapper for starting and stopping the endpoint as part of a
+  supervision tree
 - define an initial plug pipeline for requests to pass through
 - host web specific configuration for your application
 
-Interfering with the request to map it to a route at this point would be unidiomatic Phoenix. It would also make the app slower, and harder to maintain and debug.
+Interfering with the request to map it to a route at this point would be
+unidiomatic Phoenix. It would also make the app slower, and harder to maintain
+and debug.
 
 ## Forwarding conn to the shunt and calling another router
 
-Instead of intercepting the `%Conn{}` in the endpoint, we could forward it from the application's main router to the `WebhookShunt`, modify it and call a second router whose sole purpose would be to handle the incoming webhooks.
+Instead of intercepting the `%Conn{}` in the endpoint, we could forward it from
+the application's main router to the `WebhookShunt`, modify it and call a second
+router whose sole purpose would be to handle the incoming webhooks.
 
 1. The request hits router which has one path for all webhooks (`"/webhook"`)
-2. `%Conn{}` is forwarded to the `WebhookShunt` which modifies the path based on the request payload
-3. The `WebhookShunt` calls the `WebhookRouter`, passing it the modified `%Conn{}`
-4. The `WebhookRouter` matches the `%Conn{}` path and calls the appropriate action on the `WebhookController`
+2. `%Conn{}` is forwarded to the `WebhookShunt` which modifies the path based on
+   the request payload
+3. The `WebhookShunt` calls the `WebhookRouter`, passing it the modified
+   `%Conn{}`
+4. The `WebhookRouter` matches the `%Conn{}` path and calls the appropriate
+   action on the `WebhookController`
 
 I.e.,
 
-`%Conn{}` -> `Router` -> `WebhookShunt` -> `WebhookRouter` -> `WebhookController`
+`%Conn{}` -> `Router` -> `WebhookShunt` -> `WebhookRouter` ->
+`WebhookController`
 
-I think this approach is better. We don't need to modify the endpoint, the router simply forwards anything that matches the webhook path to the shunt and the app's concerns are clearly separated.
+I think this approach is better. We don't need to modify the endpoint, the
+router simply forwards anything that matches the webhook path to the shunt and
+the app's concerns are clearly separated.
 
 Let's set up our webhook path in `router.ex`:
 
@@ -184,9 +253,12 @@ scope "/", MyAppWeb do
 end
 ```
 
-As long as your external APIs makes a request to this path when you do the setup for the webhook callbacks, every incoming request to this path will be forwarded to the `WebhookShunt`.
+As long as your external APIs makes a request to this path when you do the setup
+for the webhook callbacks, every incoming request to this path will be forwarded
+to the `WebhookShunt`.
 
-Let's refactor `call/2` to handle all events by replacing the hardcoded `"addition"` event and path with the `event` variable:
+Let's refactor `call/2` to handle all events by replacing the hardcoded
+`"addition"` event and path with the `event` variable:
 
 ```elixir
 defmodule MyAppWeb.Plugs.WebhookShunt do
@@ -205,11 +277,18 @@ defmodule MyAppWeb.Plugs.WebhookShunt do
 end
 ```
 
-With this refactor, all our routes must follow the `"webhook/event"` pattern. In more complex applications, you might not be able to conveniently use the event name as a part of the path but the principle remains the same.
+With this refactor, all our routes must follow the `"webhook/event"` pattern. In
+more complex applications, you might not be able to conveniently use the event
+name as a part of the path but the principle remains the same.
 
-You'll notice I've removed the no-op `call/2` function clause. This is because we no longer have to handle all potential requests like we did in the endpoint; we can focus entirely on the webhhooks. Now, if we receive a request with an event which doesn't match a route, Phoenix will raise an error, which is what we want as we don't know how to handle that request.
+You'll notice I've removed the no-op `call/2` function clause. This is because
+we no longer have to handle all potential requests like we did in the endpoint;
+we can focus entirely on the webhhooks. Now, if we receive a request with an
+event which doesn't match a route, Phoenix will raise an error, which is what we
+want as we don't know how to handle that request.
 
-Note: if you can't configure your API to send only the webhooks you're interested in handling, you should write some code to take care of that.
+Note: if you can't configure your API to send only the webhooks you're
+interested in handling, you should write some code to take care of that.
 
 Let's also create `webhook_router.ex` in the `_web` directory:
 
@@ -226,7 +305,9 @@ defmodule MyAppWeb.WebhookRouter do
 end
 ```
 
-The `WebhookRouter` is called from the `WebhookShunt` with `WebhookRouter.call(conn, opts)`, and maps the modified `%Conn{}`s to the appropriate controller action on the `WebhookController`, which looks like this:
+The `WebhookRouter` is called from the `WebhookShunt` with
+`WebhookRouter.call(conn, opts)`, and maps the modified `%Conn{}`s to the
+appropriate controller action on the `WebhookController`, which looks like this:
 
 ```elixir
 def add(conn, params), do: #handle addition
@@ -235,6 +316,9 @@ def multiply(conn, params), do: #handle multiplication
 def divide(conn, params), do: #handle division
 ```
 
-I think this last solution ticks all the boxes. Externally, there is still only one webhook callback url; internally, we have a route and a controller action for each event our application needs to handle. Our concerns are therefore clearly separated, making the application extensible and easy to maintain.
+I think this last solution ticks all the boxes. Externally, there is still only
+one webhook callback url; internally, we have a route and a controller action
+for each event our application needs to handle. Our concerns are therefore
+clearly separated, making the application extensible and easy to maintain.
 
 So there you have it, handling webhooks in Phoenix.

--- a/_posts/2018-05-30-a-little-encouragement-goes-a-long-way-in-2018.md
+++ b/_posts/2018-05-30-a-little-encouragement-goes-a-long-way-in-2018.md
@@ -4,75 +4,212 @@ author: 'Jessica Jordan'
 github: jessica-jordan
 twitter: jjordan_dev
 bio: 'Senior Frontend Engineer, Ember Learning core team member'
-description: 'Jessica Jordan shares her thoughts for Ember.js in the coming year in response to the Ember 2018 Roadmap Call for Blog Posts.'
+description:
+  'Jessica Jordan shares her thoughts for Ember.js in the coming year in
+  response to the Ember 2018 Roadmap Call for Blog Posts.'
 topic: ember
 ---
 
-In May 2018, Ember Core team member Katie Gengler published [Ember's 2018 Roadmap: A Call for Blog Posts](https://www.emberjs.com/blog/2018/05/02/ember-2018-roadmap-call-for-posts.html). With this call-to-action she invites the community to give feedback on their hopes and wishes for Ember moving forward.
-In this context, I also want to share some of my own thoughts on Ember and what I'd be excited to see in its nearest future.
+In May 2018, Ember Core team member Katie Gengler published
+[Ember's 2018 Roadmap: A Call for Blog Posts](https://www.emberjs.com/blog/2018/05/02/ember-2018-roadmap-call-for-posts.html).
+With this call-to-action she invites the community to give feedback on their
+hopes and wishes for Ember moving forward. In this context, I also want to share
+some of my own thoughts on Ember and what I'd be excited to see in its nearest
+future.
 
 <!--break-->
 
-> The Ember team would like you to write a blog post to propose goals and direction for Ember in the remainder of 2018. The content of these posts will help us to draft our first Roadmap RFC.
+> The Ember team would like you to write a blog post to propose goals and
+> direction for Ember in the remainder of 2018. The content of these posts will
+> help us to draft our first Roadmap RFC.
 
-First off, I'm confident that Ember already has done a lot to allow me and many others to create great and maintainable applications. And it has done so very early on.
-For a while naming conventions and a CLI-driven approach to scaffold, build & serve apps have been hallmarks of Ember as a framework for the ambitious developer. Other framework ecosystems are also adopting similar approaches to increase developer productivity ([1](https://github.com/angular/angular-cli/tree/v1.6.8#cli-for-angular-applications-based-on-the-ember-cli-project), [2](https://hackernoon.com/structuring-projects-and-naming-components-in-react-1261b6e18d76)) and are having immense success with them.
+First off, I'm confident that Ember already has done a lot to allow me and many
+others to create great and maintainable applications. And it has done so very
+early on. For a while naming conventions and a CLI-driven approach to scaffold,
+build & serve apps have been hallmarks of Ember as a framework for the ambitious
+developer. Other framework ecosystems are also adopting similar approaches to
+increase developer productivity
+([1](https://github.com/angular/angular-cli/tree/v1.6.8#cli-for-angular-applications-based-on-the-ember-cli-project),
+[2](https://hackernoon.com/structuring-projects-and-naming-components-in-react-1261b6e18d76))
+and are having immense success with them.
 
-Other productivity improvements that emerged with Ember include its well-planned release cycle ([3](https://www.emberjs.com/blog/2013/09/06/new-ember-release-process.html)) that has been put into practice during the v1.x era as early as 5 years ago, and the ongoing support through LTS releases ([4](https://emberjs.com/blog/2016/02/25/announcing-embers-first-lts.html?utm_source=javascriptweekly&utm_medium=email)) for more than 2 years. This mature and dependable release process has not only been extremely progressive back then, but in fact it still is.
-Furthermore, the current testing story in Ember has evolved to be one of the most outstanding community solutions in the JavaScript realm: The modern QUnit Testing API ([5](https://rwjblue.com/2017/10/23/ember-qunit-simplication/)) that ships with v3.x apps out of the box in combination with the simple interface of `@ember/test-helpers` ([6](https://github.com/emberjs/ember-test-helpers/blob/master/API.md)) improves the readability of tests massively and also makes async testing more than straightforward.
+Other productivity improvements that emerged with Ember include its well-planned
+release cycle
+([3](https://www.emberjs.com/blog/2013/09/06/new-ember-release-process.html))
+that has been put into practice during the v1.x era as early as 5 years ago, and
+the ongoing support through LTS releases
+([4](https://emberjs.com/blog/2016/02/25/announcing-embers-first-lts.html?utm_source=javascriptweekly&utm_medium=email))
+for more than 2 years. This mature and dependable release process has not only
+been extremely progressive back then, but in fact it still is. Furthermore, the
+current testing story in Ember has evolved to be one of the most outstanding
+community solutions in the JavaScript realm: The modern QUnit Testing API
+([5](https://rwjblue.com/2017/10/23/ember-qunit-simplication/)) that ships with
+v3.x apps out of the box in combination with the simple interface of
+`@ember/test-helpers`
+([6](https://github.com/emberjs/ember-test-helpers/blob/master/API.md)) improves
+the readability of tests massively and also makes async testing more than
+straightforward.
 
-These are some of the many examples in which Ember.js has repeatedly proven itself to be a community solution that really empowers its users to get things done.
-This is why Ember is a truly productive JavaScript framework.
+These are some of the many examples in which Ember.js has repeatedly proven
+itself to be a community solution that really empowers its users to get things
+done. This is why Ember is a truly productive JavaScript framework.
 
-Not only in the past has Ember proven to put new ideas into practice in the ecosystem of front-end web development; recent experiments with WebAssembly in the Glimmer VM ([7](https://youtu.be/NhtpXs0ZtUc?t=35m56s)) signal that Ember.js will continue to run on its innovative trajectory. New features in Ember are in fact often ahead of its time.
-This is why Ember is a truly progressive JavaScript framework.
+Not only in the past has Ember proven to put new ideas into practice in the
+ecosystem of front-end web development; recent experiments with WebAssembly in
+the Glimmer VM ([7](https://youtu.be/NhtpXs0ZtUc?t=35m56s)) signal that Ember.js
+will continue to run on its innovative trajectory. New features in Ember are in
+fact often ahead of its time. This is why Ember is a truly progressive
+JavaScript framework.
 
-Progressive technologies give developers a head start in exploring new ways of writing applications. Progressive technologies will draw the interest of many new, early-adopting developers to communities. But progressiveness also poses challenges: depending on their own experience level and the amount of work they spent on critically evaluating a new feature a developer may or may not fully grasp its meaning and extent early on. E.g. a JavaScript developer who entered the field recently, might not be aware yet that a CLI can help them immensely in building and serving their app. Even a person with extensive experience in one certain programming language might not be aware of the challenges they might encounter developing JavaScript applications specifically and overlook the benefits of a progressive feature like WebAssembly easily.
+Progressive technologies give developers a head start in exploring new ways of
+writing applications. Progressive technologies will draw the interest of many
+new, early-adopting developers to communities. But progressiveness also poses
+challenges: depending on their own experience level and the amount of work they
+spent on critically evaluating a new feature a developer may or may not fully
+grasp its meaning and extent early on. E.g. a JavaScript developer who entered
+the field recently, might not be aware yet that a CLI can help them immensely in
+building and serving their app. Even a person with extensive experience in one
+certain programming language might not be aware of the challenges they might
+encounter developing JavaScript applications specifically and overlook the
+benefits of a progressive feature like WebAssembly easily.
 
-This makes me think that making features understandable to a diverse set of people does not only include explaining how technologies work, but also why they are so useful.
+This makes me think that making features understandable to a diverse set of
+people does not only include explaining how technologies work, but also why they
+are so useful.
 
-I already believe that Ember.js is a great choice for any web developer who wants to create scalable applications today.
-There's really not much I could wish for on a technical level.
-Instead when I think about what I wish for Ember, _visibility_ comes to my mind.
-I'd love both Ember's core characteristics and its cutting-edge features to be understood by even more people; even by those who haven't had much experience in using it to see its worthwhile benefits in the long-run of a project.
-I believe Ember's bottleneck for adoption and community growth isn't about technical aspects, it's about visibility and outreach.
+I already believe that Ember.js is a great choice for any web developer who
+wants to create scalable applications today. There's really not much I could
+wish for on a technical level. Instead when I think about what I wish for Ember,
+_visibility_ comes to my mind. I'd love both Ember's core characteristics and
+its cutting-edge features to be understood by even more people; even by those
+who haven't had much experience in using it to see its worthwhile benefits in
+the long-run of a project. I believe Ember's bottleneck for adoption and
+community growth isn't about technical aspects, it's about visibility and
+outreach.
 
 ## A Gap in Visibility
 
-As any other open-source project, the development of Ember lives and thrives through the time and amount of work that is being put into it. In contrast to some other major JavaScript frameworks, Ember is not being backed up by one single major company - neither financially nor contribution-wise.
-Instead Ember's user base is diverse in its professional backgrounds and interests. And this makes Ember more independent and free to evolve according to real developer needs instead of company requirements which is an amazing advantage.
+As any other open-source project, the development of Ember lives and thrives
+through the time and amount of work that is being put into it. In contrast to
+some other major JavaScript frameworks, Ember is not being backed up by one
+single major company - neither financially nor contribution-wise. Instead
+Ember's user base is diverse in its professional backgrounds and interests. And
+this makes Ember more independent and free to evolve according to real developer
+needs instead of company requirements which is an amazing advantage.
 
-But who's putting in the time and effort to maintain such an independent project? For a huge part, Ember's community does, and it does so in their free time. Countless contributors work on improvements, bug fixes and features in the early hours preceding their day jobs, on their weekends, their time-off - to bring forward a software project which can compete with other major frameworks. And this in itself is remarkable.
+But who's putting in the time and effort to maintain such an independent
+project? For a huge part, Ember's community does, and it does so in their free
+time. Countless contributors work on improvements, bug fixes and features in the
+early hours preceding their day jobs, on their weekends, their time-off - to
+bring forward a software project which can compete with other major frameworks.
+And this in itself is remarkable.
 
-This is why Ember truly is a framework of the community, by the community, for the community.
+This is why Ember truly is a framework of the community, by the community, for
+the community.
 
-And this community effort is also what keeps Ember visible in the current front-end ecosystem. In the end, who's stepping up to blog about latest features, to screencast debugging sessions, to demo Ember at their local meetup, to distribute Zoey stickers among their friends, to give talks on how to build an Ember app or to improve, fix and update any of the official online resources of Ember?
+And this community effort is also what keeps Ember visible in the current
+front-end ecosystem. In the end, who's stepping up to blog about latest
+features, to screencast debugging sessions, to demo Ember at their local meetup,
+to distribute Zoey stickers among their friends, to give talks on how to build
+an Ember app or to improve, fix and update any of the official online resources
+of Ember?
 
-It's not only the Ember Core or the Ember Learning Team who does all of this - it's also you and me and us.
+It's not only the Ember Core or the Ember Learning Team who does all of this -
+it's also you and me and us.
 
-Taking the opportunity to change the way Ember is represented in the world to further its adoption is an open issue everyone can work on.
-Ember is still a somewhat hidden gem ([8](http://blog.agilityworks.co.uk/our-blog/a-hidden-gem-ember-js)) and it keeps on "quietly shipping new cutting-edge features to its users" ([9](https://twitter.com/sugarpirate_/status/923620576970731520)). But I don't believe it has to be this way with a little help from the community.
+Taking the opportunity to change the way Ember is represented in the world to
+further its adoption is an open issue everyone can work on. Ember is still a
+somewhat hidden gem
+([8](http://blog.agilityworks.co.uk/our-blog/a-hidden-gem-ember-js)) and it
+keeps on "quietly shipping new cutting-edge features to its users"
+([9](https://twitter.com/sugarpirate_/status/923620576970731520)). But I don't
+believe it has to be this way with a little help from the community.
 
-Of course, there are those who already have a clear vision in mind right now and who are making consistent efforts to create online tutorials, write blog posts, give talks, send pull requests to the Ember.js website repository ([10](https://github.com/emberjs/website/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged)) and much more without any prompting.
-What I'd wish for Ember's 2018 Roadmap though is to find ways to **lower the entry barriers** for newcomers to get started in their attempt to advocate Ember and to be creative on how to **encourage a sense of empowerment** in the wider community regarding outreach efforts.
+Of course, there are those who already have a clear vision in mind right now and
+who are making consistent efforts to create online tutorials, write blog posts,
+give talks, send pull requests to the Ember.js website repository
+([10](https://github.com/emberjs/website/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged))
+and much more without any prompting. What I'd wish for Ember's 2018 Roadmap
+though is to find ways to **lower the entry barriers** for newcomers to get
+started in their attempt to advocate Ember and to be creative on how to
+**encourage a sense of empowerment** in the wider community regarding outreach
+efforts.
 
 ## Closing the Visibility Gap
 
-I believe one of the biggest actions that could be taken to make contribution to anything that is outreach-related easier is by increasing the discoverability of discussion channels and already ongoing Github projects and related issues. On the Ember Community Slack chat, most notably the [#st-website](https://embercommunity.slack.com/messages/CAHEZTMBK/), [#wb-marketing](https://embercommunity.slack.com/messages/C36ETE3DK/) and [#topic-talks](https://embercommunity.slack.com/messages/C9RSE508J/) channels are great first points of contact for anyone who was interested in helping out with marketing efforts to find something to help out with. I believe making these channels more discoverable for new developers, e.g. from having a noticeable call-to-action on the Ember.js website ([11](https://emberjs.com/)) or a dedicated, search-engine optimized landing page already goes a long way.
+I believe one of the biggest actions that could be taken to make contribution to
+anything that is outreach-related easier is by increasing the discoverability of
+discussion channels and already ongoing Github projects and related issues. On
+the Ember Community Slack chat, most notably the
+[#st-website](https://embercommunity.slack.com/messages/CAHEZTMBK/),
+[#wb-marketing](https://embercommunity.slack.com/messages/C36ETE3DK/) and
+[#topic-talks](https://embercommunity.slack.com/messages/C9RSE508J/) channels
+are great first points of contact for anyone who was interested in helping out
+with marketing efforts to find something to help out with. I believe making
+these channels more discoverable for new developers, e.g. from having a
+noticeable call-to-action on the Ember.js website ([11](https://emberjs.com/))
+or a dedicated, search-engine optimized landing page already goes a long way.
 
-The Learning Team and the community have already leveraged many amazing initiatives recently, including a massive technical upgrade of the official Guides which makes it even easier for developers to contribute ([12](https://guides.emberjs.com/)), the release of a status board to keep potential contributors informed which initiatives are still ongoing and require help ([13](https://emberjs.com/statusboard/)), making blog content discoverable ([14](https://github.com/emberjs/website/pull/3280)), creating a printable mini book about the framework ([15](https://github.com/ember-learn/the-shortest-ember-book)), publishing project-related updates through a newsletter every single week ([16](https://the-emberjs-times.ongoodbits.com/)) and many others.
-Speaking about these initiatives more openly and often might also draw interest of developers who don't know yet what to work on or what to start off with.
-In my opinion the increased leverage of the RFC (Request for Comments) process adopted by the Rust Community ([17](http://rust-lang.github.io/rfcs/)), Quest issues for breaking down major work packages on these official resources, and the creation of Strike Teams for agile collaboration will also deepen community interest, increase a sense of ownership of how decisions are made and allow people to succeed on their possibly first OSS issue easily.
+The Learning Team and the community have already leveraged many amazing
+initiatives recently, including a massive technical upgrade of the official
+Guides which makes it even easier for developers to contribute
+([12](https://guides.emberjs.com/)), the release of a status board to keep
+potential contributors informed which initiatives are still ongoing and require
+help ([13](https://emberjs.com/statusboard/)), making blog content discoverable
+([14](https://github.com/emberjs/website/pull/3280)), creating a printable mini
+book about the framework
+([15](https://github.com/ember-learn/the-shortest-ember-book)), publishing
+project-related updates through a newsletter every single week
+([16](https://the-emberjs-times.ongoodbits.com/)) and many others. Speaking
+about these initiatives more openly and often might also draw interest of
+developers who don't know yet what to work on or what to start off with. In my
+opinion the increased leverage of the RFC (Request for Comments) process adopted
+by the Rust Community ([17](http://rust-lang.github.io/rfcs/)), Quest issues for
+breaking down major work packages on these official resources, and the creation
+of Strike Teams for agile collaboration will also deepen community interest,
+increase a sense of ownership of how decisions are made and allow people to
+succeed on their possibly first OSS issue easily.
 
-Also supporting both new and current speakers in finding events, a good talk topic and in prepping and rehearsing a presentation is another great way to encourage the community in their sense of empowerement.
-In fact, the Women Helping Women Program ([18](https://emberwomen.com/)) has already been doing an amazing job in supporting new speakers for years and it might be due to this very program, that Ember managed to achieve record numbers of excellent talks presented by women speakers at its conferences in the past.
-Encouraging even larger parts of the community to speak and highlight Ember allows many great talks to come: I'd love to see so many of the cool and new things that recently landed or are just on their way to land in Ember highlighted: This year's EmberConf Opening Keynote by Ember Core Team members Yehuda Katz & Tom Dale ([19](https://www.youtube.com/watch?v=NhtpXs0ZtUc)) at EmberConf is among others ([20](https://twitter.com/skillsmatter/status/984752827904950273), [21](https://www.youtube.com/watch?v=8D-O4cSteRk)) an inspiring example of this type of advocacy for Ember.
-I feel that beyond that there is a quite urgent need for "introduction" type talks which are appealing to developers of any experience level and any (JavaScript) background. Features of Ember that might have already been around for a while and which have become obvious to the regular Ember user still need to be highlighted to audiences who are not that familiar with Ember yet on a regular basis. Therefore I'm confident supporting speakers in promoting their own "Why Ember" type of presentations to events outside of the Ember ecosystem is one of the most useful measures we as a community can take to advocate Ember as a framework.
+Also supporting both new and current speakers in finding events, a good talk
+topic and in prepping and rehearsing a presentation is another great way to
+encourage the community in their sense of empowerement. In fact, the Women
+Helping Women Program ([18](https://emberwomen.com/)) has already been doing an
+amazing job in supporting new speakers for years and it might be due to this
+very program, that Ember managed to achieve record numbers of excellent talks
+presented by women speakers at its conferences in the past. Encouraging even
+larger parts of the community to speak and highlight Ember allows many great
+talks to come: I'd love to see so many of the cool and new things that recently
+landed or are just on their way to land in Ember highlighted: This year's
+EmberConf Opening Keynote by Ember Core Team members Yehuda Katz & Tom Dale
+([19](https://www.youtube.com/watch?v=NhtpXs0ZtUc)) at EmberConf is among others
+([20](https://twitter.com/skillsmatter/status/984752827904950273),
+[21](https://www.youtube.com/watch?v=8D-O4cSteRk)) an inspiring example of this
+type of advocacy for Ember. I feel that beyond that there is a quite urgent need
+for "introduction" type talks which are appealing to developers of any
+experience level and any (JavaScript) background. Features of Ember that might
+have already been around for a while and which have become obvious to the
+regular Ember user still need to be highlighted to audiences who are not that
+familiar with Ember yet on a regular basis. Therefore I'm confident supporting
+speakers in promoting their own "Why Ember" type of presentations to events
+outside of the Ember ecosystem is one of the most useful measures we as a
+community can take to advocate Ember as a framework.
 
 ## Wishing Upon a Vocal Community
 
-These are some of the ideas that came to my mind when thinking about what I'd wish for Ember in 2018. I'd like to see Ember's community grow even further and I believe one major way to achieve this goal is by improving its visibility - the degree by which it is seen by those who are already becoming part of the community and also by those outside of it.
+These are some of the ideas that came to my mind when thinking about what I'd
+wish for Ember in 2018. I'd like to see Ember's community grow even further and
+I believe one major way to achieve this goal is by improving its visibility -
+the degree by which it is seen by those who are already becoming part of the
+community and also by those outside of it.
 
-In my opinion more explicit call-to-actions can have a big impact on the sense of community empowerment to make Ember visible: Being vocal about current outreach efforts that require community help, making those initiatives more discoverable and prompting the community to take action - just as has been done in this very call for blog posts ([22](https://www.emberjs.com/blog/2018/05/02/ember-2018-roadmap-call-for-posts.html)) - are some of the options that I believe should be leveraged even further.
+In my opinion more explicit call-to-actions can have a big impact on the sense
+of community empowerment to make Ember visible: Being vocal about current
+outreach efforts that require community help, making those initiatives more
+discoverable and prompting the community to take action - just as has been done
+in this very call for blog posts
+([22](https://www.emberjs.com/blog/2018/05/02/ember-2018-roadmap-call-for-posts.html)) -
+are some of the options that I believe should be leveraged even further.
 
-Ember is still a hidden gem but I'm confident that this can and will change. And with a little encouragement I believe there's no one who could do a better job at this than us - the community.
+Ember is still a hidden gem but I'm confident that this can and will change. And
+with a little encouragement I believe there's no one who could do a better job
+at this than us - the community.

--- a/_posts/2018-06-05-ember-component-playground.md
+++ b/_posts/2018-06-05-ember-component-playground.md
@@ -4,7 +4,10 @@ author: 'Tobias Bieniek'
 github: Turbo87
 twitter: tobiasbieniek
 bio: 'Senior Frontend Engineer, Ember CLI core team member'
-description: 'Tobias Bieniek introduces a mechanism for automatically discovering new components in Ember.js applications and showing them in an ember-freestyle playground.'
+description:
+  'Tobias Bieniek introduces a mechanism for automatically discovering new
+  components in Ember.js applications and showing them in an ember-freestyle
+  playground.'
 topic: ember
 ---
 
@@ -48,8 +51,8 @@ imagine that our `freestyle.hbs` would soon grow out of proportion. As with any
 other template in Ember.js we can tackle that problem by extracting components.
 
 In this case we can create a
-`lib/freestyle/app/templates/components/usage/styled-button.hbs` file that
-looks like this:
+`lib/freestyle/app/templates/components/usage/styled-button.hbs` file that looks
+like this:
 
 ```handlebars
 {{#freestyle-usage 'styled-button-example-1'}}
@@ -70,8 +73,8 @@ and in the `freestyle.hbs` template we use the following snippet instead:
 ```
 
 Now we would still have to add a subsection and a component for every component
-in our app that we want to include in the component playground, but overall
-the situation has gotten a lot more manageable.
+in our app that we want to include in the component playground, but overall the
+situation has gotten a lot more manageable.
 
 But there is always a way to improve the current situation so let's play around
 a little...
@@ -81,12 +84,12 @@ a little...
 What if we could ask Ember what "usage components" it knows about and then
 render them automatically in the `freestyle.hbs` template...? 🤔
 
-It turns out the `loader.js` dependency that every Ember.js project has
-provides us with an API to do exactly that. If we
-`import require from 'require';` and then look at `require.entries` we will
-see a map of all the known module names in your app and their corresponding
-module functions. We only care about the module names though so we can use
-`Object.keys(require.entries)` to get a list of all those module names.
+It turns out the `loader.js` dependency that every Ember.js project has provides
+us with an API to do exactly that. If we `import require from 'require';` and
+then look at `require.entries` we will see a map of all the known module names
+in your app and their corresponding module functions. We only care about the
+module names though so we can use `Object.keys(require.entries)` to get a list
+of all those module names.
 
 Next, we need to filter the list so that it only includes our "usage
 components". We can do so by using the `.filter()` method and checking for the
@@ -138,10 +141,10 @@ function findUsageComponents() {
 }
 ```
 
-With that JavaScript code out of the way we can focus on our template. Here,
-we now have a `components` list available with the names of all our "usage
-components". As usual with lists we will use a `{{#each}}`
-block to iterate over it:
+With that JavaScript code out of the way we can focus on our template. Here, we
+now have a `components` list available with the names of all our "usage
+components". As usual with lists we will use a `{{#each}}` block to iterate over
+it:
 
 ```handlebars
 {{#freestyle-guide title='My Awesome App'}}
@@ -159,14 +162,13 @@ block to iterate over it:
 {{/freestyle-guide}}
 ```
 
-If we visit the `/freestyle` route now, we should see a list of all our
-"usage components" that Ember.js knows about and usage examples for all of
-them.
+If we visit the `/freestyle` route now, we should see a list of all our "usage
+components" that Ember.js knows about and usage examples for all of them.
 
 ## Summary
 
 Just like Ember.js is able to automatically find components, models, and other
-modules when you put them in the right folder, our component playground can
-now do the same thing. "Convention over Configuration" saves us from the extra
-work of having to manually maintain the `freestyle.hbs` template by discovering
-the content automatically.
+modules when you put them in the right folder, our component playground can now
+do the same thing. "Convention over Configuration" saves us from the extra work
+of having to manually maintain the `freestyle.hbs` template by discovering the
+content automatically.

--- a/_posts/2018-06-11-actix.md
+++ b/_posts/2018-06-11-actix.md
@@ -4,7 +4,9 @@ author: 'Tobias Bieniek'
 github: Turbo87
 twitter: tobiasbieniek
 bio: 'Senior Frontend Engineer, Ember CLI core team member'
-description: 'Tobias Bieniek gives an overview of actix, an actor framework written in the Rust programming language.'
+description:
+  'Tobias Bieniek gives an overview of actix, an actor framework written in the
+  Rust programming language.'
 topic: rust
 og:
   image: /assets/images/posts/2018-06-11-actix/og-image.png
@@ -28,16 +30,16 @@ discovered so far.
 
 What is Rust?
 
-Aside from being "an iron oxide" according to [Wikipedia][wikipedia], Rust is also the
-name of a programming language that was originally invented by Graydon Hoare
-back in 2006. You can think about it as an interesting mix of high-level
-languages like JavaScript or Ruby and low-level high-performance languages
-like C++.
+Aside from being "an iron oxide" according to [Wikipedia][wikipedia], Rust is
+also the name of a programming language that was originally invented by Graydon
+Hoare back in 2006. You can think about it as an interesting mix of high-level
+languages like JavaScript or Ruby and low-level high-performance languages like
+C++.
 
 Similar to C++ it is a compiled language without a garbage collector. The fact
 that it usually uses LLVM to compile to machine code means that a lot of the
-optimizations that were developed to compile C/C++ code can also be applied
-to Rust programs.
+optimizations that were developed to compile C/C++ code can also be applied to
+Rust programs.
 
 Similar to JavaScript or Python the language often feels more high-level than
 C/C++, and it has a built-in dependency manager called `cargo`. This is somewhat
@@ -47,10 +49,10 @@ that `cargo` is also used to build and test your applications and libraries.
 The main advantage over all the other languages is safety. The Rust compiler is
 often quite strict on what data you are allowed to access at what point in the
 application logic, because it knows about concepts like threads and potential
-race conditions. This might not seem relevant to JavaScript developers, but
-even there with nested callbacks you might easily run into a situation where
-the thing you're trying to access has been deleted already. This issue is
-impossible with Rust.
+race conditions. This might not seem relevant to JavaScript developers, but even
+there with nested callbacks you might easily run into a situation where the
+thing you're trying to access has been deleted already. This issue is impossible
+with Rust.
 
 Why would you use it? It is very fast, it can be embedded into scripting
 languages if raw speed is needed, it can compile to WebAssembly, and most of
@@ -63,12 +65,12 @@ How to get started? Follow the instructions at [rustup.rs][rustup]
 
 The "actor model" is the main primitive that powers the [Erlang] programming
 language and its descendant, [Elixir]. It describes a programming model that
-simplifies the development of concurrent and multi-threaded applications or
-even applications that run distributed on multiple machines.
+simplifies the development of concurrent and multi-threaded applications or even
+applications that run distributed on multiple machines.
 
-An actor is a thing that can only be interacted with using "messages". A
-message can basically be anything that the actor can understand and in response
-to a message an actor is allowed to do several things, including:
+An actor is a thing that can only be interacted with using "messages". A message
+can basically be anything that the actor can understand and in response to a
+message an actor is allowed to do several things, including:
 
 - send a response
 - send messages to other actors
@@ -107,8 +109,8 @@ we will have a closer look at now.
 [high-performance][performance] web framework for the [Rust][rust] programming
 language.
 
-While [actix-web][actix-web] is interesting and worth another blog post, we
-will focus on the low-level primitive [actix][actix] for now as it is vital to
+While [actix-web][actix-web] is interesting and worth another blog post, we will
+focus on the low-level primitive [actix][actix] for now as it is vital to
 understanding the higher level concepts.
 
 To get started with actix, let's port our `CounterActor` above to Rust:
@@ -161,13 +163,13 @@ does have a `Result` type though, defined by `type Result = u32;` which means
 "unsigned 32 bit integer".
 
 The `CounterActor` implementation is another `struct` which is roughly similar
-to a `class` in JavaScript. It does implement several "traits", which is
-very roughly what are called "interfaces" in e.g. TypeScript or Java.
+to a `class` in JavaScript. It does implement several "traits", which is very
+roughly what are called "interfaces" in e.g. TypeScript or Java.
 
 The `Actor` trait defines that `CounterActor` is in fact an actor that complies
 with the necessary interface to be run by the actix framework. The `Context`
-type declaration can be used for more advanced implementations, but for now
-we can use the default implementation that is provided by actix itself.
+type declaration can be used for more advanced implementations, but for now we
+can use the default implementation that is provided by actix itself.
 
 Finally we implement the `Handler` trait for the `PlusOne` message that we
 defined earlier. In the `handle()` method we increment the `count` state and
@@ -208,9 +210,9 @@ Arbiter::handle().spawn(result);
 sys.run();
 ```
 
-The first thing to do when using actix actors is to set up a
-[`System`][system], that handles all those actor interactions for us. We do so
-by calling `actix::System::new()` and passing it a name.
+The first thing to do when using actix actors is to set up a [`System`][system],
+that handles all those actor interactions for us. We do so by calling
+`actix::System::new()` and passing it a name.
 
 Next we start an [`Arbiter`][artiter] in a new thread, that runs our
 `CounterActor`. If that sounds like a foreign language to you, don't worry, I
@@ -224,9 +226,9 @@ be used to send messages to the actor and receive their responses.
 
 Rust is very strict around data ownership, and the "borrow checker" makes sure
 that data access can only happen in safe ways. Since we use the `counter`
-variable for the first `send()` call, we are (at least currently) not allowed
-to reuse it inside the callback. Instead we need to create a `clone()` and use
-that one instead.
+variable for the first `send()` call, we are (at least currently) not allowed to
+reuse it inside the callback. Instead we need to create a `clone()` and use that
+one instead.
 
 The large code structure in the middle of the snippet looks roughly like a
 Promise-chain in JavaScript, and it is exactly that. The `counter.send()` call
@@ -239,15 +241,15 @@ In this specific case we use `.and_then()` to wait for the result of the
 `PlusOne` message. Once that second message has returned we print the response
 again and then use a special system arbiter call to exit the process.
 
-The major difference between a `Promise` in JavaScript and a `Future` in Rust
-is that a `Promise` automatically runs when it is created, but a `Future` needs
-to be started explicitly. This difference exists for performance reasons, and
+The major difference between a `Promise` in JavaScript and a `Future` in Rust is
+that a `Promise` automatically runs when it is created, but a `Future` needs to
+be started explicitly. This difference exists for performance reasons, and
 because in JavaScript there is no such thing as running on different threads.
 
 To start the `Future` that we have assembled we use the
-`Arbiter::handle().spawn()` function, and then finally start the `System`
-once everything is wired up correctly to block the current thread until all
-actors have finished running.
+`Arbiter::handle().spawn()` function, and then finally start the `System` once
+everything is wired up correctly to block the current thread until all actors
+have finished running.
 
 ## Summary
 
@@ -259,7 +261,8 @@ traffic to websocket clients or just log the received messages to the console.
 [rustup]: https://rustup.rs/
 [wikipedia]: https://en.wikipedia.org/wiki/Rust
 [erlang]: https://www.erlang.org/
-[performance]: https://www.techempower.com/benchmarks/#section=data-r15&hw=ph&test=plaintext
+[performance]:
+  https://www.techempower.com/benchmarks/#section=data-r15&hw=ph&test=plaintext
 [actix-web]: https://github.com/actix/actix-web
 [futures-await]: https://github.com/alexcrichton/futures-await
 [system]: https://actix.rs/actix/actix/struct.System.html

--- a/_posts/2018-06-18-intl-polyfill-loading.md
+++ b/_posts/2018-06-18-intl-polyfill-loading.md
@@ -4,19 +4,22 @@ author: 'Tobias Bieniek'
 github: Turbo87
 twitter: tobiasbieniek
 bio: 'Senior Frontend Engineer, Ember CLI core team member'
-description: 'Tobias Bieniek shows how to load the necessary polyfills for the Intl API in older browsers most effectively when using ember-intl.'
+description:
+  'Tobias Bieniek shows how to load the necessary polyfills for the Intl API in
+  older browsers most effectively when using ember-intl.'
 topic: ember
 ---
 
 At simplabs we ❤️ [ember-intl][ember-intl] and use it for all our projects where
 translations or other localizations are needed. ember-intl is based on the
-native [Intl APIs][intl] that were introduced in [all newer browsers][browsers] a while ago.
-Unfortunately some users are still using browsers that don't support them and
-this blog post will show you our preferred way to load the necessary polyfill
-and the associated data.
+native [Intl APIs][intl] that were introduced in [all newer browsers][browsers]
+a while ago. Unfortunately some users are still using browsers that don't
+support them and this blog post will show you our preferred way to load the
+necessary polyfill and the associated data.
 
 [ember-intl]: https://github.com/ember-intl/ember-intl
-[intl]: https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Intl
+[intl]:
+  https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Intl
 [browsers]: https://caniuse.com/#feat=internationalization
 
 <!--break-->
@@ -47,12 +50,12 @@ async beforeModel() {
 }
 ```
 
-To make this work we need to tell ember-intl that it should no longer bundle
-the translations in the `app.js` file, and instead it should write them out
-as JSON files into our `dist` folder. We can do so by opening the
-`config/ember-intl.js` file, and adjusting the `publicOnly` property to `true`.
-If we now call `ember build` and look at the `dist` folder we will see a
-`translations` subfolder including JSON files for all existing translations.
+To make this work we need to tell ember-intl that it should no longer bundle the
+translations in the `app.js` file, and instead it should write them out as JSON
+files into our `dist` folder. We can do so by opening the `config/ember-intl.js`
+file, and adjusting the `publicOnly` property to `true`. If we now call
+`ember build` and look at the `dist` folder we will see a `translations`
+subfolder including JSON files for all existing translations.
 
 We would like to make our translation loading code look a little simpler from
 the outside, so what we could do is add a `loadTranslations()` method to the
@@ -85,15 +88,16 @@ async beforeModel() {
 ```
 
 If we now open our app in the browser and look at the "Network" tab of the
-browser we should see the app making an AJAX request for the translations
-before it starts. 🎉
+browser we should see the app making an AJAX request for the translations before
+it starts. 🎉
 
 ## Loading the Intl.js polyfill
 
-As mentioned in the intro [some browsers](https://caniuse.com/#feat=internationalization)
-need a polyfill for the new `Intl` APIs. ember-intl makes this easy for us as
-it supports an `autoPolyfill` option in its config file. Setting this option to
-`true` will automatically add script tags like this to your `index.html` file:
+As mentioned in the intro
+[some browsers](https://caniuse.com/#feat=internationalization) need a polyfill
+for the new `Intl` APIs. ember-intl makes this easy for us as it supports an
+`autoPolyfill` option in its config file. Setting this option to `true` will
+automatically add script tags like this to your `index.html` file:
 
 ```html
 <script src="/assets/intl/intl.min.js"></script>
@@ -102,19 +106,19 @@ it supports an `autoPolyfill` option in its config file. Setting this option to
 <script src="/assets/intl/locales/fr.js"></script>
 ```
 
-That is a nice first step, but should not be used for any real user-facing
-apps. The reason for this is that it adds a significant number of additional
-HTTP requests to the startup time of your app, and those requests aren't even
-that small. `intl.min.js` downloads roughly 40 kB and each locale script
-another 25 kB of uncompressed JavaScript code. It would be much better if we
-would only load them if the browser actually needed the polyfill...
+That is a nice first step, but should not be used for any real user-facing apps.
+The reason for this is that it adds a significant number of additional HTTP
+requests to the startup time of your app, and those requests aren't even that
+small. `intl.min.js` downloads roughly 40 kB and each locale script another 25
+kB of uncompressed JavaScript code. It would be much better if we would only
+load them if the browser actually needed the polyfill...
 
 Let's turn off the `autoPolyfill` option and implement lazy loading of the
 polyfill files instead.
 
 The first thing we need for this is a function that downloads JS code and then
-runs it. We could hack something together with `fetch()` and `eval()`, but
-there is a better solution:
+runs it. We could hack something together with `fetch()` and `eval()`, but there
+is a better solution:
 
 ```js
 function loadJS(url) {
@@ -127,11 +131,11 @@ function loadJS(url) {
 }
 ```
 
-The above function creates a `<script>` tag, sets the passed in `url` on it,
-and returns a `Promise` that resolves once the script has loaded.
+The above function creates a `<script>` tag, sets the passed in `url` on it, and
+returns a `Promise` that resolves once the script has loaded.
 
-With the `loadJS` helper function in place we can add a `loadPolyfill()`
-method to our `intl` service:
+With the `loadJS` helper function in place we can add a `loadPolyfill()` method
+to our `intl` service:
 
 ```js
 async loadPolyfill() {
@@ -166,7 +170,8 @@ the user chooses. For that reason we implement two more methods on the `intl`
 service:
 
 - a `loadPolyfillData()` method
-- a `loadLocale()` method that combines `loadTranslations()` and `loadPolyfillData()`
+- a `loadLocale()` method that combines `loadTranslations()` and
+  `loadPolyfillData()`
 
 ```js
 import IntlService from 'ember-intl/services/intl';
@@ -215,5 +220,5 @@ and data that we actually need for the specific browser. Most users don't pay
 the extra cost of loading the polyfill and related data, and for the browsers
 that do need it, it's available on demand.
 
-If you have any questions about these patterns or need help implementing them
-in your apps feel free to [contact us](/contact/).
+If you have any questions about these patterns or need help implementing them in
+your apps feel free to [contact us](/contact/).

--- a/_posts/2018-06-27-actix-tcp-client.md
+++ b/_posts/2018-06-27-actix-tcp-client.md
@@ -4,7 +4,9 @@ author: 'Tobias Bieniek'
 github: Turbo87
 twitter: tobiasbieniek
 bio: 'Senior Frontend Engineer, Ember CLI core team member'
-description: 'Tobias Bieniek shows how actix, the actor framework written in Rust, can be used to build a basic TCP client.'
+description:
+  'Tobias Bieniek shows how actix, the actor framework written in Rust, can be
+  used to build a basic TCP client.'
 topic: rust
 og:
   image: /assets/images/posts/2018-06-27-actix-tcp-client/og-image.png
@@ -27,10 +29,10 @@ correct dependency versions.**
 
 ## The Goal
 
-Our goal in this blog post is to build an `Actor` that connects to a certain
-TCP server, listens for new messages and forwards them to another `recipient`
-actor. For simplicity we'll assume that the server is using a line break after
-each message.
+Our goal in this blog post is to build an `Actor` that connects to a certain TCP
+server, listens for new messages and forwards them to another `recipient` actor.
+For simplicity we'll assume that the server is using a line break after each
+message.
 
 ## Project Setup
 
@@ -52,8 +54,8 @@ binary projects have a `main()` function and get compiled to executables, while
 library projects are used to share code and functionality at
 [crates.io](https://crates.io).
 
-Fun fact: did you know that [crates.io][crates] is an open-source project
-itself and built with Rust and [Ember.js][ember]?
+Fun fact: did you know that [crates.io][crates] is an open-source project itself
+and built with Rust and [Ember.js][ember]?
 
 [crates]: https://github.com/rust-lang/crates.io
 [ember]: https://emberjs.com/
@@ -78,15 +80,15 @@ project and add the following line _after_ the `[dependencies]` declaration:
 actix = "0.5"
 ```
 
-Now, whenever we build the project again, `cargo` will make sure to download
-the necessary dependencies from crates.io and build them before building the
-actual project. `cargo` is using a build cache though, so don't worry if it
-takes a long time if you first try to build it. The following builds should be
-much faster.
+Now, whenever we build the project again, `cargo` will make sure to download the
+necessary dependencies from crates.io and build them before building the actual
+project. `cargo` is using a build cache though, so don't worry if it takes a
+long time if you first try to build it. The following builds should be much
+faster.
 
 It's time to implement a basic `Actor` as the base for our experiment. We don't
-want to worry too much about project organization for now, so let's implement
-it right in the `src/main.rs` file:
+want to worry too much about project organization for now, so let's implement it
+right in the `src/main.rs` file:
 
 ```rust
 extern crate actix;
@@ -142,9 +144,9 @@ impl Actor for TcpClientActor {
 }
 ```
 
-If we use `cargo run` again, the "TcpClientActor started!" message should
-appear on the screen, and the app should keep running because we have
-implemented nothing that would stop the actor.
+If we use `cargo run` again, the "TcpClientActor started!" message should appear
+on the screen, and the app should keep running because we have implemented
+nothing that would stop the actor.
 
 First milestone achieved! 🎉
 
@@ -188,22 +190,22 @@ The `Connector` actor can be used to perform DNS lookups, or connect to remote
 servers via TCP, which is exactly what we want!
 
 The `Connector::from_registry()` function returns an `Addr` instance for the
-`Connector` and we can use the `send()` method on it to send a `Connect`
-message and wait for the answer (using a `Future`).
+`Connector` and we can use the `send()` method on it to send a `Connect` message
+and wait for the answer (using a `Future`).
 
 Next we use the `into_actor()` modifier to transform the `Future` into another
 kind of `Future`, where we get passed not only the result, but also the actor
-instance and the context in any callbacks that we implement. This is helpful
-to work around the Rust compiler complaining about lifetime issues.
+instance and the context in any callbacks that we implement. This is helpful to
+work around the Rust compiler complaining about lifetime issues.
 
 Now we're ready to use the result and we do so by implementing a callback for
-the `map()` method. We'll keep it simple for now and just print a message to
-the terminal whether the connection was successful or not.
+the `map()` method. We'll keep it simple for now and just print a message to the
+terminal whether the connection was successful or not.
 
 Since we have to handle two different kinds of errors here (`ConnectorError` and
-`MailboxError`) we have to implement two different error handlers too. They
-have the same code but since the error classes are different, they can't easily
-share the same implementation unfortunately.
+`MailboxError`) we have to implement two different error handlers too. They have
+the same code but since the error classes are different, they can't easily share
+the same implementation unfortunately.
 
 Finally, we block the current thread using the `wait()` method until the
 `Future` is resolved.
@@ -223,9 +225,9 @@ is using underneath.
 
 [tokio]: https://tokio.rs/
 
-The version of `actix` that we are currently using (v0.5.8) has dependencies
-on v0.1 of the `tokio` libraries, so to avoid unnecessary conflicts we will use
-the same versions. Let's add the new dependencies to the `Cargo.toml` file:
+The version of `actix` that we are currently using (v0.5.8) has dependencies on
+v0.1 of the `tokio` libraries, so to avoid unnecessary conflicts we will use the
+same versions. Let's add the new dependencies to the `Cargo.toml` file:
 
 ```toml
 tokio-codec = "0.1"
@@ -252,9 +254,9 @@ complaining about the `stream` variable not being used. Let's fix that by
 reading something from the TCP stream.
 
 A `TcpStream` in the context of `tokio` is the wording for the TCP connection
-between a client and a server, and includes both the read and write parts of
-the connection. Since we only care about the read part for now we should split
-the stream into the two parts and focus on the read part for now:
+between a client and a server, and includes both the read and write parts of the
+connection. Since we only care about the read part for now we should split the
+stream into the two parts and focus on the read part for now:
 
 ```rust
 Ok(stream) => {
@@ -282,8 +284,8 @@ let line_reader = FramedRead::new(r, LinesCodec::new());
 This combination of `LinesCodec` and `FramedRead` from the `tokio-codecs` crate
 can be used to work with the `Read` trait in a more comfortable way. The
 `FramedRead` instance acts as an asynchronous stream of values that we could
-call `poll()` on, or we'll attach it to the actor in a more convenient way
-by implementing the `StreamHandler` trait from `actix`:
+call `poll()` on, or we'll attach it to the actor in a more convenient way by
+implementing the `StreamHandler` trait from `actix`:
 
 ```rust
 impl StreamHandler<String, std::io::Error> for TcpClientActor {
@@ -301,8 +303,8 @@ ctx.add_stream(line_reader);
 
 right below the line that constructs the `FramedRead` instance.
 
-I won't spoiler anything, but take a bit of time and see what happens now if
-you start `cargo run` again... 🚀
+I won't spoiler anything, but take a bit of time and see what happens now if you
+start `cargo run` again... 🚀
 
 ## Forward messages to other actors
 
@@ -347,9 +349,9 @@ for `ReceivedLine` messages, and print them to the terminal once received.
 Next, we will need to adjust our `TcpClientActor` implementation to no longer
 print messages by itself, but instead forward them to the second actor. For that
 the `TcpClientActor` needs to know where to send them. We could save the
-`Addr<_, ConsoleLogger>` instance in the `TcpClientActor` struct, but that
-would create a tight coupling between those actors, and we want the
-`TcpClientActor` implementation to be as generic as possible.
+`Addr<_, ConsoleLogger>` instance in the `TcpClientActor` struct, but that would
+create a tight coupling between those actors, and we want the `TcpClientActor`
+implementation to be as generic as possible.
 
 The more generic solution is to use the `Recipient` struct of `actix`:
 
@@ -397,11 +399,11 @@ will see that everything still works! 🎥
 ## Summary
 
 We hope that by now you're a little more comfortable around actors and how to
-use and implement them in Rust. This blog post has shown how two actors can
-work together without any tight coupling other than the messages they exchange.
-We have also demonstrated how to use an actor as a TCP client, which can be
-used as a gateway for other actors that want to share the same connection to the
-server. In the next blog post of this series we will explore how to send
-messages and keep connections and actors alive using the `Supervisor`.
+use and implement them in Rust. This blog post has shown how two actors can work
+together without any tight coupling other than the messages they exchange. We
+have also demonstrated how to use an actor as a TCP client, which can be used as
+a gateway for other actors that want to share the same connection to the server.
+In the next blog post of this series we will explore how to send messages and
+keep connections and actors alive using the `Supervisor`.
 
 👋

--- a/_posts/2018-07-03-building-a-pwa-with-glimmer-js.md
+++ b/_posts/2018-07-03-building-a-pwa-with-glimmer-js.md
@@ -4,7 +4,9 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte dives deep into the details of how simplabs built Breethe, an open source progressive web app, with Glimmer.js.'
+description:
+  'Marco Otte-Witte dives deep into the details of how simplabs built Breethe,
+  an open source progressive web app, with Glimmer.js.'
 topic: ember
 og:
   image: /assets/images/posts/2018-07-03-building-a-pwa-with-glimmer-js/og-image.png
@@ -13,24 +15,24 @@ og:
 We recently set out to build a progressive web app with
 [Glimmer.js](http://glimmerjs.com). Instead of building it with
 [Ember.js](http://emberjs.com), which is our standard framework of choice, we
-wanted to see how suitable for prime-time Glimmer.js is and what we'd be able
-to accomplish with it. To put it short, we are really happy with how building
-the app went and the result that we were able to achieve. In this series of
-posts, we will give some insights into how we built the app, why we made
-particular decisions and what the result looks like.
+wanted to see how suitable for prime-time Glimmer.js is and what we'd be able to
+accomplish with it. To put it short, we are really happy with how building the
+app went and the result that we were able to achieve. In this series of posts,
+we will give some insights into how we built the app, why we made particular
+decisions and what the result looks like.
 
 <!--break-->
 
 ## Breethe
 
 While this project was mostly meant as a technology spike to validate Glimmer's
-suitability for real projects as well as testing some techniques for running
-and serving web apps that we had in our minds for some time, we wanted to build
+suitability for real projects as well as testing some techniques for running and
+serving web apps that we had in our minds for some time, we wanted to build
 something useful and meaningful. What we came up with is
-[Breethe](https://breethe.app), a progressive web app that gives users quick
-and easy access to air quality data for locations around the world. Pollution
-and global warming are getting worse rather than better and having easy access
-to data that shows how bad the situation actually is, is the first step for
+[Breethe](https://breethe.app), a progressive web app that gives users quick and
+easy access to air quality data for locations around the world. Pollution and
+global warming are getting worse rather than better and having easy access to
+data that shows how bad the situation actually is, is the first step for
 everyone to question their decisions and maybe change a few things in their
 daily lives.
 
@@ -113,10 +115,10 @@ _setupRouting() {
 First of all, we create a new router instance. We then map URLs to the
 corresponding states of the app. The routes `/`, `/search` and
 `/search/:searchTerm` all map to the `MODE_SEARCH` mode that renders the search
-form and search results if there are any. The `/location/:locationId` route
-maps to the `MODE_RESULTS` mode that renders a particular location's data and
-quality score. We use the `mode` property in two tracked properties
-`isSearchMode` and `isResultsMode`.
+form and search results if there are any. The `/location/:locationId` route maps
+to the `MODE_RESULTS` mode that renders a particular location's data and quality
+score. We use the `mode` property in two tracked properties `isSearchMode` and
+`isResultsMode`.
 [Tracked properties](https://glimmerjs.com/guides/tracked-properties) are
 Glimmer's equivalent to Ember's computed properties and will result in the
 component being re-rendered when their value changes.
@@ -145,8 +147,8 @@ component for the current mode:
 ```
 
 You might notice the `@` prefix of the `searchTerm` and `locationId` properties
-that are set on the components. This prefix distinguishes properties that are
-to be passed to the component instance as opposed to attributes that will be
+that are set on the components. This prefix distinguishes properties that are to
+be passed to the component instance as opposed to attributes that will be
 applied to the component's root DOM element.
 
 The `Search` component renders the `SearchForm` component that implements the
@@ -159,10 +161,10 @@ text field for the search term and the button to submit the search:
 />
 ```
 
-`@onSubmit={{action searchByTerm}}` assigns the
-`searchByTerm` method of the `Search` component as an action to the `@onSubmit`
-property of the `SearchForm` component. Whenever the search form is submitted,
-the `SearchForm` component invokes the assigned action:
+`@onSubmit={{action searchByTerm}}` assigns the `searchByTerm` method of the
+`Search` component as an action to the `@onSubmit` property of the `SearchForm`
+component. Whenever the search form is submitted, the `SearchForm` component
+invokes the assigned action:
 
 ```ts
 submitSearch(event) {
@@ -188,9 +190,9 @@ async searchByTerm(searchTerm) {
 }
 ```
 
-The `loading` and `locations` properties are tracked properties so that
-changing them results in the component to be re-rendered. They are used in the
-template like this:
+The `loading` and `locations` properties are tracked properties so that changing
+them results in the component to be re-rendered. They are used in the template
+like this:
 
 ```hbs
 <div class="results">
@@ -210,10 +212,10 @@ template like this:
 </div>
 ```
 
-This is just a brief overview of how an application built with Glimmer.js
-works. We will cover some of these things in more detail in future posts,
-particularly how we load and manage data with Orbit.js. For a closer look on
-the inner workings of Breethe, check out the
+This is just a brief overview of how an application built with Glimmer.js works.
+We will cover some of these things in more detail in future posts, particularly
+how we load and manage data with Orbit.js. For a closer look on the inner
+workings of Breethe, check out the
 [code on github](https://github.com/simplabs/breethe-client).
 
 ## From Glimmer.js to Ember.js
@@ -272,9 +274,15 @@ module('Component: MeasurementRow', function(hooks) {
         @unit="ppm"
       />
     `);
-    let label = this.containerElement.querySelector('[data-test-measurement-label]').textContent.trim();
-    let value = this.containerElement.querySelector('[data-test-measurement-value]').textContent.trim();
-    let unit = this.containerElement.querySelector('[data-test-measurement-unit]').textContent.trim();
+    let label = this.containerElement
+      .querySelector('[data-test-measurement-label]')
+      .textContent.trim();
+    let value = this.containerElement
+      .querySelector('[data-test-measurement-value]')
+      .textContent.trim();
+    let unit = this.containerElement
+      .querySelector('[data-test-measurement-unit]')
+      .textContent.trim();
 
     assert.equal(label, 'PM25', 'Parameter is rendered');
     assert.equal(value, '12', 'Value is rendered');
@@ -303,8 +311,8 @@ available for Ember.js applications, check out
 Glimmer.js' testing APIs still have some shortcomings (see
 [this issue](https://github.com/glimmerjs/glimmer.js/issues/14)) and are not
 entirely ready for prime time. In order to test some more advanced component
-behaviors, we use [Puppeteer](https://pptr.dev) to run the entire application
-in a headless browser.
+behaviors, we use [Puppeteer](https://pptr.dev) to run the entire application in
+a headless browser.
 
 ## Outlook
 

--- a/_posts/2018-07-24-from-spa-to-pwa.md
+++ b/_posts/2018-07-24-from-spa-to-pwa.md
@@ -4,18 +4,20 @@ author: 'Marco Otte-Witte'
 github: marcoow
 twitter: marcoow
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte goes over the characteristics of progressive web apps and shows how to make the next step from a SPA to a PWA.'
+description:
+  'Marco Otte-Witte goes over the characteristics of progressive web apps and
+  shows how to make the next step from a SPA to a PWA.'
 topic: javascript
 og:
   image: /assets/images/posts/2018-07-24-from-spa-to-pwa/og-image.png
 ---
 
 Progressive Web Apps are the next level of browser based applications. While
-Single Page Apps (SPAs) have already meant a giant leap forward, PWAs are
-taking things even one step further. They offer a rich user experience that
-parallels what users know and expect from native apps and combine that with the
-benefits that browser based applications provide. In this post, we'll look at
-how to turn a Single Page App into a Progressive Web App.
+Single Page Apps (SPAs) have already meant a giant leap forward, PWAs are taking
+things even one step further. They offer a rich user experience that parallels
+what users know and expect from native apps and combine that with the benefits
+that browser based applications provide. In this post, we'll look at how to turn
+a Single Page App into a Progressive Web App.
 
 <!--break-->
 
@@ -30,10 +32,10 @@ maybe change a few things in their daily lives.
 
 ![Video of the Breethe PWA](/assets/images/posts/2018-07-24-from-spa-to-pwa/breethe-video.gif)
 
-The application is [open source](https://github.com/simplabs/breethe-client)
-and we encourage everyone interested to look through the source for reference.
-To learn more about how we built Breethe with
-[Glimmer.js](http://glimmerjs.com), refer to the
+The application is [open source](https://github.com/simplabs/breethe-client) and
+we encourage everyone interested to look through the source for reference. To
+learn more about how we built Breethe with [Glimmer.js](http://glimmerjs.com),
+refer to the
 [previous post in this series](/blog/2018/07/03/building-a-pwa-with-glimmer-js).
 None of the contents in this post are specific to Glimmer.js in any way though,
 but all generally applicable to all frontend stacks.
@@ -49,31 +51,31 @@ the orignal iPhone:
 <iframe width="560" height="315" src="https://www.youtube.com/embed/y1B2c3ZD9fk?start=4451" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 
 Unfortunately that idea was one of the few of Jobs' that never really took off.
-In fact, Apple released the first native SDK for the iPhone in 2008. That
-change in strategy lead to a huge market for native mobile apps and played a
+In fact, Apple released the first native SDK for the iPhone in 2008. That change
+in strategy lead to a huge market for native mobile apps and played a
 significant role in mobile devices becoming ever more ubiquitous over the past
 decade.
 
 While native apps enable great things and previously unforeseen use cases, they
 come with some drawbacks. They generally
 [show high conversion rates](https://jmango360.com/wiki/mobile-app-vs-mobile-website-statistics/)
-which is the main reason why marketing departments keep pushing for them. On
-the downside though, they have some significant drawbacks, the main one being
-that apps have to be downloaded and installed which can be a significant effort
-for users for several reasons (ultimately leading to the question of how many
+which is the main reason why marketing departments keep pushing for them. On the
+downside though, they have some significant drawbacks, the main one being that
+apps have to be downloaded and installed which can be a significant effort for
+users for several reasons (ultimately leading to the question of how many
 potential users are lost before they even install the app where they then
 **could** have been successfully converted):
 
 - users that are on the mobile website already, when asked to install the app,
-  need to leave that website, go to the app store, download the app and
-  continue through the installation process
+  need to leave that website, go to the app store, download the app and continue
+  through the installation process
 - once the app is installed, all input that potentially was made on the website
   before is lost and needs to be restored besides users potentially needing to
   login in the app again
 - native apps are
   [relatively large on average](https://sweetpricing.com/blog/2017/02/average-app-file-size/),
-  leading to long download times which are particularly painful on less
-  reliable mobile connections
+  leading to long download times which are particularly painful on less reliable
+  mobile connections
 
 In contrast, **web apps are easily accessible via the browser** without forcing
 users to go through an app store and installation process and load almost
@@ -82,18 +84,18 @@ instantaneously - if done right, even on unreliable mobile connections.
 Another advantage of native apps is mostly a historic one now. Historically,
 native apps were able to offer a better user experience both in terms of the
 purely visual experience and also in terms of features. With the quickly
-evolving web platform and capabilities of modern browsers, this is no longer
-the case though and **web apps are now capable of offering equal if not better
-user experiences compared to native apps**. Combined with almost instantaneous
-load times and superior discoverability, Progressive Web Apps are clearly the
-better choice than native apps in a large number of scenarios now –
+evolving web platform and capabilities of modern browsers, this is no longer the
+case though and **web apps are now capable of offering equal if not better user
+experiences compared to native apps**. Combined with almost instantaneous load
+times and superior discoverability, Progressive Web Apps are clearly the better
+choice than native apps in a large number of scenarios now –
 [Appscope](https://appsco.pe) is a great resource for discovering PWAs of all
 kinds.
 
-This has only been the case relatively recently though. While Chrome and
-Firefox supported Service Workers (which are the main building block for PWAs)
-for quite some time, two major browsers were falling behind - namely Safari and
-Internet Explorer. These two (actually not Internet Explorer but its successor
+This has only been the case relatively recently though. While Chrome and Firefox
+supported Service Workers (which are the main building block for PWAs) for quite
+some time, two major browsers were falling behind - namely Safari and Internet
+Explorer. These two (actually not Internet Explorer but its successor
 [Edge](https://www.microsoft.com/de-de/windows/microsoft-edge)) have finally
 caught up recently and
 [Service Workers are now supported by all major browsers](https://caniuse.com/#feat=serviceworkers),
@@ -105,8 +107,8 @@ A decade after the introduction of the original iPhone (and a detour via the
 [multi-billion native app economy](https://www.appannie.com/en/insights/market-data/predictions-app-economy-2018/)),
 Progressive Web Apps are ready to be used and they are here to stay. And we are
 only getting started - as Progressive Web Apps have only recently really took
-off, **it's fair to expect massive improvements in terms of what's possible
-over the next coming years**.
+off, **it's fair to expect massive improvements in terms of what's possible over
+the next coming years**.
 
 ## What are PWAs?
 
@@ -128,9 +130,9 @@ Installability and Connectivity Independence.
 
 ## Installability
 
-Progressive Web apps can be installed on the user's home screen and thus
-_"taken out of the browser"_ so that they mingle with the user's native apps
-without the user noticing a difference. That characteristic is enabled by the
+Progressive Web apps can be installed on the user's home screen and thus _"taken
+out of the browser"_ so that they mingle with the user's native apps without the
+user noticing a difference. That characteristic is enabled by the
 [_"App Manifest"_](https://developers.google.com/web/fundamentals/web-app-manifest/)
 that describes how an app is supposed to behave when run _"outside"_ of the
 browser. The App Manifest is a simple JSON file with key/value pairs that
@@ -182,8 +184,8 @@ The main keys in the manifest are `name`, `icons`, `background_color`,
 - `background_color`: sets the color for the splash screen that is shown when
   the app is started from the home screen
 - `start_url`: the URL to load when the app is started from the home screen
-- `display`: tells the browser how to display the app when started from the
-  home screen; this should usually be `"standalone"`
+- `display`: tells the browser how to display the app when started from the home
+  screen; this should usually be `"standalone"`
 - `orientation`: the orientation to launch the app with if only one orientation
   is supported
 
@@ -198,9 +200,9 @@ browser UI:
 
 ## Connectivity Independence
 
-The main requirement for any web application to be able to work independently
-of the network is that it **must be able to start up while there is no network
-at all** and the device is offline. For a browser-based application designed to
+The main requirement for any web application to be able to work independently of
+the network is that it **must be able to start up while there is no network at
+all** and the device is offline. For a browser-based application designed to
 load all required assets remotely, that is no easy task. One of the first
 approaches for achieving this was
 [Google Gears](<https://en.wikipedia.org/wiki/Gears_(software)>). Gears was
@@ -212,11 +214,11 @@ Many of the original ideas behind Gears found their way into the HTML5 spec
 though, in particular the idea of Gear's `LocalServer` module that allowed
 running a local server inside of the browser. That server would be able to
 handle any requests made by the browser instead of actually sending the request
-over the network. This is essentially (besides some other features) what
-service workers offer. They are standalone pieces of JavaScript code that get
-installed into the users browser and are subsequently able to intercept any
-request that the browser makes and serve the response from their internal cache
-instead of relying on the remote server's response.
+over the network. This is essentially (besides some other features) what service
+workers offer. They are standalone pieces of JavaScript code that get installed
+into the users browser and are subsequently able to intercept any request that
+the browser makes and serve the response from their internal cache instead of
+relying on the remote server's response.
 
 Installing a service worker is as simple as running a little script:
 
@@ -232,8 +234,8 @@ Installing a service worker is as simple as running a little script:
 
 This calls the navigator's `serviceWorker` API's `register` method (if the
 browser supports that API), passing the name of the JavaScript file with the
-service worker code as an argument. The `register` method returns a promise
-that rejects if the service worker could not be registered successfully.
+service worker code as an argument. The `register` method returns a promise that
+rejects if the service worker could not be registered successfully.
 
 Once the service worker is registered, it will start receiving various events
 during the
@@ -272,11 +274,11 @@ self.addEventListener('install', function(event) {
 Here, when the _"install"_ event is fired, we open the service worker cache,
 request the critical assets and store them in the service worker's cache.
 
-The next event in the lifecycle is the _"activate"_ event that is typically
-used to delete old caches so that when the service worker is updated, no stale
-data is left on the user's device. In the Breethe PWA, we only use one cache
-and when the service worker is activated, simply delete all caches that are not
-that current one:
+The next event in the lifecycle is the _"activate"_ event that is typically used
+to delete old caches so that when the service worker is updated, no stale data
+is left on the user's device. In the Breethe PWA, we only use one cache and when
+the service worker is activated, simply delete all caches that are not that
+current one:
 
 ```js
 self.addEventListener('activate', function(event) {
@@ -300,8 +302,8 @@ _"fetch"_ events whenever the browser makes a request for any remote resource.
 This is the relevant event that we need to listen for in order to make sure the
 PWA can start up successfully if the device is offline. In the case of an SPA
 where there only is one HTML document (which is `index.html`), this is as easy
-as always serving that from the service worker's cache when the original
-request fails:
+as always serving that from the service worker's cache when the original request
+fails:
 
 ```js
 self.addEventListener('fetch', function(event) {
@@ -320,11 +322,11 @@ reality in Breethe,
 [we check a few other things as well](https://github.com/simplabs/breethe-client/blob/master/lib/service-worker/workers/service-worker.js#L88))
 and if that is the case, try making the request and loading the resource from
 the network first. If that fails and the promise returned from `fetch` rejects
-(one possible reason for that being that the device is offline), we simply
-serve the `index.html` from the service worker's cache so that the app can
-start up successfully in the browser. All of the application's assets that are
-referenced in `index.html` are cached to and served from the service worker's
-cache as well in a
+(one possible reason for that being that the device is offline), we simply serve
+the `index.html` from the service worker's cache so that the app can start up
+successfully in the browser. All of the application's assets that are referenced
+in `index.html` are cached to and served from the service worker's cache as well
+in a
 [separate event handler](https://github.com/simplabs/breethe-client/blob/master/lib/service-worker/workers/service-worker.js#L65).
 
 Allowing apps to start up offline with Service Workers is very straight forward
@@ -342,9 +344,9 @@ thus making it available for offline use. The
 [WebStorage API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API)
 defines `localStorage` and `sessionStorage` which can be used for storing
 key/value pairs. Cookies have been around for quite some time and not only can
-they be used for tracking users or keeping their sessions alive when the
-browser is closed but also for storing simple data. When dealing with bigger,
-structured datasets though, the storage API of choice is generally
+they be used for tracking users or keeping their sessions alive when the browser
+is closed but also for storing simple data. When dealing with bigger, structured
+datasets though, the storage API of choice is generally
 [`IndexedDB`](https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API).
 
 `IndexedDB` is a transactional database system, similar to SQL-based RDBMS:
@@ -386,7 +388,11 @@ export const location: ModelDefinition = {
     coordinates: { type: 'string' },
   },
   relationships: {
-    measurements: { type: 'hasMany', model: 'measurement', inverse: 'location' },
+    measurements: {
+      type: 'hasMany',
+      model: 'measurement',
+      inverse: 'location',
+    },
   },
 };
 
@@ -411,10 +417,10 @@ export const schema: SchemaSettings = {
 };
 ```
 
-The `location` model represents a measurement location that air quality data
-has been recorded for. Each location has a number of `measurements` that
-represent individual data points for particular parameters, e.g. 42.38 µg/m³
-for Ozone (O₃). With that schema, a store can be instantiated:
+The `location` model represents a measurement location that air quality data has
+been recorded for. Each location has a number of `measurements` that represent
+individual data points for particular parameters, e.g. 42.38 µg/m³ for Ozone
+(O₃). With that schema, a store can be instantiated:
 
 ```typescript
 import Store from '@orbit/store';
@@ -437,9 +443,9 @@ const remote = new JSONAPISource({
 });
 ```
 
-In order to be able to use the data loaded from the remote store when the app
-is offline, Breethe defines a second source that is backed by `IndexedDB` and
-that all data that enters the store via the remote source is synced into:
+In order to be able to use the data loaded from the remote store when the app is
+offline, Breethe defines a second source that is backed by `IndexedDB` and that
+all data that enters the store via the remote source is synced into:
 
 ```typescript
 import IndexedDBSource from '@orbit/indexeddb';
@@ -455,14 +461,13 @@ store.on('transform', transform => {
 });
 ```
 
-With this setup, all data that gets loaded by the app while the device is
-online is available for later offline use, where it will be read from
-`IndexedDB` instead. This mechanism works the other way round as well of
-course, such that the app could buffer any modifications to data in the store
-in `IndexedDB` while offline and then sync these changes back to the remote API
-once the device comes back online - refer to the
-[Orbit.js docs](http://orbitjs.com/v0.15/guide/) for more information about
-advanced mechanics like this.
+With this setup, all data that gets loaded by the app while the device is online
+is available for later offline use, where it will be read from `IndexedDB`
+instead. This mechanism works the other way round as well of course, such that
+the app could buffer any modifications to data in the store in `IndexedDB` while
+offline and then sync these changes back to the remote API once the device comes
+back online - refer to the [Orbit.js docs](http://orbitjs.com/v0.15/guide/) for
+more information about advanced mechanics like this.
 
 With the combination of service workers and `IndexedDB`, PWAs are fully
 independent of the network status and offer the same experience as native apps
@@ -474,24 +479,23 @@ details behind convenient APIs.
 
 Testing is an essential part of modern software engineering and we at simplabs
 (and I'm sure this is true for anyone reading this as well) would **never ship
-code that is not fully tested** - as we could not know whether the code
-actually works or whether we subsequently break it when making changes. The
-first thing that comes to mind when thinking about tests are typically unit
-tests that test a small part of an app (a unit) in isolation. Depending on the
-framework of choice and its testing philosophy and tools, there might also be
-means of
+code that is not fully tested** - as we could not know whether the code actually
+works or whether we subsequently break it when making changes. The first thing
+that comes to mind when thinking about tests are typically unit tests that test
+a small part of an app (a unit) in isolation. Depending on the framework of
+choice and its testing philosophy and tools, there might also be means of
 [higher level test](https://guides.emberjs.com/release/testing/testing-components/)
 that test larger subsets of an app (and we have
 [quite](https://github.com/simplabs/breethe-client/blob/master/src/ui/components/MeasurementRow/component-test.ts)
 [a lot](https://github.com/simplabs/breethe-client/blob/master/src/ui/components/SearchForm/component-test.ts)
 of these for Breethe).
 
-Testing PWAs, in particular their offline behavior, is slightly different
-though as it requires the correct interplay of various parts that cannot be
-isolated well - namely the app itself, the service worker, storage APIs like
-`IndexedDB` and the browser. A proper PWA test suite needs to take all of these
-parts into account and have a higher level perspective on the system under test
-than is the case in a unit test. A great tool for tests like these is Google's
+Testing PWAs, in particular their offline behavior, is slightly different though
+as it requires the correct interplay of various parts that cannot be isolated
+well - namely the app itself, the service worker, storage APIs like `IndexedDB`
+and the browser. A proper PWA test suite needs to take all of these parts into
+account and have a higher level perspective on the system under test than is the
+case in a unit test. A great tool for tests like these is Google's
 [puppeteer](https://pptr.dev) that allows running and controlling a headless
 instance of Chrome.
 
@@ -519,7 +523,9 @@ describe('when offline', function() {
       await page.click('[data-test-search-submit]');
       await page.waitForSelector('[data-test-search-result="Salzburg"]');
       await page.click('[data-test-search-result="Salzburg"] a');
-      await page.waitForSelector('[data-test-measurement="PM10"] [data-test-measurement-value="15"]');
+      await page.waitForSelector(
+        '[data-test-measurement="PM10"] [data-test-measurement-value="15"]',
+      );
       await page.click('[data-test-home-link]');
       await page.waitForSelector('[data-test-search]');
 
@@ -530,7 +536,9 @@ describe('when offline', function() {
       await page.waitForSelector('[data-test-search-result="Salzburg"]');
       await page.click('[data-test-search-result="Salzburg"] a');
       // check the correct data is still present
-      let element = await page.waitForSelector('[data-test-measurement="PM10"] [data-test-measurement-value="15"]');
+      let element = await page.waitForSelector(
+        '[data-test-measurement="PM10"] [data-test-measurement-value="15"]',
+      );
       expect(page.url()).to.match(/\/location\/2$/);
 
       expect(element).to.be.ok;
@@ -541,8 +549,8 @@ describe('when offline', function() {
 
 This test uses
 [puppeteer's API](https://github.com/GoogleChrome/puppeteer/blob/v1.5.0/docs/api.md)
-to create a new browser object (which will start an actual instance of Chrome
-in the background), open a page, interact with DOM elements and assert on their
+to create a new browser object (which will start an actual instance of Chrome in
+the background), open a page, interact with DOM elements and assert on their
 presence and state. It starts by going through the app's main flow once so data
 is loaded from the API and `IndexedDB` is populated. It then disables the
 network (`page.setOfflineMode(true)`), reloads the page (which is then served
@@ -551,8 +559,8 @@ the DOM correctly being generated from the data read from `IndexedDB`.
 
 A testing setup like this makes it easy to achieve decent test coverage for
 PWAs, testing all of the parts involved - the app itself but also the service
-worker and storage APIs like `IndexedDB`. These test are even reasonably fast
-to execute -
+worker and storage APIs like `IndexedDB`. These test are even reasonably fast to
+execute -
 [Breethe's suite of puppeteer tests](https://github.com/simplabs/breethe-client/tree/master/integration-tests)
 completes in
 [around 1min](https://travis-ci.org/simplabs/breethe-client/jobs/403597086#L683).
@@ -560,10 +568,10 @@ completes in
 ## Outlook
 
 This post and the
-[previous one](/blog/2018/07/03/building-a-pwa-with-glimmer-js) have given
-an overview of how to write an SPA (in this case with Glimmer.js) and then
-turning that into a [Progressive Web App](http://breethe.app). With Breethe, we
-haven't stopped there though but employed server side rendering to combine the
+[previous one](/blog/2018/07/03/building-a-pwa-with-glimmer-js) have given an
+overview of how to write an SPA (in this case with Glimmer.js) and then turning
+that into a [Progressive Web App](http://breethe.app). With Breethe, we haven't
+stopped there though but employed server side rendering to combine the
 advantages of a PWA with those of classic server rendered websites. In the next
 post in this series, we will have a detailed look at what specifically those
 advantages are and how we were able to achieve them.

--- a/_posts/2018-11-27-open-source-maintenance.md
+++ b/_posts/2018-11-27-open-source-maintenance.md
@@ -4,7 +4,9 @@ author: 'Tobias Bieniek'
 github: Turbo87
 twitter: tobiasbieniek
 bio: 'Senior Frontend Engineer, Ember CLI core team member'
-description: 'Tobias Bieniek introduces best practices for simplifying and speeding up his work on open-source and other projects.'
+description:
+  'Tobias Bieniek introduces best practices for simplifying and speeding up his
+  work on open-source and other projects.'
 topic: misc
 ---
 
@@ -23,32 +25,34 @@ subsequent development of [GitHub] has made version control mainstream for open
 source projects.
 
 While many tutorials focus on using Git from the command line, we have found
-that using a graphical user interface to visualize the history graph can make
-it quite a bit easier for beginners to understand what is going on. One good
-example of such a tool is [Fork], which is freely available for Windows and macOS:
+that using a graphical user interface to visualize the history graph can make it
+quite a bit easier for beginners to understand what is going on. One good
+example of such a tool is [Fork], which is freely available for Windows and
+macOS:
 
 ![Screenshot of Fork](/assets/images/posts/2018-11-27-open-source-maintenance/git-fork.png#@1173-2346)
 
 When working on multiple different projects, it is useful to rely on similar
 conventions, for example, when naming things. In the context of Git this is most
-relevant when naming [remotes](https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes),
-tags and branches.
+relevant when naming
+[remotes](https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes), tags
+and branches.
 
 When we publish new releases we "tag" the release commits with a tag name like
 `v1.2.3`, corresponding to the new version. When working in the JavaScript
-ecosystem we use `yarn version` (or `npm version`) to automatically adjust
-the `version` field in the `package.json` file, commit the change and finally
-create a tag on the new commit.
+ecosystem we use `yarn version` (or `npm version`) to automatically adjust the
+`version` field in the `package.json` file, commit the change and finally create
+a tag on the new commit.
 
 For branches we use the default `master` branch as our main development branch.
 Feature branches are named after the thing that they are implementing or fixing
 and ideally only contain isolated, focused changes. Similar to the tag names we
-sometimes keep version branches around to support older releases with names
-like `v1.x` or `v2.3.x`.
+sometimes keep version branches around to support older releases with names like
+`v1.x` or `v2.3.x`.
 
-For remotes we use `upstream`, `origin` and for all other remotes the GitHub
-(or GitLab, BitBucket, etc.) username of the remote owner. `upstream` means the
-main project on GitHub and `origin` is my personal fork where I push feature
+For remotes we use `upstream`, `origin` and for all other remotes the GitHub (or
+GitLab, BitBucket, etc.) username of the remote owner. `upstream` means the main
+project on GitHub and `origin` is my personal fork where I push feature
 branches, which will turn into PRs against the `upstream` repository. Here is an
 example for our `qunit-dom` project on my machine:
 
@@ -59,9 +63,10 @@ example for our `qunit-dom` project on my machine:
 | `lukemelia`  | `git@github.com:lukemelia/qunit-dom.git`  |
 | `jackbeegan` | `git@github.com:jackbeegan/qunit-dom.git` |
 
-Why is this useful? Because it allows us to define [shell aliases](https://shapeshed.com/unix-alias/)
-for some of the most commonly used git commands for which we don't use a
-graphical user interface. Here are a few examples of things we regularly use:
+Why is this useful? Because it allows us to define
+[shell aliases](https://shapeshed.com/unix-alias/) for some of the most commonly
+used git commands for which we don't use a graphical user interface. Here are a
+few examples of things we regularly use:
 
 | Alias | Command                       | Description                                                                                           |
 | ----- | ----------------------------- | ----------------------------------------------------------------------------------------------------- |
@@ -92,18 +97,18 @@ gph
 Having a good test suite is very important to be able to change code and be
 confident that the change is not breaking anything. This is one of the major
 reasons why we love [Ember.js], because it comes with a great testing system
-out-of-the-box and allows us to write tests for all of the critical parts of
-the apps that we develop.
+out-of-the-box and allows us to write tests for all of the critical parts of the
+apps that we develop.
 
 You can find more information on testing in Ember.js on the official
 [guides](https://guides.emberjs.com/release/testing/).
 
 But this topic not limited to just Ember.js, other ecosystems have similar
-tools. For Node.js the most popular testing solutions these days are [Jest]
-and [Mocha]. In the [Rust] ecosystem testing is already built into their
-package manager [cargo], but there are [plenty of crates](https://github.com/rust-unofficial/awesome-rust#testing)
-to make testing even more pleasant, including the very valuable [proptest]
-crate.
+tools. For Node.js the most popular testing solutions these days are [Jest] and
+[Mocha]. In the [Rust] ecosystem testing is already built into their package
+manager [cargo], but there are
+[plenty of crates](https://github.com/rust-unofficial/awesome-rust#testing) to
+make testing even more pleasant, including the very valuable [proptest] crate.
 
 ## Linting
 
@@ -136,8 +141,8 @@ this is relevant.
 One important thing to mention here is that CI can not only run your test suite
 but can often also do other things like publishing new versions of your
 projects. On most of our projects we have configured TravisCI to automatically
-publish new releases to [npm] whenever we push a new Git tag to the server.
-You can find instruction on how to configure this in their official
+publish new releases to [npm] whenever we push a new Git tag to the server. You
+can find instruction on how to configure this in their official
 [documentation](https://docs.travis-ci.com/user/deployment/npm/).
 
 ## Semantic Versioning
@@ -159,15 +164,16 @@ important rules:
    considered "unstable"
 
 Since the majority of package managers including [yarn], [cargo], [hex] and
-[bundler] follow these semantics when resolving dependencies, it is very important
-to comply with these rules. But they are also useful in order for your users
-to get a sense of what they can expect from a new release.
+[bundler] follow these semantics when resolving dependencies, it is very
+important to comply with these rules. But they are also useful in order for your
+users to get a sense of what they can expect from a new release.
 
 While this can be controversial, we consider dropping support for older Node.js,
-Elixir, Ruby, Rust, or other language releases a breaking change. This means that if
-your package [declares](https://docs.npmjs.com/files/package.json#engines)
-that it works with Node.js 4, and you release a new version that needs at least
-Node.js 6, then you should increase the **major** version.
+Elixir, Ruby, Rust, or other language releases a breaking change. This means
+that if your package
+[declares](https://docs.npmjs.com/files/package.json#engines) that it works with
+Node.js 4, and you release a new version that needs at least Node.js 6, then you
+should increase the **major** version.
 
 ## Dependency Update Services
 
@@ -177,33 +183,34 @@ on a test framework. While keeping the dependencies of a single project
 up-to-date is a manageable task, it is becoming a full-time job once you
 maintain a larger number of separate projects.
 
-Fortunately for us this is a task that can be automated quite well, at least
-if you have a good test suite and continuous integration set up. While we
-first used [Greenkeeper] for this task, we have lately transitioned to using
+Fortunately for us this is a task that can be automated quite well, at least if
+you have a good test suite and continuous integration set up. While we first
+used [Greenkeeper] for this task, we have lately transitioned to using
 [dependabot], which supports not only npm, but all sorts of different package
 managers, language ecosystems, and even monorepos.
 
 Dependabot will automatically open Pull Requests on your projects whenever one
 of your dependencies has published a new version. This will cause your CI
-service to run the test suite against that new dependency version and tell
-you whether it is compatible with your code or not. If configured, dependabot
-can also automatically merge those Pull Requests once CI has finished and the
-test suite passed.
+service to run the test suite against that new dependency version and tell you
+whether it is compatible with your code or not. If configured, dependabot can
+also automatically merge those Pull Requests once CI has finished and the test
+suite passed.
 
 ## Changelogs
 
 While Semantic Versioning helps your users to know if they need to expect
-breaking changes from a release, it is much better to have a human-readable
-list of changes that went into a release. This is what a "Changelog" is for.
-Typically this is a `CHANGELOG.md` file in the root folder of your project
-that lists all your released versions including the changes that went into
-each release.
+breaking changes from a release, it is much better to have a human-readable list
+of changes that went into a release. This is what a "Changelog" is for.
+Typically this is a `CHANGELOG.md` file in the root folder of your project that
+lists all your released versions including the changes that went into each
+release.
 
-It can be quite tedious to write these things by hand, but fortunately there
-are generators that can do most of the work for us. These generators can be
-divided into two groups:
+It can be quite tedious to write these things by hand, but fortunately there are
+generators that can do most of the work for us. These generators can be divided
+into two groups:
 
-1. the first group is based on [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages)
+1. the first group is based on
+   [semantic commit messages](https://seesparkbox.com/foundry/semantic_commit_messages)
    and lists all of the commits that are part of a certain release
 2. the second group is based upon GitHub Pull Requests (or similar) and uses
    issue/PR labels to categorize changes
@@ -215,11 +222,12 @@ list of very fine-grained changes that are not directly helpful to the user.
 Instead we use [lerna-changelog] to generate our changelogs from all of the
 merged pull requests that went into each of the releases. To make this work
 properly it is important to focus each pull request on only one single, logical
-change, and label it properly as either `enhancement`, `bug`, `breaking`, or
-any of the other supported/configured labels. To ensure that all of our projects
-use the same set of labels we use [github-label-sync].
+change, and label it properly as either `enhancement`, `bug`, `breaking`, or any
+of the other supported/configured labels. To ensure that all of our projects use
+the same set of labels we use [github-label-sync].
 
-An [example changelog](https://github.com/simplabs/qunit-dom/blob/master/CHANGELOG.md)
+An
+[example changelog](https://github.com/simplabs/qunit-dom/blob/master/CHANGELOG.md)
 can be seen on our qunit-dom project.
 
 ## Summary

--- a/_posts/2018-12-10-assert-your-style.md
+++ b/_posts/2018-12-10-assert-your-style.md
@@ -4,26 +4,39 @@ author: 'Jessica Jordan'
 github: jessica-jordan
 twitter: jjordan_dev
 bio: 'Senior Frontend Engineer, Ember Learning core team member'
-description: 'Jessica Jordan explains approaches and patterns for testing styles in Ember.js applications.'
+description:
+  'Jessica Jordan explains approaches and patterns for testing styles in
+  Ember.js applications.'
 topic: javascript
 og:
   image: /assets/images/posts/2018-12-10-assert-your-style/og-image.png
 ---
 
-Sometimes you really want to make sure that your web application looks good; and that it keeps doing so in the future.
-**Automated tests** are an important foundation for making your application's appearance future-proof and this may involve the integration of a screenshot-based testing tool like [Percy.io](https://percy.io/) or [PhantomCSS](https://github.com/HuddleEng/PhantomCSS).
+Sometimes you really want to make sure that your web application looks good; and
+that it keeps doing so in the future. **Automated tests** are an important
+foundation for making your application's appearance future-proof and this may
+involve the integration of a screenshot-based testing tool like
+[Percy.io](https://percy.io/) or
+[PhantomCSS](https://github.com/HuddleEng/PhantomCSS).
 
-But writing your own **visual regression tests** for critical styles in your application can be really useful, too - and it can be easily done on top of that!
+But writing your own **visual regression tests** for critical styles in your
+application can be really useful, too - and it can be easily done on top of
+that!
 
 <!--break-->
 
-These are a few approaches you can choose from to assert against the styling of your web page as part of your automated integration and acceptance test suite:
+These are a few approaches you can choose from to assert against the styling of
+your web page as part of your automated integration and acceptance test suite:
 
 ## Testing Inline Styles of a HTML Element
 
-Although it's a good practice to keep your HTML and your CSS entirely separate, **inline styles** on components and other elements in your application are sometimes necessary to be able to apply CSS property values that change dynamically. And testing those styles can be important, too.
+Although it's a good practice to keep your HTML and your CSS entirely separate,
+**inline styles** on components and other elements in your application are
+sometimes necessary to be able to apply CSS property values that change
+dynamically. And testing those styles can be important, too.
 
-Imagine you created a component with an inline style attached to it assigning a variable blue background color to it:
+Imagine you created a component with an inline style attached to it assigning a
+variable blue background color to it:
 
 ```js
 // app/components/simplabs-logo-tile.js
@@ -47,7 +60,8 @@ export default Component.extend({
 });
 ```
 
-Using `ember-test-selectors` to apply `data-` attributes to this component, you can make it easier to interact with your component later on in the test.
+Using `ember-test-selectors` to apply `data-` attributes to this component, you
+can make it easier to interact with your component later on in the test.
 
 ```bash
 ember install ember-test-selectors
@@ -78,9 +92,13 @@ export default Component.extend({
 });
 ```
 
-To learn more about the rationale behind `ember-test-selectors`, be sure to also [give this introduction a read](/blog/2017/11/17/ember-test-selectors-road-to-1-0).
+To learn more about the rationale behind `ember-test-selectors`, be sure to also
+[give this introduction a read](/blog/2017/11/17/ember-test-selectors-road-to-1-0).
 
-Using the [HTMLElement.style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) API, we can assert if the correct background color has been applied to our component:
+Using the
+[HTMLElement.style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style)
+API, we can assert if the correct background color has been applied to our
+component:
 
 ```js
 // tests/integration/components/simplabs-logo-tile-test.js
@@ -101,22 +119,48 @@ module('Integration | Component | simplabs-logo-tile', function(hooks) {
 });
 ```
 
-`HTMLElement.style` allows to check for the value of **individual CSS properties**. The same API can also be used to assign new values for any CSS property programmatically.
-You can read more about [the style attribute in the MDN docs on HTMLElement.style here](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style).
+`HTMLElement.style` allows to check for the value of **individual CSS
+properties**. The same API can also be used to assign new values for any CSS
+property programmatically. You can read more about
+[the style attribute in the MDN docs on HTMLElement.style here](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style).
 
-A major **benefit** of testing **CSS properties** directly is that it allows us to derive information on how inline styles are applied to elements in our application. This is particularly useful if we want to test **dynamic styles**.
+A major **benefit** of testing **CSS properties** directly is that it allows us
+to derive information on how inline styles are applied to elements in our
+application. This is particularly useful if we want to test **dynamic styles**.
 
-**Testing inline styles** also has its **drawbacks** though: these styles don't necessarily reflect the way the element is ultimately rendered on the page. In this situation the assertion against an element's **computed style** provides much more insight.
+**Testing inline styles** also has its **drawbacks** though: these styles don't
+necessarily reflect the way the element is ultimately rendered on the page. In
+this situation the assertion against an element's **computed style** provides
+much more insight.
 
 ## Testing Computed Styles of a HTML Element
 
-At times you also want to check against the actual **computed value** of your element in your tests. Some CSS definitions require the browser to resolve the basic computation, the actual computed styles will be applied during rendering. For example, in the case of an element with a percentage-based width defined via CSS stylesheets (e.g. `width: 80%`), the computed style will resolve to `width: 800px` if the element happens to be a relatively positioned (`position: relative`) child element of another DOM node with a computed width of `1000px`. If the element's parent element turns out to have a width of `500px` though, the computed width of the "80% wide" child will resolve to a mere `400px`.
+At times you also want to check against the actual **computed value** of your
+element in your tests. Some CSS definitions require the browser to resolve the
+basic computation, the actual computed styles will be applied during rendering.
+For example, in the case of an element with a percentage-based width defined via
+CSS stylesheets (e.g. `width: 80%`), the computed style will resolve to
+`width: 800px` if the element happens to be a relatively positioned
+(`position: relative`) child element of another DOM node with a computed width
+of `1000px`. If the element's parent element turns out to have a width of
+`500px` though, the computed width of the "80% wide" child will resolve to a
+mere `400px`.
 
-Computed styles provide information about the styles that are **ultimately assigned** to an element. Due to [CSS specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity) browsers will decide which CSS property value either defined in a CSS stylesheet or an inline style is most relevant and this value will also be reflected in the element's computed styles.
+Computed styles provide information about the styles that are **ultimately
+assigned** to an element. Due to
+[CSS specificity](https://developer.mozilla.org/en-US/docs/Web/CSS/Specificity)
+browsers will decide which CSS property value either defined in a CSS stylesheet
+or an inline style is most relevant and this value will also be reflected in the
+element's computed styles.
 
-The [getComputedStyle method](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle) will return an object containing these most relevant style values. In contrast to the object returned from `HTMLElement.style` the return value of `getComputedStyle` is read-only.
+The
+[getComputedStyle method](https://developer.mozilla.org/en-US/docs/Web/API/Window/getComputedStyle)
+will return an object containing these most relevant style values. In contrast
+to the object returned from `HTMLElement.style` the return value of
+`getComputedStyle` is read-only.
 
-Therefore the `getComputedStyle` method is the ideal candidate for asserting styles of an element in rendering tests:
+Therefore the `getComputedStyle` method is the ideal candidate for asserting
+styles of an element in rendering tests:
 
 ```js
 // tests/integration/components/simplabs-logo-tile-test.js
@@ -131,17 +175,28 @@ module('Integration | Component | simplabs-logo-tile', function(hooks) {
   test('it allows setting a dark background color', async function(assert) {
     await render(hbs`{{simplabs-logo-tile tileColor="dark"}}`);
 
-    let computedStyle = window.getComputedStyle(find('[data-test-simplabs-logo-tile]'), null);
-    assert.equal(computedStyle.getPropertyValue('background-color'), 'rgb(29, 113, 182)');
+    let computedStyle = window.getComputedStyle(
+      find('[data-test-simplabs-logo-tile]'),
+      null,
+    );
+    assert.equal(
+      computedStyle.getPropertyValue('background-color'),
+      'rgb(29, 113, 182)',
+    );
   });
 });
 ```
 
 ## Easy Style Assertions with qunit-dom
 
-Now we know how we can write style-related tests for our automated test process that assert that the expected styles are applied to elements on the web page.
+Now we know how we can write style-related tests for our automated test process
+that assert that the expected styles are applied to elements on the web page.
 
-But there's an even easier way to assert the computed styles of elements in your **QUnit test suite**. Since [v0.8.1](https://twitter.com/simplabs/status/1065913669995978752) of [qunit-dom](/blog/2017/10/24/high-level-assertions-with-qunit-dom) you can make your tests truly ✨
+But there's an even easier way to assert the computed styles of elements in your
+**QUnit test suite**. Since
+[v0.8.1](https://twitter.com/simplabs/status/1065913669995978752) of
+[qunit-dom](/blog/2017/10/24/high-level-assertions-with-qunit-dom) you can make
+your tests truly ✨
 
 Check it [out](https://github.com/simplabs/qunit-dom):
 
@@ -155,7 +210,8 @@ or
 yarn add --dev qunit-dom
 ```
 
-In your rendering test you're now able to check for the component's style using the `hasStyle` method:
+In your rendering test you're now able to check for the component's style using
+the `hasStyle` method:
 
 ```js
 // tests/integration/components/simplabs-logo-tile-test.js
@@ -177,10 +233,14 @@ module('Integration | Component | simplabs-logo-tile', function(hooks) {
 });
 ```
 
-You can read more about the usage of the `.hasStyle` method in the [API documentation](https://github.com/simplabs/qunit-dom/blob/master/API.md#hasStyle).
+You can read more about the usage of the `.hasStyle` method in the
+[API documentation](https://github.com/simplabs/qunit-dom/blob/master/API.md#hasStyle).
 
 ---
 
-There are different ways to assert against inline styles and computed styles in your application and if you're using Ember & QUnit, [qunit-dom](https://github.com/simplabs/qunit-dom) is your best bet to make your style tests easy to write and read.
+There are different ways to assert against inline styles and computed styles in
+your application and if you're using Ember & QUnit,
+[qunit-dom](https://github.com/simplabs/qunit-dom) is your best bet to make your
+style tests easy to write and read.
 
 Questions? Suggestions? [Contact us!](/contact/)

--- a/_posts/2018-12-20-factories-best-practices.md
+++ b/_posts/2018-12-20-factories-best-practices.md
@@ -5,42 +5,108 @@ github: geekygrappler
 twitter: geekygrappler
 topic: testing
 bio: 'Senior Frontend Engineer'
-description: "Andy Brown introduces best practices for using factories in order to make your colleagues' and your own future self's lives easier."
+description:
+  "Andy Brown introduces best practices for using factories in order to make
+  your colleagues' and your own future self's lives easier."
 ---
 
-Writing tests is like drinking beer 🍻. When you first try it, the taste is really quite unpalatable, but everyone else around you is doing it and they seem to be enjoying it. You've heard about all the benefits of it, people won't stop telling you how great it is, how it changed their lives for the better. Also there is a lot of peer pressure and judgement involved, don't be that dev... so you conceal your grimace and keep trying it, on a daily basis here at simplabs. And just like beer, in no time at all, on a long hot day, when you feel yourself tiring of writing all those features and tweaking all that CSS, you realise that what you need to relax is to write a good, concise, logical, cool and refreshing test. At least that's been my experience and I want to share a few tips for factories so that your tests are easy for your ~~friends~~, ~~colleagues~~, the next developer to read.
+Writing tests is like drinking beer 🍻. When you first try it, the taste is
+really quite unpalatable, but everyone else around you is doing it and they seem
+to be enjoying it. You've heard about all the benefits of it, people won't stop
+telling you how great it is, how it changed their lives for the better. Also
+there is a lot of peer pressure and judgement involved, don't be that dev... so
+you conceal your grimace and keep trying it, on a daily basis here at simplabs.
+And just like beer, in no time at all, on a long hot day, when you feel yourself
+tiring of writing all those features and tweaking all that CSS, you realise that
+what you need to relax is to write a good, concise, logical, cool and refreshing
+test. At least that's been my experience and I want to share a few tips for
+factories so that your tests are easy for your ~~friends~~, ~~colleagues~~, the
+next developer to read.
 
 <!--break-->
 
 ## AAA
 
-Before I dive into factories, firstly I want to mention AAA: Arrange, Act, Assert. I covered this paradigm over [here](/blog/2017/09/17/magic-test-data/), and I still stand by it. It's the most important thing you can do to make your tests straight forward and understandable for others.
+Before I dive into factories, firstly I want to mention AAA: Arrange, Act,
+Assert. I covered this paradigm over [here](/blog/2017/09/17/magic-test-data/),
+and I still stand by it. It's the most important thing you can do to make your
+tests straight forward and understandable for others.
 
 ## Factories > Fixtures
 
-Fixtures are hard coded data, a file with data representing a model in it, or any data that your application needs. Factories generate data dynamically, using functions, and can be called upon during the test with parameters passed to manipulate to output data.
+Fixtures are hard coded data, a file with data representing a model in it, or
+any data that your application needs. Factories generate data dynamically, using
+functions, and can be called upon during the test with parameters passed to
+manipulate to output data.
 
-I would strongly discourage the use of fixtures. There are many excellent posts out there comparing factories and fixtures, and, apart from the ones that are wrong, they all say that factories > fixtures 🎉. I want to focus on one particular use case I've seen a few times, which often leads to the inclusion of fixtures in a mostly factory based test suite.
+I would strongly discourage the use of fixtures. There are many excellent posts
+out there comparing factories and fixtures, and, apart from the ones that are
+wrong, they all say that factories > fixtures 🎉. I want to focus on one
+particular use case I've seen a few times, which often leads to the inclusion of
+fixtures in a mostly factory based test suite.
 
-In most applications there is often one gnarly model. In ecommerce applications it tends to be something like `order`. This will have many `products`, belong to a `user`, may have some reference to a `payment` and `delivery`, maybe it will have some kind of self referential relationship, or polymorphic relationship. You get the picture, it's got a lot of stuff, it's grown over time to become and all-encompassing monster and it _will_ make your head hurt to think about it. It's often in these situtaion that we reach for a fixture, sometimes we even copy and paste a response from our production API 😱.
+In most applications there is often one gnarly model. In ecommerce applications
+it tends to be something like `order`. This will have many `products`, belong to
+a `user`, may have some reference to a `payment` and `delivery`, maybe it will
+have some kind of self referential relationship, or polymorphic relationship.
+You get the picture, it's got a lot of stuff, it's grown over time to become and
+all-encompassing monster and it _will_ make your head hurt to think about it.
+It's often in these situtaion that we reach for a fixture, sometimes we even
+copy and paste a response from our production API 😱.
 
-The full API response fixture is the worst kind of fixture and it is a code smell. It means that rather than creating a declarative test that will help future developers (and your future self) understand what parts of this model are important for a particular test and how the model works, you get a 1,203 line json file. If I ever see a fixture like this while fixing a broken test, I have to replace it with a factory. I don't do this because I like creating extra work for myself, believe me, I don't. I do it because I don't understand what specific parts of that model were important to the test by looking at the fixture. In order to fix the test I need to figure out how the model works. I try to build a mental picture of the model and create the data for the test using a factory (often many factories pulled together), so it's clear and concise what parts of the `order` are required for the `orders with multiple deliveries arriving on the same day, only show 1 estimated delivery date not multiple` test. In this test (which is fantastically named), I can expect to see an `order` factory which has a `delivery` factory with more than one delivery, but all planned for the same day. All the other parts of the `order` model are likely not relevant to this test, so don't include them, or leave them as the defaults. Some pseudocode as we're so far into the post without a single line of it.
+The full API response fixture is the worst kind of fixture and it is a code
+smell. It means that rather than creating a declarative test that will help
+future developers (and your future self) understand what parts of this model are
+important for a particular test and how the model works, you get a 1,203 line
+json file. If I ever see a fixture like this while fixing a broken test, I have
+to replace it with a factory. I don't do this because I like creating extra work
+for myself, believe me, I don't. I do it because I don't understand what
+specific parts of that model were important to the test by looking at the
+fixture. In order to fix the test I need to figure out how the model works. I
+try to build a mental picture of the model and create the data for the test
+using a factory (often many factories pulled together), so it's clear and
+concise what parts of the `order` are required for the
+`orders with multiple deliveries arriving on the same day, only show 1 estimated delivery date not multiple`
+test. In this test (which is fantastically named), I can expect to see an
+`order` factory which has a `delivery` factory with more than one delivery, but
+all planned for the same day. All the other parts of the `order` model are
+likely not relevant to this test, so don't include them, or leave them as the
+defaults. Some pseudocode as we're so far into the post without a single line of
+it.
 
 ```js
 test('orders with deliveries from different carriers arriving on the same day, only show 1 estimated delivery date', function(assert) {
   let tomorrow = Date.tomorrow();
-  let dhl = make('delivery', { estimatedDeliveryDate: tomorrow, carrier: 'dhl' });
-  let ups = make('delivery', { estimatedDeliveryDate: tomorrow, carrier: 'ups' });
+  let dhl = make('delivery', {
+    estimatedDeliveryDate: tomorrow,
+    carrier: 'dhl',
+  });
+  let ups = make('delivery', {
+    estimatedDeliveryDate: tomorrow,
+    carrier: 'ups',
+  });
   let order = make('order', { deliveries: [dhl, ups] });
 
-  assert.equal(order.estimatedDeliveryDates.length, 1, 'We should only show one delivery date');
-  assert.equal(order.estimatedDeliveryDates[0], tomorrow, 'The delivery date is correct');
+  assert.equal(
+    order.estimatedDeliveryDates.length,
+    1,
+    'We should only show one delivery date',
+  );
+  assert.equal(
+    order.estimatedDeliveryDates[0],
+    tomorrow,
+    'The delivery date is correct',
+  );
 });
 ```
 
 ## Fun fun factories 🏭
 
-This is the part where young me thinks old me is a boring loser. Don't give your factories fun names 🙅‍♂️. Often with factory libraries you will be able to have a default model, e.g. `user` and you'll be able to have named factories e.g. `specialUser`. What is quite fun is to have themed names for your factories, for example:
+This is the part where young me thinks old me is a boring loser. Don't give your
+factories fun names 🙅‍♂️. Often with factory libraries you will be able to have a
+default model, e.g. `user` and you'll be able to have named factories e.g.
+`specialUser`. What is quite fun is to have themed names for your factories, for
+example:
 
 ```js
 //factories/user.js
@@ -61,7 +127,14 @@ Factory.define({
 });
 ```
 
-Now while it's fun to have Game of Thrones characters in your testing code base, it is a terrible practice. At the moment the difference between Jon and Rob is quite clear, and if I was writing a test about inheritance of Winterfell, it would be clear with a quick scan of the factory file, what the difference between Jon and Rob is, regardless of whether I've watched GoT or not. However, even though I know nothing about this ficticious GoT app, I can promise you one thing, the model will grow with time and the list of attrs will start to grow for both of our heroes. Let me give one scenario for what could happen:
+Now while it's fun to have Game of Thrones characters in your testing code base,
+it is a terrible practice. At the moment the difference between Jon and Rob is
+quite clear, and if I was writing a test about inheritance of Winterfell, it
+would be clear with a quick scan of the factory file, what the difference
+between Jon and Rob is, regardless of whether I've watched GoT or not. However,
+even though I know nothing about this ficticious GoT app, I can promise you one
+thing, the model will grow with time and the list of attrs will start to grow
+for both of our heroes. Let me give one scenario for what could happen:
 
 ```js
 beforeEach(() => {
@@ -71,8 +144,14 @@ beforeEach(() => {
 
 // Added by me on day 1
 test('bastards cannot inherit', function(assert) {
-  assert.ok(rob.canInherit, 'The King in the North, Rob Stark shall inherit Winterfell');
-  assert.notOk(jon.canInherit, 'Get ye to The Wall, Winterfell will never belong to Jon Snow.');
+  assert.ok(
+    rob.canInherit,
+    'The King in the North, Rob Stark shall inherit Winterfell',
+  );
+  assert.notOk(
+    jon.canInherit,
+    'Get ye to The Wall, Winterfell will never belong to Jon Snow.',
+  );
 });
 
 // Added by you on day 10
@@ -80,8 +159,14 @@ test('Leaders can raise armies', function(assert) {
   /* let's introduce someone who can tell us interesting things about Jon and Rob */
   let threeEyedRaven = make('brandon_stark');
 
-  assert.ok(threeEyedRaven.canRaiseArmies(rob), 'Noble of blood, strong of heart, Rob Stark can raise an army.');
-  assert.ok(threeEyedRaven.canRaiseArmies(jon), 'Principles command authority, Jon Snow can raise an army.');
+  assert.ok(
+    threeEyedRaven.canRaiseArmies(rob),
+    'Noble of blood, strong of heart, Rob Stark can raise an army.',
+  );
+  assert.ok(
+    threeEyedRaven.canRaiseArmies(jon),
+    'Principles command authority, Jon Snow can raise an army.',
+  );
 });
 
 //Added by me on day 102
@@ -128,7 +213,14 @@ Factory.define({
 });
 ```
 
-Now my example is a bit of fun, but my point is this: If you create wittily themed named factories, the attributes they contain will be unclear to everyone but you (and even to you on day 102). Often you will have a bare minimum number of attributes required for a certain model, e.g. every user must have a name and an email or the app will implode, and these things should live in the `default` factory. If you need to modify the default, and admin users are a good example of this, then keep the modification simple and make it obvious from the name what properties are changing.
+Now my example is a bit of fun, but my point is this: If you create wittily
+themed named factories, the attributes they contain will be unclear to everyone
+but you (and even to you on day 102). Often you will have a bare minimum number
+of attributes required for a certain model, e.g. every user must have a name and
+an email or the app will implode, and these things should live in the `default`
+factory. If you need to modify the default, and admin users are a good example
+of this, then keep the modification simple and make it obvious from the name
+what properties are changing.
 
 ```js
 //user.js
@@ -145,15 +237,21 @@ Factory.define({
 });
 ```
 
-But of course **you should not do this(!)**, even with sensible naming, because it will become a dumping ground for each attribute a test requires if it involves an admin user.
+But of course **you should not do this(!)**, even with sensible naming, because
+it will become a dumping ground for each attribute a test requires if it
+involves an admin user.
 
 Which leads me onto my final topic.
 
 ## Declarative factories
 
-Don't use named factories or traits, they're an antipattern\*. The admin user is again a good example where you might be tempted to use one of these. If your model is such that `isAdmin` boolean is all that is needed to make someone an admin then your test should be.
+Don't use named factories or traits, they're an antipattern\*. The admin user is
+again a good example where you might be tempted to use one of these. If your
+model is such that `isAdmin` boolean is all that is needed to make someone an
+admin then your test should be.
 
-<small>\* I think, I'm not really sure what an antipattern is, but humour me.</small>
+<small>\* I think, I'm not really sure what an antipattern is, but humour
+me.</small>
 
 ```js
 test('Admin users are taken to the dashboard on login', async function(assert) {
@@ -168,7 +266,15 @@ test('Admin users are taken to the dashboard on login', async function(assert) {
 });
 ```
 
-This declarative factory use is slightly longer than `make('admin_user')` (👈 named factory) or `make('user', 'isAdmin')` (👈 trait), but it's far superior, like the difference between Jon 💘 and Rob 💀. Yes both the named factory and the trait tell a reader that you're testing an admin (user), but the declarative factory version used here also tells the reader how a user becomes an admin, i.e. which properties are specifically important to adminship. Even if you require a few more attributes to become an admin, I would still recommend listing those attributes in the test, again informing any reader what attributes are related to becoming an admin.
+This declarative factory use is slightly longer than `make('admin_user')` (👈
+named factory) or `make('user', 'isAdmin')` (👈 trait), but it's far superior,
+like the difference between Jon 💘 and Rob 💀. Yes both the named factory and
+the trait tell a reader that you're testing an admin (user), but the declarative
+factory version used here also tells the reader how a user becomes an admin,
+i.e. which properties are specifically important to adminship. Even if you
+require a few more attributes to become an admin, I would still recommend
+listing those attributes in the test, again informing any reader what attributes
+are related to becoming an admin.
 
 ```js
 test('Admin users are taken to the dashboard on login', async function(assert) {
@@ -186,19 +292,43 @@ test('Admin users are taken to the dashboard on login', async function(assert) {
 });
 ```
 
-If this list becomes quite long and it is used in a lot of places, and I mean very long and _a lot_ of places, then maybe you could switch to a named factory or trait, but you would need to police it quite strictly and ensure that nothing else is added to that definition. What will happen is that developers add the attribute they need for their specific test to the definition, rather than writing it in the test, not realising that this attribute will now be created unneccessarily in all tests using this named factory or trait. This won't break those tests (usually), they'll be fine, but it leads to bloated factories and developers unaware of which attributes are strictly relevant to the test they're trying to fix.
+If this list becomes quite long and it is used in a lot of places, and I mean
+very long and _a lot_ of places, then maybe you could switch to a named factory
+or trait, but you would need to police it quite strictly and ensure that nothing
+else is added to that definition. What will happen is that developers add the
+attribute they need for their specific test to the definition, rather than
+writing it in the test, not realising that this attribute will now be created
+unneccessarily in all tests using this named factory or trait. This won't break
+those tests (usually), they'll be fine, but it leads to bloated factories and
+developers unaware of which attributes are strictly relevant to the test they're
+trying to fix.
 
 ## Don't use Mirage for tests - Ember bonus topic 🐹
 
-Let me premise this section by saying I have always been a Mirage fanboy. I have used it in a great number of my own personal projects for prototyping. I am not throwing shade at the project or any of it's creators/contributors. I simply have developed a strong opinion on where use of Mirage is appropriate. I prefer using [ember-data-factory-guy](https://github.com/danielspaniel/ember-data-factory-guy) (Factory Guy) in tests.
+Let me premise this section by saying I have always been a Mirage fanboy. I have
+used it in a great number of my own personal projects for prototyping. I am not
+throwing shade at the project or any of it's creators/contributors. I simply
+have developed a strong opinion on where use of Mirage is appropriate. I prefer
+using
+[ember-data-factory-guy](https://github.com/danielspaniel/ember-data-factory-guy)
+(Factory Guy) in tests.
 
 My arguments for not using Mirage:
 
 #### 1. Running a server for unit/integration tests
 
-In my opinion the main use for Mirage is as a rapid prototyping tool. It can also be used for testing, but by default, only testing in acceptance tests. Mirage provides you with a Javascript server that runs in the browser and intercepts API requests, responding to them before a network request is even made, either those requests made by your application in `dev` or those made during acceptance tests.
+In my opinion the main use for Mirage is as a rapid prototyping tool. It can
+also be used for testing, but by default, only testing in acceptance tests.
+Mirage provides you with a Javascript server that runs in the browser and
+intercepts API requests, responding to them before a network request is even
+made, either those requests made by your application in `dev` or those made
+during acceptance tests.
 
-If you want to use Mirage in testing, and you write more than acceptance tests then you will need to use a ['hack' or 'workaround'](http://www.ember-cli-mirage.com/versions/v0.4.x/manually-starting-mirage/) to manually start and stop the mirage server during integration and unit tests. And you definitely should be writing integration and unit tests.
+If you want to use Mirage in testing, and you write more than acceptance tests
+then you will need to use a
+['hack' or 'workaround'](http://www.ember-cli-mirage.com/versions/v0.4.x/manually-starting-mirage/)
+to manually start and stop the mirage server during integration and unit tests.
+And you definitely should be writing integration and unit tests.
 
 #### 2. Test Clarity
 
@@ -212,13 +342,23 @@ test('The page shows me all the foos', async function(assert) {
 
   await visit('/foos');
 
-  assert.equal(find('[data-test-foo]').length, 5, 'Five foos are shown on the page');
+  assert.equal(
+    find('[data-test-foo]').length,
+    5,
+    'Five foos are shown on the page',
+  );
 });
 ```
 
-It's not bad, we are at least following AAA, but there is a step that is unclear, between adding foos to the server and them appearing on the page. The details of that are contained in Mirage's config file. Take a look at the equivalent test with Factory Guy for the data and [Pretender](https://github.com/pretenderjs/pretender) for mocking API calls (Mirage uses this under the hood\*).
+It's not bad, we are at least following AAA, but there is a step that is
+unclear, between adding foos to the server and them appearing on the page. The
+details of that are contained in Mirage's config file. Take a look at the
+equivalent test with Factory Guy for the data and
+[Pretender](https://github.com/pretenderjs/pretender) for mocking API calls
+(Mirage uses this under the hood\*).
 
-<small>\*Factory Guy also uses pretender under the hood to mock API calls for certain helper functions that you can use with Factory Guy if you want.</small>
+<small>\*Factory Guy also uses pretender under the hood to mock API calls for
+certain helper functions that you can use with Factory Guy if you want.</small>
 
 ```js
 //acceptance/foo-index-test.js
@@ -232,11 +372,20 @@ test('The page shows me all the foos', async function(assert) {
 
   await visit('/foos');
 
-  assert.equal(find('[data-test-foo]').length, 5, 'Five foos are shown on the page');
+  assert.equal(
+    find('[data-test-foo]').length,
+    5,
+    'Five foos are shown on the page',
+  );
 });
 ```
 
-Here we're being a little more explicit in the test. Put yourself in the shoes of a junior developer. The Mirage test shows me _more_ Ember magic, even though they promised me there is a lot less magic now than there used to be in 2012. The factory test is more explicit, it tells us that visiting `/foos` url will trigger a `GET` request to `/api/foos` and we return a list of foos. It's a small difference but will help a junior to realise what
+Here we're being a little more explicit in the test. Put yourself in the shoes
+of a junior developer. The Mirage test shows me _more_ Ember magic, even though
+they promised me there is a lot less magic now than there used to be in 2012.
+The factory test is more explicit, it tells us that visiting `/foos` url will
+trigger a `GET` request to `/api/foos` and we return a list of foos. It's a
+small difference but will help a junior to realise what
 
 ```js
 model() {
@@ -248,9 +397,22 @@ is actually doing.
 
 #### 3. Duplication & Complexity
 
-Mirage builds a server, with a database and its own ORM (Object-Relational Mapping). This is quite a complex and interesting set up. Mirage attempts to extract away this complexity and provide you with a simple API in order to prototype and test, which it does quite well. Unfortunately one of the drawbacks of this complexity is that Mirage uses a system of factory and model files to generate your data for the server. The model files are used to declare relationships and the factory files used to create default values or fake data.
+Mirage builds a server, with a database and its own ORM (Object-Relational
+Mapping). This is quite a complex and interesting set up. Mirage attempts to
+extract away this complexity and provide you with a simple API in order to
+prototype and test, which it does quite well. Unfortunately one of the drawbacks
+of this complexity is that Mirage uses a system of factory and model files to
+generate your data for the server. The model files are used to declare
+relationships and the factory files used to create default values or fake data.
 
-Factory Guy doesn't need to have a model file because it is much simpler. It creates ember data models or JSON objects and returns them directly in tests without creating a server. Factory Guy therefore uses your app's model files along with its factory files and doesn't require any extra model files. Mirage creates its own set of models on the 'server' to return in API calls and be turned into ember data models by your app. The duplication and extra complexity may appear minor, but I have often spent serious time debugging Mirage when its ORM has not produced the data exactly how I expected.
+Factory Guy doesn't need to have a model file because it is much simpler. It
+creates ember data models or JSON objects and returns them directly in tests
+without creating a server. Factory Guy therefore uses your app's model files
+along with its factory files and doesn't require any extra model files. Mirage
+creates its own set of models on the 'server' to return in API calls and be
+turned into ember data models by your app. The duplication and extra complexity
+may appear minor, but I have often spent serious time debugging Mirage when its
+ORM has not produced the data exactly how I expected.
 
 ## Conclusion
 
@@ -258,4 +420,5 @@ I've been told it is always good to finish with a strong conclusion.
 
 ![Strong gif](/assets/images/posts/2018-12-20-factories-best-practices/strong.gif)
 
-I hope you enjoyed this post and will start using factories over fixtures and using named factories / traits more sparingly.
+I hope you enjoyed this post and will start using factories over fixtures and
+using named factories / traits more sparingly.

--- a/_posts/2019-02-08-ember-js-film-release.md
+++ b/_posts/2019-02-08-ember-js-film-release.md
@@ -5,28 +5,41 @@ github: mrmrcoleman
 twitter: mrmrcoleman
 topic: ember
 bio: 'Communications and Community Outreach Specialist'
-description: 'Mark Coleman announces the release of "Ember.js: The Documentary" in which simplabs is featured among other well-known figures from the Ember.js community.'
+description:
+  'Mark Coleman announces the release of "Ember.js: The Documentary" in which
+  simplabs is featured among other well-known figures from the Ember.js
+  community.'
 ---
 
-We're very pleased to announce that simplabs are featured in the new [HoneyPot](https://www.honeypot.io/) film **'Ember: A Mini Documentary'** that will premiere in Amsterdam this evening (2019-02-08).
+We're very pleased to announce that simplabs are featured in the new
+[HoneyPot](https://www.honeypot.io/) film **'Ember: A Mini Documentary'** that
+will premiere in Amsterdam this evening (2019-02-08).
 
-The film is a deep dive into the world of Ember.js and includes an interview with our CEO Marco Otte-Witte. After the screening there will also be a Q&A with Yehuda Katz & Special Guests!
+The film is a deep dive into the world of Ember.js and includes an interview
+with our CEO Marco Otte-Witte. After the screening there will also be a Q&A with
+Yehuda Katz & Special Guests!
 
 <!--break-->
 
-The premiere kicks off at 18:30 at [Pakhuis De Zwijger](https://dezwijger.nl/) and there are still a few spots available.
+The premiere kicks off at 18:30 at [Pakhuis De Zwijger](https://dezwijger.nl/)
+and there are still a few spots available.
 
 Here's the agenda from the meetup page:
 
 - 18.30 - 19.00: Doors open + drinks & snacks!
-- 19.00 - 19.15: Talk "From JavaScript Dabbler to Ember Book Author: My Journey" by Balint Erdi
+- 19.00 - 19.15: Talk "From JavaScript Dabbler to Ember Book Author: My Journey"
+  by Balint Erdi
 - 19.15 - 19.30: Intro from Yehuda Katz & documentary makers Honeypot
 - 19.30 - 20.00: Premiere of Ember.js: The Documentary
 - 20.00 - 20.30: Q&A with Yehuda Katz & special guests
 - 20.30 - 22.00: Networking with speakers & attendees
 
-Grab a spot while you still can: [https://www.meetup.com/de-DE/Honeypot_Amsterdam/events/258262410/](https://www.meetup.com/de-DE/Honeypot_Amsterdam/events/258262410/)
+Grab a spot while you still can:
+[https://www.meetup.com/de-DE/Honeypot_Amsterdam/events/258262410/](https://www.meetup.com/de-DE/Honeypot_Amsterdam/events/258262410/)
 
-We've seen a preview of the film and it looks fantastic! Unfortunately we can't be there in person but we'd like to thank HoneyPot for making this film and we hope the evening is a great success!
+We've seen a preview of the film and it looks fantastic! Unfortunately we can't
+be there in person but we'd like to thank HoneyPot for making this film and we
+hope the evening is a great success!
 
-Check the trailer here: [https://www.youtube.com/watch?v=V0AC3Z1WIcc](https://www.youtube.com/watch?v=V0AC3Z1WIcc)
+Check the trailer here:
+[https://www.youtube.com/watch?v=V0AC3Z1WIcc](https://www.youtube.com/watch?v=V0AC3Z1WIcc)

--- a/_posts/2019-02-11-ember-js-film-berlin.md
+++ b/_posts/2019-02-11-ember-js-film-berlin.md
@@ -5,12 +5,19 @@ github: mrmrcoleman
 twitter: mrmrcoleman
 topic: ember
 bio: 'Communications and Community Outreach Specialist'
-description: 'Mark Coleman announces the screening of "Ember.js: The Documentary" in Berlin, Feb. 11th 2019.'
+description:
+  'Mark Coleman announces the screening of "Ember.js: The Documentary" in
+  Berlin, Feb. 11th 2019.'
 ---
 
-Following on from last week's premiere in Amsterdam the new [HoneyPot](https://www.honeypot.io/) film **'Ember: A Mini Documentary'** will be shown in Berlin this evening (2019-02-11).
+Following on from last week's premiere in Amsterdam the new
+[HoneyPot](https://www.honeypot.io/) film **'Ember: A Mini Documentary'** will
+be shown in Berlin this evening (2019-02-11).
 
-The film is a deep dive into the world of Ember.js and includes an interview with our CEO Marco Otte-Witte. After the screening Jessica Jordan from simplabs will present '**Everything They Didn't Tell You About the Ember Community'** which will be followed by a Q&A.
+The film is a deep dive into the world of Ember.js and includes an interview
+with our CEO Marco Otte-Witte. After the screening Jessica Jordan from simplabs
+will present '**Everything They Didn't Tell You About the Ember Community'**
+which will be followed by a Q&A.
 
 <!--break-->
 
@@ -21,11 +28,15 @@ Here's the agenda from the meetup page:
 - 18.30 - 19.00: Doors open + drinks & snacks!
 - 19.00 - 19.15: Intro from documentary makers Honeypot
 - 19.15 - 19.45: Screening of Ember.js: The Documentary
-- 19.45 - 20.15: Jessica Jordan: Everything They Didn't Tell You About the Ember Community (+Q&A)
+- 19.45 - 20.15: Jessica Jordan: Everything They Didn't Tell You About the Ember
+  Community (+Q&A)
 - 20.15 - 22.00: Networking, mingling, drinking and partying.
 
-Grab a spot while you still can: [https://www.meetup.com/Honeypot_Berlin/events/258352778/](https://www.meetup.com/Honeypot_Berlin/events/258352778/)
+Grab a spot while you still can:
+[https://www.meetup.com/Honeypot_Berlin/events/258352778/](https://www.meetup.com/Honeypot_Berlin/events/258352778/)
 
-Check the trailer here: [https://www.youtube.com/watch?v=V0AC3Z1WIcc](https://www.youtube.com/watch?v=V0AC3Z1WIcc)
+Check the trailer here:
+[https://www.youtube.com/watch?v=V0AC3Z1WIcc](https://www.youtube.com/watch?v=V0AC3Z1WIcc)
 
-We'd like to thank HoneyPot for making this film and we hope the evening is a great success!
+We'd like to thank HoneyPot for making this film and we hope the evening is a
+great success!

--- a/_posts/2019-03-07-march-monthly-update.md
+++ b/_posts/2019-03-07-march-monthly-update.md
@@ -5,10 +5,14 @@ github: mrmrcoleman
 twitter: mrmrcoleman
 topic: simplabs
 bio: 'Communications and Community Outreach Specialist'
-description: 'Mark Coleman shares simplabs'' monthly update for March 2019, covering EmberConf 2019, the release of "Ember.js: The Documentary" and various upcoming events.'
+description:
+  'Mark Coleman shares simplabs'' monthly update for March 2019, covering
+  EmberConf 2019, the release of "Ember.js: The Documentary" and various
+  upcoming events.'
 ---
 
-Welcome to our new monthly update. Each month we'll cover the events and activities that have been happening at simplabs. Enjoy.
+Welcome to our new monthly update. Each month we'll cover the events and
+activities that have been happening at simplabs. Enjoy.
 
 <!--break-->
 
@@ -16,48 +20,92 @@ Welcome to our new monthly update. Each month we'll cover the events and activit
 
 #### Ricardo Mendes from the Ember.js Core Team joins simplabs
 
-We're very excited to announce that [Ricardo Mendes](https://twitter.com/locks) from the Ember.js core team has joined simplabs.
+We're very excited to announce that [Ricardo Mendes](https://twitter.com/locks)
+from the Ember.js core team has joined simplabs.
 
-Before Ricardo joined the team we were pleased to sponsor him through the Ember.js sponsorship program. Chris Manson spent his 20% time pairing with Ricardo on [Guidemaker](https://github.com/empress/guidemaker) to add features to help the Ember Octane documentation process and released a 1.0 of Guidemaker.
+Before Ricardo joined the team we were pleased to sponsor him through the
+Ember.js sponsorship program. Chris Manson spent his 20% time pairing with
+Ricardo on [Guidemaker](https://github.com/empress/guidemaker) to add features
+to help the Ember Octane documentation process and released a 1.0 of Guidemaker.
 
-Our CEO Marco says _"We are very excited to welcome Ricardo Mendes to simplabs. Being a long-term member of the Ember Core Team, we have been in touch with him for years already. His deep knowledge and teaching ability will be hugely beneficial for our clients."_
+Our CEO Marco says _"We are very excited to welcome Ricardo Mendes to simplabs.
+Being a long-term member of the Ember Core Team, we have been in touch with him
+for years already. His deep knowledge and teaching ability will be hugely
+beneficial for our clients."_
 
 #### EmberConf 2019
 
 ![EmberConf 2019](/assets/images/posts/2019-03-07-march-monthly-update/emberconf-logo.png)
 
-[EmberConf 2019](https://emberconf.com/) in Portland starts on March 18th and we're proud to be sponsoring the event. We'll also be taking some members of the team along.
+[EmberConf 2019](https://emberconf.com/) in Portland starts on March 18th and
+we're proud to be sponsoring the event. We'll also be taking some members of the
+team along.
 
-Ricardo Mendes will host a [Contributors Workshop](https://emberconf.com/schedule.html#contributors-workshop) along with [Jen Weber](https://twitter.com/jwwweber) from [BioBright](https://twitter.com/biobright_org).
+Ricardo Mendes will host a
+[Contributors Workshop](https://emberconf.com/schedule.html#contributors-workshop)
+along with [Jen Weber](https://twitter.com/jwwweber) from
+[BioBright](https://twitter.com/biobright_org).
 
-Also, [Jessica Jordan](https://twitter.com/jjordan_dev) will be giving a talk about [Crafting Web Comics in Ember](https://emberconf.com/speakers.html#jessica-jordan) which promises to be a very fun and informative talk.
+Also, [Jessica Jordan](https://twitter.com/jjordan_dev) will be giving a talk
+about
+[Crafting Web Comics in Ember](https://emberconf.com/speakers.html#jessica-jordan)
+which promises to be a very fun and informative talk.
 
-If you're attending EmberConf 2019 and would like to speak to us about our work, please [please get in touch.](/contact/)
+If you're attending EmberConf 2019 and would like to speak to us about our work,
+please [please get in touch.](/contact/)
 
 #### Ember.js film premiere
 
 ![Ember.js - The Documentary](/assets/images/posts/2019-03-07-march-monthly-update/emberjs-documentary.png)
 
-We are very pleased that our CEO Marco Otte-Witte was featured alongside Ember.js co-creators [Yahuda Katz](https://twitter.com/wycats) and [Tom Dale](https://twitter.com/tomdale) in HoneyPot's new film ["Ember.js - The Documentary"](https://www.youtube.com/watch?v=Cvz-9ccflKQ)!
+We are very pleased that our CEO Marco Otte-Witte was featured alongside
+Ember.js co-creators [Yahuda Katz](https://twitter.com/wycats) and
+[Tom Dale](https://twitter.com/tomdale) in HoneyPot's new film
+["Ember.js - The Documentary"](https://www.youtube.com/watch?v=Cvz-9ccflKQ)!
 
-The film was premiered at meetups across Europe and we'd like to thank [Honeypot](https://twitter.com/honeypotio) for putting it together.
+The film was premiered at meetups across Europe and we'd like to thank
+[Honeypot](https://twitter.com/honeypotio) for putting it together.
 
 ## Events
 
-_We're always interested in new speakers for the various meetups we're involved in. If you'd like to give a talk, [please get in touch.](/contact/)_
+_We're always interested in new speakers for the various meetups we're involved
+in. If you'd like to give a talk, [please get in touch.](/contact/)_
 
 #### Upcoming events
 
-simplabs are involved in two upcoming meetups this month. On March 28th [Chris Manson](https://www.twitter.com/real_ate) will be reviving the Ember.js Dublin meetup with an Ember Octane Workshop at the [Intercom](https://twitter.com/intercom) offices. Register [here](https://www.meetup.com/emberjsdublin/events/259356879/).
+simplabs are involved in two upcoming meetups this month. On March 28th
+[Chris Manson](https://www.twitter.com/real_ate) will be reviving the Ember.js
+Dublin meetup with an Ember Octane Workshop at the
+[Intercom](https://twitter.com/intercom) offices. Register
+[here](https://www.meetup.com/emberjsdublin/events/259356879/).
 
-On the same day in Munich [Marco](https://twitter.com/marcoow) is hosting the Elixir Munich meetup with talks from [Peer Stritzinger](https://twitter.com/peerstr), [Philipp Neugebauer](https://twitter.com/ppneugebauer) and Sami Buzz. Sign up on the meetup page [here](https://www.meetup.com/Elixir-Munich/events/259526263/).
+On the same day in Munich [Marco](https://twitter.com/marcoow) is hosting the
+Elixir Munich meetup with talks from
+[Peer Stritzinger](https://twitter.com/peerstr),
+[Philipp Neugebauer](https://twitter.com/ppneugebauer) and Sami Buzz. Sign up on
+the meetup page [here](https://www.meetup.com/Elixir-Munich/events/259526263/).
 
 #### Past Events
 
-February was a busy month for events. Jessica gave a talk at [c't webdev](https://twitter.com/ct_webdev) where she spoke about [Crafting Web Comics in Ember](https://ctwebdev.de/programm.html#slot-21). Also, Jessica is co-organized [Ember.js Berlin](https://www.meetup.com/Ember-js-Berlin/events/258984499/) on March 5th with [Rami Al-Rihawi](https://twitter.com/rrihawi_) and [Isaac Ezer](https://twitter.com/isaacezer).
+February was a busy month for events. Jessica gave a talk at
+[c't webdev](https://twitter.com/ct_webdev) where she spoke about
+[Crafting Web Comics in Ember](https://ctwebdev.de/programm.html#slot-21). Also,
+Jessica is co-organized
+[Ember.js Berlin](https://www.meetup.com/Ember-js-Berlin/events/258984499/) on
+March 5th with [Rami Al-Rihawi](https://twitter.com/rrihawi_) and
+[Isaac Ezer](https://twitter.com/isaacezer).
 
-Marco ran the [February Ember.js meetup](https://www.meetup.com/Ember-js-Munich/events/258726028/) featuring [Toon Verwaest](https://twitter.com/tverwaes) and [Michael Klein](https://twitter.com/LevelbossMike).
+Marco ran the
+[February Ember.js meetup](https://www.meetup.com/Ember-js-Munich/events/258726028/)
+featuring [Toon Verwaest](https://twitter.com/tverwaes) and
+[Michael Klein](https://twitter.com/LevelbossMike).
 
-[Tobias Bieniek](https://twitter.com/tobiasbieniek) asked the question [_Help! How do you let others know what’s going on when you’re 8000 feet up in the air in a plane without an engine?!_](http://bangbangcon.com/west/speakers/#tobias-bieniek) at [!!Con West](https://twitter.com/bangbangconwest).
+[Tobias Bieniek](https://twitter.com/tobiasbieniek) asked the question
+[_Help! How do you let others know what’s going on when you’re 8000 feet up in the air in a plane without an engine?!_](http://bangbangcon.com/west/speakers/#tobias-bieniek)
+at [!!Con West](https://twitter.com/bangbangconwest).
 
-Finally, [Chris Manson](https://twitter.com/real_ate) co-organized the [DublinJS meetup](https://www.meetup.com/DublinJS/events/fbllfpyzfbhb/) at [Workday](https://twitter.com/workday) with with [Gabriel Costa](https://twitter.com/gcgoncalves) and [Luciano Mammino](https://twitter.com/loige).
+Finally, [Chris Manson](https://twitter.com/real_ate) co-organized the
+[DublinJS meetup](https://www.meetup.com/DublinJS/events/fbllfpyzfbhb/) at
+[Workday](https://twitter.com/workday) with with
+[Gabriel Costa](https://twitter.com/gcgoncalves) and
+[Luciano Mammino](https://twitter.com/loige).

--- a/_posts/2019-03-13-elixir-umbrella-mox.md
+++ b/_posts/2019-03-13-elixir-umbrella-mox.md
@@ -5,7 +5,9 @@ github: niklaslong
 twitter: niklas_long
 topic: elixir
 bio: 'Backend Engineer, author of Breethe API'
-description: 'Niklas Long shows how Elixir Umbrella applications not only improve the organization of a code base but also allow for an improved testing setup.'
+description:
+  'Niklas Long shows how Elixir Umbrella applications not only improve the
+  organization of a code base but also allow for an improved testing setup.'
 ---
 
 What's the big deal with Elixir umbrellas?
@@ -33,9 +35,9 @@ raise awareness by providing everyone with easy access to accurate data.
 
 ![Video of the Breethe PWA](/assets/images/posts/2018-07-24-from-spa-to-pwa/breethe-video.gif)
 
-The application is [open source](https://github.com/simplabs/breethe-server)
-and we encourage everyone interested to look through the source for reference.
-The server for this application was implemented using an
+The application is [open source](https://github.com/simplabs/breethe-server) and
+we encourage everyone interested to look through the source for reference. The
+server for this application was implemented using an
 [Elixir](https://elixir-lang.org) umbrella application which will be the focus
 of this post. The client for Breethe was built with
 [Glimmer.js](http://glimmerjs.com), which we discussed in previous posts:
@@ -55,8 +57,8 @@ use an umbrella app will make the process tremendously easy.
 Using an umbrella allowed us to split our server into two very distinct
 applications, communicating together by way of rigorously defined APIs. The
 first application functions as the data handling entity of the project - named
-_breethe_ (see below). It communicates with the air quality data provider
-(a third-party API) to gather the data, then processes and caches it for future
+_breethe_ (see below). It communicates with the air quality data provider (a
+third-party API) to gather the data, then processes and caches it for future
 use. The second application in the umbrella is the web interface built with
 Phoenix - named _breethe_web_. It requests the data from the first application,
 serializes it to JSON and delivers the payload to the client in compliance with
@@ -90,10 +92,10 @@ continues to implement the same interface. The same would work the other way
 round if we wanted to change the webserver.
 
 However, for this approach to work well, the APIs used to communicate between
-the different applications in the umbrella need to be carefully defined. We
-want to keep the interfaces as little as possible to keep complexity contained.
-As an example, here are the publicly available functions on the _breethe_ app
-in the umbrella:
+the different applications in the umbrella need to be carefully defined. We want
+to keep the interfaces as little as possible to keep complexity contained. As an
+example, here are the publicly available functions on the _breethe_ app in the
+umbrella:
 
 ```elixir
 # apps/breethe/lib/breethe.ex
@@ -108,20 +110,20 @@ def search_measurements(location_id), do: # ...
 
 Equally, these are the only functions the Phoenix web app (or any other app in
 the umbrella) can call on the _breethe_ app. These principles are of course not
-only applicable at the top level of the application but also within its
-internal logical contexts. For example, within the _breethe_ app, we have
-isolated the functions explicitly making requests to third-party APIs and
-abstracted them away behind an interface. This, again, reduces complexity and
-facilitates testing as we can isolate the different components of the business
-logic. This philosophy lends itself very well to being tested using Mox.
+only applicable at the top level of the application but also within its internal
+logical contexts. For example, within the _breethe_ app, we have isolated the
+functions explicitly making requests to third-party APIs and abstracted them
+away behind an interface. This, again, reduces complexity and facilitates
+testing as we can isolate the different components of the business logic. This
+philosophy lends itself very well to being tested using Mox.
 
 ## Testing domains independently using Mox
 
 [Mox](https://github.com/plataformatec/mox), as the name suggests, is a library
 that defines mocks bound to specific behaviours. A behaviour is a set of
-function signatures that must be implemented by a module. Consequently,
-Mox guarantees the mocks for a module be consistent with the original functions
-they replace during testing. This rigidity makes the tests more maintainable and
+function signatures that must be implemented by a module. Consequently, Mox
+guarantees the mocks for a module be consistent with the original functions they
+replace during testing. This rigidity makes the tests more maintainable and
 requires that the behaviours for each module be meticulously defined; precisely
 the qualities desired when implementing the APIs within our umbrella.
 
@@ -175,8 +177,8 @@ switches to the `Breethe.Mock` module, which defines the mocks.
 The test for this controller action is meant to check two things. Firstly, that
 the router redirects the connection to the appropriate controller action.
 Secondly, that the controller action processes the call and queries the
-_breethe_ application correctly using the right function defined on the
-latter's API - in this case `get_location(location_id)`.
+_breethe_ application correctly using the right function defined on the latter's
+API - in this case `get_location(location_id)`.
 
 ```elixir
 # apps/breethe_web/test/breethe_web/controllers/location_controller_test.exs
@@ -200,17 +202,18 @@ end
 
 I've broken it down into its four main parts:
 
-1. It sets up the test data with [ExMachina](https://github.com/thoughtbot/ex_machina). <br/><br/>
+1. It sets up the test data with
+   [ExMachina](https://github.com/thoughtbot/ex_machina). <br/><br/>
 
 ```elixir
 location = insert(:location, measurements: [])
 ```
 
 2. It defines a mock in the `Breethe.Mock` module for the
-   `get_location(location_id)` function defined in the _breethe_ application's API
-   and sets the return value to the location we created at 1. The mock is passed
-   as an argument to the `expect` clause which verifies the mock is executed
-   during the test (instead of the real function). <br/><br/>
+   `get_location(location_id)` function defined in the _breethe_ application's
+   API and sets the return value to the location we created at 1. The mock is
+   passed as an argument to the `expect` clause which verifies the mock is
+   executed during the test (instead of the real function). <br/><br/>
 
 ```elixir
 Breethe.Mock
@@ -218,9 +221,9 @@ Breethe.Mock
 ```
 
 As long as we’ve established the callback in the behaviour implemented by the
-Breethe module, we don’t need to explicitly define the Breethe.Mock module
-(Mox creates it). Here's the callback for this particular function
-(for reference, it isn't coded in the test).
+Breethe module, we don’t need to explicitly define the Breethe.Mock module (Mox
+creates it). Here's the callback for this particular function (for reference, it
+isn't coded in the test).
 
 ```elixir
 # apps/breethe/lib/breethe.ex
@@ -237,7 +240,8 @@ conn = get(build_conn(), "api/locations/#{location.id}", [])
 ```
 
 4. It tests the JSON response (abridged for brevity) is correct by asserting on
-   the attributes of the location created in 1. and returned from the mock in 2. <br/><br/>
+   the attributes of the location created in 1. and returned from the mock in 2.
+   <br/><br/>
 
 ```elixir
 assert json_response(conn, 200) == %{
@@ -247,10 +251,10 @@ assert json_response(conn, 200) == %{
         }
 ```
 
-Using mocks greatly simplifies the testing process. Each test can be smaller
-and more specific. Each test is faster as we are not making calls to the
-database or external systems; we are only running the anonymous functions that
-define the mocks. For instance, the mock in our example above only executes:
+Using mocks greatly simplifies the testing process. Each test can be smaller and
+more specific. Each test is faster as we are not making calls to the database or
+external systems; we are only running the anonymous functions that define the
+mocks. For instance, the mock in our example above only executes:
 
 ```elixir
 fn _location_id -> location end
@@ -262,12 +266,11 @@ fast and modularised tests.
 
 ## Conclusion
 
-Elixir umbrella apps shine when structuring projects containing clear
-boundaries between their constituent parts. The philosophy they implement
-deeply resembles that of functional programming (and Lego), where small
-building blocks combine into a larger whole. It is however important to be
-precise when defining the internal APIs of the application as they act as the
-glue holding everything together. Lastly, Mox is a wonderful tool for testing.
-Not only does it make mocking APIs very simple and elegant, it also encourages
-best practices such as defining behaviours to keep the code consistent and
-robust.
+Elixir umbrella apps shine when structuring projects containing clear boundaries
+between their constituent parts. The philosophy they implement deeply resembles
+that of functional programming (and Lego), where small building blocks combine
+into a larger whole. It is however important to be precise when defining the
+internal APIs of the application as they act as the glue holding everything
+together. Lastly, Mox is a wonderful tool for testing. Not only does it make
+mocking APIs very simple and elegant, it also encourages best practices such as
+defining behaviours to keep the code consistent and robust.

--- a/_posts/2019-03-18-emberconf-update.md
+++ b/_posts/2019-03-18-emberconf-update.md
@@ -5,7 +5,9 @@ github: mrmrcoleman
 twitter: mrmrcoleman
 topic: simplabs
 bio: 'Communications and Community Outreach Specialist'
-description: "Mark Coleman gives an update on the simplabs team's presence at EmberConf 2019 and our involvement with many events at and around the conference."
+description:
+  "Mark Coleman gives an update on the simplabs team's presence at EmberConf
+  2019 and our involvement with many events at and around the conference."
 ---
 
 We mentioned this in our March monthly update but in case you missed it, here's
@@ -16,8 +18,8 @@ how we're involved in EmberConf 2019.
 ![EmberConf 2019](/assets/images/posts/2019-03-07-march-monthly-update/emberconf-logo.png)
 
 [EmberConf 2019](https://emberconf.com/) in Portland starts on March 18th and
-we're proud to be sponsoring the event. We'll also be taking some members of
-the team along.
+we're proud to be sponsoring the event. We'll also be taking some members of the
+team along.
 
 Ricardo Mendes will host a
 [Contributors Workshop](https://emberconf.com/schedule.html#contributors-workshop)
@@ -31,7 +33,7 @@ which promises to be a very fun and informative talk.
 Lastly, [Chris Manson](https://twitter.com/real_ate) will be giving a lightning
 talk about [empress-blog](https://github.com/empress/empress-blog).
 
-If you're attending EmberConf 2019 and would like to speak to us about our
-work, please [get in touch.](/contact/)
+If you're attending EmberConf 2019 and would like to speak to us about our work,
+please [get in touch.](/contact/)
 
 See you there!

--- a/_posts/2019-03-29-qonto-project.md
+++ b/_posts/2019-03-29-qonto-project.md
@@ -5,12 +5,15 @@ github: mrmrcoleman
 twitter: mrmrcoleman
 topic: simplabs
 bio: 'Communications and Community Outreach Specialist'
-description: 'Mark Coleman announces our new client Qonto, a Paris based VC funded Fintech startup who are "the ideal banking alternative for freelancers, startups and SMEs."'
+description:
+  'Mark Coleman announces our new client Qonto, a Paris based VC funded Fintech
+  startup who are "the ideal banking alternative for freelancers, startups and
+  SMEs."'
 ---
 
-We're very pleased to announce that we've started working with [Qonto](https://qonto.eu/),
-a Paris based VC funded Fintech startup who are "the ideal banking alternative
-for freelancers, startups and SMEs."
+We're very pleased to announce that we've started working with
+[Qonto](https://qonto.eu/), a Paris based VC funded Fintech startup who are "the
+ideal banking alternative for freelancers, startups and SMEs."
 
 <!--break-->
 
@@ -26,17 +29,19 @@ and guide new development initiatives while establishing best practices and
 transferring knowledge to in-house engineers on the job via reviews and pairing
 sessions.
 
-Just as with previous Team Augmentation projects like [trainline](/cases/trainline/) this
-approach brings "double value for the client" says simlpabs CEO Marco
-Otte-Witte, "short term value is added by the client immediately gaining more
-engineering power, but additional long term value is added through improved
-architecture, code quality, processes and leveled up in-house engineers."
+Just as with previous Team Augmentation projects like
+[trainline](/cases/trainline/) this approach brings "double value for the
+client" says simlpabs CEO Marco Otte-Witte, "short term value is added by the
+client immediately gaining more engineering power, but additional long term
+value is added through improved architecture, code quality, processes and
+leveled up in-house engineers."
 
 simplabs engineers Tobias Bieniek and Ricardo Mendes who are both Ember.js core
 members are working on the Qonto project. They started by analyzing Qonto's code
 and found the templates were using the rather antiquated Emblem.js which nobody
 was really happy with but was difficult to migrate away from. To tackle this
-Tobias created and open sourced [emblem-migrator](https://github.com/simplabs/emblem-migrator/) which Qonto and
+Tobias created and open sourced
+[emblem-migrator](https://github.com/simplabs/emblem-migrator/) which Qonto and
 all other Emblem.js users can now use.
 
 Next simplabs engineers identified that Qonto's test suite speed was impeding

--- a/_posts/2019-04-05-april-monthly-update.md
+++ b/_posts/2019-04-05-april-monthly-update.md
@@ -5,10 +5,14 @@ github: mrmrcoleman
 twitter: mrmrcoleman
 topic: simplabs
 bio: 'Communications and Community Outreach Specialist'
-description: "Mark Coleman shares simplabs' monthly update for April 2019, covering new joiners, new clients and a number of upcoming events."
+description:
+  "Mark Coleman shares simplabs' monthly update for April 2019, covering new
+  joiners, new clients and a number of upcoming events."
 ---
 
-Welcome to the second installment of our monthly update. Each month we cover the events and activities that have been happening at simplabs along with the things we're looking forward to. Enjoy.
+Welcome to the second installment of our monthly update. Each month we cover the
+events and activities that have been happening at simplabs along with the things
+we're looking forward to. Enjoy.
 
 <!--break-->
 
@@ -16,37 +20,61 @@ Welcome to the second installment of our monthly update. Each month we cover the
 
 #### Florian Pichler joins simplabs
 
-We're very excited to announce that [Florian Pichler](https://twitter.com/pichfl/) has joined simplabs.
+We're very excited to announce that
+[Florian Pichler](https://twitter.com/pichfl/) has joined simplabs.
 
-Florian’s career has varied from user interfaces and print design to frontend development but what ties his entire career together is a strong focus on user experience.
+Florian’s career has varied from user interfaces and print design to frontend
+development but what ties his entire career together is a strong focus on user
+experience.
 
-He has a wealth of experience doing consulting work around new technologies and both native and web-based apps. In this work he has helped to shape, design and bring to life projects for Audi, BMW, Microsoft, Zurich Insurance Group and many more.
+He has a wealth of experience doing consulting work around new technologies and
+both native and web-based apps. In this work he has helped to shape, design and
+bring to life projects for Audi, BMW, Microsoft, Zurich Insurance Group and many
+more.
 
-Florian also speaks at events about design and development and is also a maintainer for [BookPlayer](https://github.com/TortugaPower/BookPlayer), a free and open source iOS app for audiobooks.
+Florian also speaks at events about design and development and is also a
+maintainer for [BookPlayer](https://github.com/TortugaPower/BookPlayer), a free
+and open source iOS app for audiobooks.
 
-Our CEO Marco says _"I'm very happy to have Florian on board. His expertise in both the engineering and design fields as well as experience working with big corporate clients make him a valuable addition to the team and will allow us to bring more value to simplabs clients in the future."_
+Our CEO Marco says _"I'm very happy to have Florian on board. His expertise in
+both the engineering and design fields as well as experience working with big
+corporate clients make him a valuable addition to the team and will allow us to
+bring more value to simplabs clients in the future."_
 
 #### simplabs welcomes new client Qonto
 
 ![Qonto Logo](/assets/images/posts/2019-03-29-qonto-project/qonto-logo.png)
 
-Equally as exciting is our new client Qonto, a Paris based VC funded Fintech startup who are “the ideal banking alternative for freelancers, startups and SMEs.”
+Equally as exciting is our new client Qonto, a Paris based VC funded Fintech
+startup who are “the ideal banking alternative for freelancers, startups and
+SMEs.”
 
-Qonto reached out to simplabs looking for a combination of added engineering power and outside expertise to help their in-house engineers improve. We call this [Team Augmentation](/services/team-augmentation/) and you can read the full annoucement [here](/blog/2019/03/29/qonto-project/).
+Qonto reached out to simplabs looking for a combination of added engineering
+power and outside expertise to help their in-house engineers improve. We call
+this [Team Augmentation](/services/team-augmentation/) and you can read the full
+annoucement [here](/blog/2019/03/29/qonto-project/).
 
 #### Other news
 
-[Chris Manson](https://twitter.com/real_ate) was on the Ember Weekend podcast talking about [Empress](https://github.com/hodgesmr/Empress). Listen to the full show here: [https://emberweekend.com/episodes/empress-the-ember-press](https://emberweekend.com/episodes/empress-the-ember-press)
+[Chris Manson](https://twitter.com/real_ate) was on the Ember Weekend podcast
+talking about [Empress](https://github.com/hodgesmr/Empress). Listen to the full
+show here:
+[https://emberweekend.com/episodes/empress-the-ember-press](https://emberweekend.com/episodes/empress-the-ember-press)
 
-Also, [Niklas Long](https://twitter.com/niklas_long) put out a well received blog post about Elixir Umbrella Applications and testing with Mox [here](/blog/2019/03/13/elixir-umbrella-mox/).
+Also, [Niklas Long](https://twitter.com/niklas_long) put out a well received
+blog post about Elixir Umbrella Applications and testing with Mox
+[here](/blog/2019/03/13/elixir-umbrella-mox/).
 
 ## Upcoming Events
 
-_We're always interested in new speakers for the various meetups we're involved in. If you'd like to give a talk, [please get in touch.](/contact/)_
+_We're always interested in new speakers for the various meetups we're involved
+in. If you'd like to give a talk, [please get in touch.](/contact/)_
 
 #### simplabs sponsors ElixirConfEU 2019
 
-We're very pleased to be sponsoring [ElixirConfEU](http://www.elixirconf.eu/) which is starting in Prague on the 8th of April. We've sent over a load of simplabs stickers, so grab one while you can.
+We're very pleased to be sponsoring [ElixirConfEU](http://www.elixirconf.eu/)
+which is starting in Prague on the 8th of April. We've sent over a load of
+simplabs stickers, so grab one while you can.
 
 ![ElixirConfEU 2019](/assets/images/posts/2019-04-05-april-monthly-update/elixir-conf-stickers.jpg)
 
@@ -54,22 +82,40 @@ We're very pleased to be sponsoring [ElixirConfEU](http://www.elixirconf.eu/) wh
 
 ![EmberFestEU](/assets/images/posts/2019-04-05-april-monthly-update/ember-fest-logo.png)
 
-Also, we've been busy behind the scenes getting ready for this year's [EmberFestEU](https://emberfest.eu/). We have booked the venue and will announce the host city soon - there are some hints on the website already though so go see whether you can find them. Early bird tickets are going on sale soon so keep an eye on the [twitter](https://twitter.com/EmberFest) for more news as well.
+Also, we've been busy behind the scenes getting ready for this year's
+[EmberFestEU](https://emberfest.eu/). We have booked the venue and will announce
+the host city soon - there are some hints on the website already though so go
+see whether you can find them. Early bird tickets are going on sale soon so keep
+an eye on the [twitter](https://twitter.com/EmberFest) for more news as well.
 
 #### Meetups
 
-The next DublinJS meetup, taking place in May and hosted by Chris Manson, is already [online](https://www.meetup.com/DublinJS/events/fbllfpyzhbkb/). Speakers to follow soon.
+The next DublinJS meetup, taking place in May and hosted by Chris Manson, is
+already [online](https://www.meetup.com/DublinJS/events/fbllfpyzhbkb/). Speakers
+to follow soon.
 
-The next Ember.js Dublin meetup will take place on April 18th will be an Ember Contributor workshop. Chris Manson will be running a "workshop to get you started contributing to one of the many Ember projects". Details [here](https://www.meetup.com/emberjsdublin/events/260148921/).
+The next Ember.js Dublin meetup will take place on April 18th will be an Ember
+Contributor workshop. Chris Manson will be running a "workshop to get you
+started contributing to one of the many Ember projects". Details
+[here](https://www.meetup.com/emberjsdublin/events/260148921/).
 
 ## Past Events
 
 #### EmberConf 2019
 
-simplabs sent a group of people to EmberConf2019 in Portland where Ricardo Mendes hosted a contributor workshop and [Jessica Jordan](https://twitter.com/jjordan_dev) gave a talk about Crafting Web Comics in Ember.
+simplabs sent a group of people to EmberConf2019 in Portland where Ricardo
+Mendes hosted a contributor workshop and
+[Jessica Jordan](https://twitter.com/jjordan_dev) gave a talk about Crafting Web
+Comics in Ember.
 
 ![EmberConf2019 Team Photo](/assets/images/posts/2019-04-05-april-monthly-update/ember-conf-team-photo.jpg)
 
 #### Meetups
 
-And last but not least, Marco hosted [Elixir Munich](https://www.meetup.com/Elixir-Munich/events/259526263/), Chris hosted [Ember.js Dublin](https://twitter.com/emberjsdublin/status/1101080708662132736) and [DublinJS](https://www.meetup.com/DublinJS/events/fbllfpyzgbdb/) and Jessica hosted [Ember.js Berlin!](https://www.meetup.com/Ember-js-Berlin/events/258984499/)
+And last but not least, Marco hosted
+[Elixir Munich](https://www.meetup.com/Elixir-Munich/events/259526263/), Chris
+hosted
+[Ember.js Dublin](https://twitter.com/emberjsdublin/status/1101080708662132736)
+and [DublinJS](https://www.meetup.com/DublinJS/events/fbllfpyzgbdb/) and Jessica
+hosted
+[Ember.js Berlin!](https://www.meetup.com/Ember-js-Berlin/events/258984499/)

--- a/_posts/2019-04-05-spas-pwas-and-ssr.md
+++ b/_posts/2019-04-05-spas-pwas-and-ssr.md
@@ -5,17 +5,18 @@ github: marcoow
 twitter: marcoow
 topic: javascript
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte dives deep into different approaches for building web apps like SPAs, PWAs, SSR and how they all can be combined for the best result.'
+description:
+  'Marco Otte-Witte dives deep into different approaches for building web apps
+  like SPAs, PWAs, SSR and how they all can be combined for the best result.'
 og:
   image: /assets/images/posts/2019-04-05-spas-pwas-and-ssr/og-image.png
 ---
 
-Single Page Apps, Progressive Web Apps and classic Server side rendered
-websites are often seen as orthogonal approaches to building web apps where
-only one is best suited for a particular project and one has to make a choice
-to go with one of them. In this post we'll explore why that doesn't have to be
-the case, since all 3 approaches can actually be combined in order to achieve
-the best result.
+Single Page Apps, Progressive Web Apps and classic Server side rendered websites
+are often seen as orthogonal approaches to building web apps where only one is
+best suited for a particular project and one has to make a choice to go with one
+of them. In this post we'll explore why that doesn't have to be the case, since
+all 3 approaches can actually be combined in order to achieve the best result.
 
 <!--break-->
 
@@ -24,21 +25,21 @@ the best result.
 Modern websites are in many cases not really websites anymore, but in fact full
 blown apps with desktop-grade feature sets and user experiences that happen to
 run in a browser as opposed to standalone apps. While the much-loved
-[Spacejam Website](https://www.spacejam.com/archive/spacejam/movie/jam.htm)
-was a pretty standard page in terms of interactivity and design only about 2
-decades ago
+[Spacejam Website](https://www.spacejam.com/archive/spacejam/movie/jam.htm) was
+a pretty standard page in terms of interactivity and design only about 2 decades
+ago
 
 ![Screenshot of the Spacejam Website](/assets/images/posts/2019-03-16-spas-pwas-and-ssr/spacejam.png#@600-1200)
 
-we can now go to [Google Maps](https://www.google.com/maps), zoom and rotate
-the earth in 3D space, measure distances between arbitrary points and have a
-look at our neighbor's backyard:
+we can now go to [Google Maps](https://www.google.com/maps), zoom and rotate the
+earth in 3D space, measure distances between arbitrary points and have a look at
+our neighbor's backyard:
 
 ![Video of Google Maps](/assets/images/posts/2019-03-16-spas-pwas-and-ssr/maps.gif)
 
 All of this functionality, interactivity and visual appeal comes at a cost
-though, mainly in the the form of JavaScript code. The median size of
-JavaScript used on pages across the Internet is now
+though, mainly in the the form of JavaScript code. The median size of JavaScript
+used on pages across the Internet is now
 [ca. 400KB on the desktop and ca. 360KB on mobile devices](https://httparchive.org/reports/state-of-javascript),
 an increase of ca. 36% and ca. 50% respectively over the past 3 years. All of
 this JavaScript not only has to be loaded via often spotty connections but also
@@ -61,12 +62,12 @@ browser, it is running continuously and handles route changes in the browser so
 that no subsequent page loads are necessary &mdash; SPAs trade a slow initial
 load for fast or often immediate subsequent route changes.
 
-The initial response though that delivers the user's first impression will
-often be either empty or just a basic loading state as shown above. Only after
-the application's JavaScript has been loaded, parsed, compiled and executed,
-can the application start up and render anything meaningful on the screen. This
-results in relatively slow _time to first meaningful paint_ (TTFMP) and _time
-to interactive_ (TTI) metrics.
+The initial response though that delivers the user's first impression will often
+be either empty or just a basic loading state as shown above. Only after the
+application's JavaScript has been loaded, parsed, compiled and executed, can the
+application start up and render anything meaningful on the screen. This results
+in relatively slow _time to first meaningful paint_ (TTFMP) and _time to
+interactive_ (TTI) metrics.
 
 #### TTFMP: Time to first meaningful paint
 
@@ -80,8 +81,8 @@ occurs once the app has started and the actual UI is painted on the screen.
 
 This is the time when the app is first usable and able to react to user inputs.
 In the above example of the SPA, time to interactive and time to first
-meaningful paint happen at the same time which is when the app has fully
-started up, has painted the UI on screen and is waiting for user input.
+meaningful paint happen at the same time which is when the app has fully started
+up, has painted the UI on screen and is waiting for user input.
 
 ## The App Shell Model
 
@@ -93,14 +94,13 @@ request with an empty HTML document with only some script tags and maybe a
 loading spinner, the server would respond with the minimal set of code that is
 necessary for rendering the app's minimal UI and making it interactive. In most
 cases, that would be the visual framework of the app's main blocks and some
-barebones functionality associated to that (e.g. a working slideout menu
-without the individual menu items actually being functional).
+barebones functionality associated to that (e.g. a working slideout menu without
+the individual menu items actually being functional).
 
-Although this does not improve the app's _TTFMP_ or _TTI_, at least it gives
-the user a first visual impression of what the app will look like once it has
-started up. Of course the app shell can be cached in the browser using a
-service worker so that for subsequent visits it can be served from that
-instantly.
+Although this does not improve the app's _TTFMP_ or _TTI_, at least it gives the
+user a first visual impression of what the app will look like once it has
+started up. Of course the app shell can be cached in the browser using a service
+worker so that for subsequent visits it can be served from that instantly.
 
 ## Back to SSR
 
@@ -119,8 +119,8 @@ browser on the server side as well as follows:
 - the server responds to `GET` requests for all routes the single page app
   supports
 - once a request comes in, the server constructs an application state from the
-  request path and potentially additional data like a session cookie and
-  injects that into the app
+  request path and potentially additional data like a session cookie and injects
+  that into the app
 - it then executes the app and renders the app's UI into a string, leveraging
   libraries like [SimpleDOM](https://github.com/ember-fastboot/simple-dom) or
   [jsdom](https://github.com/jsdom/jsdom)
@@ -133,49 +133,49 @@ browser on the server side as well as follows:
 
 With this setup, the _TTFMP_ metric is dramatically improved. Although users
 still have to wait for the app's JavaScript to load and the app to start before
-they are able to use it, instead of only being shown a meaningless UI while
-they wait for that to happen, they see the app's full UI immediately as that is
-served in the response to the initial request. The initial UI can even be
-partly interactive - elements like links or even functional elements like hover
-menus that can be implemented in CSS only will already be usable before the app
-has started up.
+they are able to use it, instead of only being shown a meaningless UI while they
+wait for that to happen, they see the app's full UI immediately as that is
+served in the response to the initial request. The initial UI can even be partly
+interactive - elements like links or even functional elements like hover menus
+that can be implemented in CSS only will already be usable before the app has
+started up.
 
 ## SPA + SSR + PWA
 
-Combining SPAs with classic SSR, we get the best of both worlds - a fast
-_TTFMP_ plus the benefits of an SPA like immediate page transitions, vivid UX
-etc. On top of that, patterns of PWAs can be added, for example caching the
-initial pre-rendered response in a service worker so that it can be shown
-immediately on subsequent visits or showing the app shell from the service worker
-cache and then injecting the SSR response into that which is likely available
-before the app has started up.
+Combining SPAs with classic SSR, we get the best of both worlds - a fast _TTFMP_
+plus the benefits of an SPA like immediate page transitions, vivid UX etc. On
+top of that, patterns of PWAs can be added, for example caching the initial
+pre-rendered response in a service worker so that it can be shown immediately on
+subsequent visits or showing the app shell from the service worker cache and
+then injecting the SSR response into that which is likely available before the
+app has started up.
 
 SPAs, SSR and PWAs are not orthogonal concepts that are exclusive of each other
-but are actually complementary. SSR can be leveraged for a fast _TTFMP_ and
-some very basic functionality like links etc. Once the JavaScript referenced
-in the SSR response has been loaded, the SPA starts up in the browser, takes
-over the DOM and intercepts all subsequent route changes and handles them
-immediately in the browser. And finally concepts of PWAs like effective
-client-side caching and offline functionality via service workers can be added
-on top for maximal performance and the optimum user experience.
+but are actually complementary. SSR can be leveraged for a fast _TTFMP_ and some
+very basic functionality like links etc. Once the JavaScript referenced in the
+SSR response has been loaded, the SPA starts up in the browser, takes over the
+DOM and intercepts all subsequent route changes and handles them immediately in
+the browser. And finally concepts of PWAs like effective client-side caching and
+offline functionality via service workers can be added on top for maximal
+performance and the optimum user experience.
 
 ## Deployment
 
 When leveraging SSR for SPAs, it is important to get some aspects of the
-deployment right. Pre-rendering the application for the first request is only
-an improvement over the classic way of serving an SPA and should not be a
+deployment right. Pre-rendering the application for the first request is only an
+improvement over the classic way of serving an SPA and should not be a
 requirement to use the app. Neither should it slow down delivery of the app. To
 make sure these requirements are met, it is important to make sure of two
 things:
 
 - The pre-rendering must run within a timeout so that if for some reason it
-  takes longer than x ms or whatever a reasonable threshold for a particular
-  app might be, the server cancels the pre-renderer and instead serves the SPA
-  the classic way (which is responding with the static, empty HTML file).
+  takes longer than x ms or whatever a reasonable threshold for a particular app
+  might be, the server cancels the pre-renderer and instead serves the SPA the
+  classic way (which is responding with the static, empty HTML file).
 - Likewise, errors in the pre-renderer should not be forwarded to the users and
-  thus block them from booting the app in the browser. Whenever the
-  pre-renderer encounters an error, it should fall back to serving the app the
-  classic SPA way just like if it runs into the timeout.
+  thus block them from booting the app in the browser. Whenever the pre-renderer
+  encounters an error, it should fall back to serving the app the classic SPA
+  way just like if it runs into the timeout.
 
 ## Breethe
 
@@ -194,23 +194,23 @@ Server-side-rendering an SPA comes with a drawback which is added latency. When
 serving an SPA as a static HTML file that contains only a loading state or an
 app shell, the HTML file can be served from a CDN which reduces latency. When
 serving the response for the initial request from a Node server, there will
-always be some additional latency. The Node server will likely not be running
-on an edge note in a CDN, thus connecting to it will take the user slightly
-longer than connecting to an edge node. Also, the server takes some time to run
-the app, capture what it renders and respond with that, adding further latency.
+always be some additional latency. The Node server will likely not be running on
+an edge note in a CDN, thus connecting to it will take the user slightly longer
+than connecting to an edge node. Also, the server takes some time to run the
+app, capture what it renders and respond with that, adding further latency.
 Thus, the browser will know slightly later which scripts to load and thus start
 loading them slightly later which leads to a longer _TTI_.
 
 However, with average _TTI_ measurements in the range of several seconds for
-many sites in particular when requested from mobile devices, an added latency
-of a few hundred milliseconds might be well worth it in many cases. Without
-SSR, _TTFMP_ is generally equal to _TTI_ for SPAs and PWAs - with SSR, _TTFMP_
-occurs as soon as the initial response is received while _TTI_ is only slightly
-delayed. So while the user needs to wait slightly longer for the app to be
-fully started up, the app's UI (and content) is available pretty much
-immediately. Whether that is a valuable improvement is a case-by-case decision
-of course. In the example of Breethe, when looking at the result page for a
-particular location, it's a pretty obvious decision:
+many sites in particular when requested from mobile devices, an added latency of
+a few hundred milliseconds might be well worth it in many cases. Without SSR,
+_TTFMP_ is generally equal to _TTI_ for SPAs and PWAs - with SSR, _TTFMP_ occurs
+as soon as the initial response is received while _TTI_ is only slightly
+delayed. So while the user needs to wait slightly longer for the app to be fully
+started up, the app's UI (and content) is available pretty much immediately.
+Whether that is a valuable improvement is a case-by-case decision of course. In
+the example of Breethe, when looking at the result page for a particular
+location, it's a pretty obvious decision:
 
 ![Breethe - results for Muncich](/assets/images/posts/2019-03-16-spas-pwas-and-ssr/breethe-results.png)
 
@@ -223,18 +223,17 @@ is available immediately.
 
 The possibilities of combining SPAs with SSR and PWA mechanics do not end with
 the above described patterns though but we can go a step further. As it turns
-out, leveraging SSR for an SPA enables to also leverage
-**Progressive Enhancement** patterns so that the initial response can be
-functional beyond just links and interactive elements built in CSS. Many things
-we're all doing in JavaScript in SPAs these days have equivalents in pure HTML.
-These might not be as powerful and elaborate as what can be done with modern
-JavaScript but they can serve as a fallback for when the app's JavaScript is
-slow to load or fails to load completely. That way we're coming back full
-circle to a concept from 1 or 2 decades ago where JavaScript enhances the HTML
-document rather than generating it - and all that while we're using an SPA that
-is completely written in JavaScript but that we're also running in the server
-side so that users don't necessarily have to wait until the app runs in their
-browsers.
+out, leveraging SSR for an SPA enables to also leverage **Progressive
+Enhancement** patterns so that the initial response can be functional beyond
+just links and interactive elements built in CSS. Many things we're all doing in
+JavaScript in SPAs these days have equivalents in pure HTML. These might not be
+as powerful and elaborate as what can be done with modern JavaScript but they
+can serve as a fallback for when the app's JavaScript is slow to load or fails
+to load completely. That way we're coming back full circle to a concept from 1
+or 2 decades ago where JavaScript enhances the HTML document rather than
+generating it - and all that while we're using an SPA that is completely written
+in JavaScript but that we're also running in the server side so that users don't
+necessarily have to wait until the app runs in their browsers.
 
 I will elaborate on how exactly the approach works in the next post of this
 series so stay tuned!

--- a/_posts/2019-04-24-dependency-updates-for-gitlab.md
+++ b/_posts/2019-04-24-dependency-updates-for-gitlab.md
@@ -5,7 +5,9 @@ github: Turbo87
 twitter: tobiasbieniek
 topic: misc
 bio: 'Senior Frontend Engineer, Ember CLI core team member'
-description: 'Tobias Bieniek shares how to set up the Renovate bot for automatic dependency updates with self-hosted internal GitLab servers.'
+description:
+  'Tobias Bieniek shares how to set up the Renovate bot for automatic dependency
+  updates with self-hosted internal GitLab servers.'
 og:
   image: /assets/images/posts/2019-04-24-dependency-updates-for-gitlab/og-image.png
 ---
@@ -33,17 +35,16 @@ because of bugs or security issues. dependabot will even label the PR with
 Another similar service is called [Renovate][renovate]. The main difference:
 Renovate is an open source project that you can run yourself, if you want to.
 The hosted service works fine if your project is on [GitHub][gh] or
-[GitLab][gl], but if you're using a self-hosted internal GitLab server you
-will have to run the service yourself. Fear not, this sounds a lot more
-complicated than it actually is, and the rest of this blog post will show you
-how to do it.
+[GitLab][gl], but if you're using a self-hosted internal GitLab server you will
+have to run the service yourself. Fear not, this sounds a lot more complicated
+than it actually is, and the rest of this blog post will show you how to do it.
 
 Before we start, let's make sure we are all in the same boat. The most common
 setup we have found when working with our clients is running GitLab on a
-self-hosted server within the corporate firewall and VPN. Most of the time
-that includes using [GitLab CI][gl-ci] to run the test suite for new commits or
-merge requests. This blog post is assuming the above setup and having GitLab CI
-set up to use the "[Docker executor][docker-executor]".
+self-hosted server within the corporate firewall and VPN. Most of the time that
+includes using [GitLab CI][gl-ci] to run the test suite for new commits or merge
+requests. This blog post is assuming the above setup and having GitLab CI set up
+to use the "[Docker executor][docker-executor]".
 
 To give you a rough idea of how we will set this up: Renovate will use a
 dedicated user account on your GitLab instance to open merge requests. It will
@@ -75,8 +76,8 @@ In short:
 - Save the generated token somewhere until we need it later
 
 Finally, make sure that our new GitLab account has access to the projects that
-you want it to run on. It will need to have at least "Developer" permissions
-so that the bot is able to create branches and push updates to those branches.
+you want it to run on. It will need to have at least "Developer" permissions so
+that the bot is able to create branches and push updates to those branches.
 
 ## Renovate Repository
 
@@ -85,9 +86,9 @@ repository. You can create the repository either under your personal account,
 the new Renovate account or, ideally, in the same GitLab group where you keep
 all your other projects.
 
-Let's start off with a blank repository and then we will add the necessary
-files as we go. Once the repository is created, `git clone` it to your local
-machine so that we can create some content.
+Let's start off with a blank repository and then we will add the necessary files
+as we go. Once the repository is created, `git clone` it to your local machine
+so that we can create some content.
 
 Renovate is a JavaScript-based project, but it supports updating dependencies of
 a lot of other languages too. Because it is based on JavaScript we will use
@@ -195,8 +196,8 @@ it to the repository.
 ## Using GitLab CI
 
 We now have a way to run our Renovate bot manually, but that is not what we
-want. We want to automate all the things! ... and GitLab CI is a great way to
-do just that.
+want. We want to automate all the things! ... and GitLab CI is a great way to do
+just that.
 
 The first thing we need to do is teach GitLab CI about our `RENOVATE_TOKEN`
 environment variable. We can do so on the "Settings > CI / CD" page of our
@@ -238,18 +239,19 @@ pipeline" form should now show up in your browser and we will fill it like this:
 - Target Branch: `master`
 - Active: Yes, please!
 
-Now, click the "Save pipeline schedule" button and GitLab will take you back
-to the "Schedules" page showing our newly created schedule.
+Now, click the "Save pipeline schedule" button and GitLab will take you back to
+the "Schedules" page showing our newly created schedule.
 
 Aaaand that's it! Some time in the next hour GitLab CI should trigger the `run`
-job, that will run our Renovate bot, and that will create merge requests on
-your configured repositories.
+job, that will run our Renovate bot, and that will create merge requests on your
+configured repositories.
 
 If you need more help getting this set up or if you want to talk about any of
-the topics here in more detail please do [contact us](/contact/)!
-If you enjoyed this blog post you can also let us know via [Twitter].
+the topics here in more detail please do [contact us](/contact/)! If you enjoyed
+this blog post you can also let us know via [Twitter].
 
-[open-source-maintenance]: https://simplabs.com/blog/2018/11/27/open-source-maintenance.html
+[open-source-maintenance]:
+  https://simplabs.com/blog/2018/11/27/open-source-maintenance.html
 [greenkeeper]: https://greenkeeper.io/
 [dependabot]: https://dependabot.com/
 [renovate]: https://github.com/renovatebot/renovate/

--- a/_posts/2019-05-10-may-monthly-update.md
+++ b/_posts/2019-05-10-may-monthly-update.md
@@ -5,10 +5,15 @@ github: mrmrcoleman
 twitter: mrmrcoleman
 topic: simplabs
 bio: 'Communications and Community Outreach Specialist'
-description: "Mark Coleman shares simplabs' monthly update for May 2019, covering new joiners, new OSS projects and our involvement with the Erlang Ecosystem Foundation."
+description:
+  "Mark Coleman shares simplabs' monthly update for May 2019, covering new
+  joiners, new OSS projects and our involvement with the Erlang Ecosystem
+  Foundation."
 ---
 
-Welcome to the third installment of our monthly update. Each month we cover the events and activities that have been happening at simplabs along with the things we're looking forward to. Enjoy.
+Welcome to the third installment of our monthly update. Each month we cover the
+events and activities that have been happening at simplabs along with the things
+we're looking forward to. Enjoy.
 
 <!--break-->
 
@@ -16,67 +21,107 @@ Welcome to the third installment of our monthly update. Each month we cover the 
 
 #### Samanta de Barros joins simplabs
 
-We’re very excited to announce that [Samanta de Barros](https://twitter.com/sami_dbc) has joined simplabs.
+We’re very excited to announce that
+[Samanta de Barros](https://twitter.com/sami_dbc) has joined simplabs.
 
-Samanta started out her career as a .Net and Java developer before shifting her attentions to Ember and Rails as she preferred the agility of web applications. Her work as a consultant helped Samanta to build experience with many different types of companies. She has shared this experience in talks at events including EmberConf and JSDay Uy. Watch Samanta's EmberConf talk "Let's Test that Addon!" [here](https://www.youtube.com/watch?v=31kVznd-zys).
+Samanta started out her career as a .Net and Java developer before shifting her
+attentions to Ember and Rails as she preferred the agility of web applications.
+Her work as a consultant helped Samanta to build experience with many different
+types of companies. She has shared this experience in talks at events including
+EmberConf and JSDay Uy. Watch Samanta's EmberConf talk "Let's Test that Addon!"
+[here](https://www.youtube.com/watch?v=31kVznd-zys).
 
-Our CEO Marco says _“I'm very happy to have Samanta on board. Her expertise with both Ember.js and Rails as well as experience with consulting international clients and as a public speaker make her a great fit to our team and we all look forward to working with her.”_
+Our CEO Marco says _“I'm very happy to have Samanta on board. Her expertise with
+both Ember.js and Rails as well as experience with consulting international
+clients and as a public speaker make her a great fit to our team and we all look
+forward to working with her.”_
 
 #### ember-intl-analyzer released
 
 Yet another cool tool to emerge from out work with [Qonto](https://qonto.eu/en)!
 
-The ember-intl-analyzer CLI tool analyzes your app code and finds unused translations for you and will soon provide warnings for missing and broken translations too.
+The ember-intl-analyzer CLI tool analyzes your app code and finds unused
+translations for you and will soon provide warnings for missing and broken
+translations too.
 
-Check it out here: [https://github.com/simplabs/ember-intl-analyzer](https://github.com/simplabs/ember-intl-analyzer)
+Check it out here:
+[https://github.com/simplabs/ember-intl-analyzer](https://github.com/simplabs/ember-intl-analyzer)
 
 #### simplabs is a founding sponsor of the Erlang Ecosystem Foundation
 
-We are very pleased to be a founding sponsor of the Erlang Ecosystem Foundation alongside companies like Cisco, Whatsapp Inc. and Erlang Solutions.
+We are very pleased to be a founding sponsor of the Erlang Ecosystem Foundation
+alongside companies like Cisco, Whatsapp Inc. and Erlang Solutions.
 
-The Erlang Ecosystem Foundation is a new non-profit organization dedicated to furthering the state of the art for Erlang, Elixir, LFE, and other technologies based on the BEAM.
+The Erlang Ecosystem Foundation is a new non-profit organization dedicated to
+furthering the state of the art for Erlang, Elixir, LFE, and other technologies
+based on the BEAM.
 
-Join the mailing list [here](https://erlef.org/) or [follow them on Twitter](https://twitter.com/TheErlef) to be kept up-to-date.
+Join the mailing list [here](https://erlef.org/) or
+[follow them on Twitter](https://twitter.com/TheErlef) to be kept up-to-date.
 
 #### Other news
 
-In other news [Tobias Bieniek](https://twitter.com/TobiasBieniek) released [a well received blog post](/blog/2019/04/24/dependency-updates-for-gitlab/) about automatically updating dependencies on internal Gitlab servers.
+In other news [Tobias Bieniek](https://twitter.com/TobiasBieniek) released
+[a well received blog post](/blog/2019/04/24/dependency-updates-for-gitlab/)
+about automatically updating dependencies on internal Gitlab servers.
 
-[Chris Manson](https://twitter.com/real_ate) joined [Jen Weber](https://twitter.com/jwwweber/) for an episode of "May I ask a question", the weekly Emberjs Q&A livestream [here](https://www.youtube.com/watch?v=v1rBL5_KPqU).
+[Chris Manson](https://twitter.com/real_ate) joined
+[Jen Weber](https://twitter.com/jwwweber/) for an episode of "May I ask a
+question", the weekly Emberjs Q&A livestream
+[here](https://www.youtube.com/watch?v=v1rBL5_KPqU).
 
-And last but not least [Ricardo Mendes](https://twitter.com/locks) released a new episode of the Conversas em Código podcast, this time talking about [Twilio, WebSockets, Phoenix Presence and more](https://trello.com/c/8W25cdsV/28-episode-19-of-locks-portuguese-podcast).
+And last but not least [Ricardo Mendes](https://twitter.com/locks) released a
+new episode of the Conversas em Código podcast, this time talking about
+[Twilio, WebSockets, Phoenix Presence and more](https://trello.com/c/8W25cdsV/28-episode-19-of-locks-portuguese-podcast).
 
 ## Upcoming Events
 
-_We're always interested in new speakers for the various meetups we're involved in. If you'd like to give a talk, [please get in touch.](/contact/)_
+_We're always interested in new speakers for the various meetups we're involved
+in. If you'd like to give a talk, [please get in touch.](/contact/)_
 
 #### Ember.js Berlin - Javascript for Beginners
 
-On May 24th and 25th [Jessica Jordan](https://twitter.com/jjordan_dev) is leading a Javascript for beginners workshop.
+On May 24th and 25th [Jessica Jordan](https://twitter.com/jjordan_dev) is
+leading a Javascript for beginners workshop.
 
-Day 1 is an installation party to make sure that everybody is set up for day 2 when attendees will be guided through creating their first web application using EmberJS. The workshop is open to women and those who are non-binary, and you can sign up using the links below!
+Day 1 is an installation party to make sure that everybody is set up for day 2
+when attendees will be guided through creating their first web application using
+EmberJS. The workshop is open to women and those who are non-binary, and you can
+sign up using the links below!
 
-[Day 1](https://www.meetup.com/Ember-js-Berlin/events/260668921/) & [Day 2.](https://www.meetup.com/Ember-js-Berlin/events/260668987/)
+[Day 1](https://www.meetup.com/Ember-js-Berlin/events/260668921/) &
+[Day 2.](https://www.meetup.com/Ember-js-Berlin/events/260668987/)
 
 #### Jessica Jordan at JSConfEU
 
 ![JsConfEU](/assets/images/posts/2019-05-10-may-monthly-update/jsconfeu.png)
 
-On the 1st of June [Jessica Jordan](https://twitter.com/jjordan_dev) is speaking at [JSConfEU](https://2019.jsconf.eu/) with her talk "Crafting Comics for Literally Everyone" she highlights how you can craft an immersive webcomic experience that is accessible for blind, visually-impaired and sighted readers alike!
+On the 1st of June [Jessica Jordan](https://twitter.com/jjordan_dev) is speaking
+at [JSConfEU](https://2019.jsconf.eu/) with her talk "Crafting Comics for
+Literally Everyone" she highlights how you can craft an immersive webcomic
+experience that is accessible for blind, visually-impaired and sighted readers
+alike!
 
-Full talk details [here](https://2019.jsconf.eu/jessica-jordan/crafting-comics-for-literally-everyone.html).
+Full talk details
+[here](https://2019.jsconf.eu/jessica-jordan/crafting-comics-for-literally-everyone.html).
 
 #### Ricardo Mendes talking at Commit Porto
 
-On the 22nd of June [Ricardo Mendes](https://twitter.com/locks) is giving the talk "Thriving through the hype cycle: an Ember.js story" at [CommitPorto](https://commitporto.com/).
+On the 22nd of June [Ricardo Mendes](https://twitter.com/locks) is giving the
+talk "Thriving through the hype cycle: an Ember.js story" at
+[CommitPorto](https://commitporto.com/).
 
 Full talk details to follow soon.
 
 #### Jessica speaking at FullStackCon London
 
-In London this July [Jessica Jordan](https://twitter.com/jjordan_dev) is speaking at [FullStackConf](https://skillsmatter.com/conferences/11213-fullstack-london-2019-the-conference-on-javascript-node-and-internet-of-things) with her talk "Crafting Comics or Literally Everyone".
+In London this July [Jessica Jordan](https://twitter.com/jjordan_dev) is
+speaking at
+[FullStackConf](https://skillsmatter.com/conferences/11213-fullstack-london-2019-the-conference-on-javascript-node-and-internet-of-things)
+with her talk "Crafting Comics or Literally Everyone".
 
-Follow [their Twitter](https://twitter.com/fullstackcon) for updates as the event approaches.
+Follow [their Twitter](https://twitter.com/fullstackcon) for updates as the
+event approaches.
 
 #### EmberFest - October 17th & 18th - Earlybird tickets sold out
 
@@ -84,24 +129,38 @@ Follow [their Twitter](https://twitter.com/fullstackcon) for updates as the even
 
 The [EmberFest](https://emberfest.eu/) early bird tickets are now sold out!
 
-Taking place in Copenhagen in October, EmberFestEU brings together the European Ember community for two days of talks and activities.
+Taking place in Copenhagen in October, EmberFestEU brings together the European
+Ember community for two days of talks and activities.
 
-Grab a ticket [here](https://emberfest.eu/) while you still can and keep an eye on the [twitter](https://twitter.com/EmberFest) for updates as the conference takes shape.
+Grab a ticket [here](https://emberfest.eu/) while you still can and keep an eye
+on the [twitter](https://twitter.com/EmberFest) for updates as the conference
+takes shape.
 
 ## Past Events
 
 #### Open Source Contribution workshop with Qonto at EmberJSParis
 
-On April 23rd [Tobias Bieniek](https://twitter.com/TobiasBieniek/) and [Ricardo Mendes](https://twitter.com/locks) led an [open source contribution workshop](https://www.meetup.com/Paris-EmberJS-Lab/events/260514153/) with the EmberJSParis meetup group at the Qonto offices.
+On April 23rd [Tobias Bieniek](https://twitter.com/TobiasBieniek/) and
+[Ricardo Mendes](https://twitter.com/locks) led an
+[open source contribution workshop](https://www.meetup.com/Paris-EmberJS-Lab/events/260514153/)
+with the EmberJSParis meetup group at the Qonto offices.
 
-The evening was a great success with many pull requests made to guides, addons and ember-cli... someone even wrote an RFC!
+The evening was a great success with many pull requests made to guides, addons
+and ember-cli... someone even wrote an RFC!
 
-The event was later covered in [The Ember Times](https://the-emberjs-times.ongoodbits.com/2019/05/03/issue-96). Well done to all involved!
+The event was later covered in
+[The Ember Times](https://the-emberjs-times.ongoodbits.com/2019/05/03/issue-96).
+Well done to all involved!
 
 #### simplabs sponsored ElixirConf EU 2019
 
-We were proud sponsors on ElixirConfEU which took place in Prague on the 8th and 9th of April and by all accounts was a fantastic event.
+We were proud sponsors on ElixirConfEU which took place in Prague on the 8th and
+9th of April and by all accounts was a fantastic event.
 
 #### Tobias Bieniek's talk from EmberCamp Chicago 2019 released
 
-And lastly, looking way back to September 2018, [Tobias Bieniek's](https://twitter.com/TobiasBieniek/) talk from [EmberCamp Chicago](https://twitter.com/embercamp), "Internationalization: It's Easy in Ember" was released and is [now available on YouTube.](https://www.youtube.com/watch?v=K4nKWp1z4cU&t=0s&list=PL4eq2DPpyBbm-vTgHMdBjUi1Qd5GiRIfW&index=5)
+And lastly, looking way back to September 2018,
+[Tobias Bieniek's](https://twitter.com/TobiasBieniek/) talk from
+[EmberCamp Chicago](https://twitter.com/embercamp), "Internationalization: It's
+Easy in Ember" was released and is
+[now available on YouTube.](https://www.youtube.com/watch?v=K4nKWp1z4cU&t=0s&list=PL4eq2DPpyBbm-vTgHMdBjUi1Qd5GiRIfW&index=5)

--- a/_posts/2019-07-15-sentry-and-ember.md
+++ b/_posts/2019-07-15-sentry-and-ember.md
@@ -5,14 +5,16 @@ github: Turbo87
 twitter: tobiasbieniek
 topic: ember
 bio: 'Senior Frontend Engineer, Ember CLI core team member'
-description: 'Tobias Bieniek explains how to set up Sentry for Ember.js applications using @sentry/browser instead of the now unnecessary ember-cli-sentry.'
+description:
+  'Tobias Bieniek explains how to set up Sentry for Ember.js applications using
+  @sentry/browser instead of the now unnecessary ember-cli-sentry.'
 og:
   image: /assets/images/posts/2019-07-15-sentry-and-ember/og-image.png
 ---
 
 Are you confident that your apps have no bugs? Do you not need a support team
-because no user ever complains about something not working? Then this post
-is not for you!
+because no user ever complains about something not working? Then this post is
+not for you!
 
 We use a lot of tools at simplabs to ensure reasonably high quality code, but
 occasionally something slips through. The important thing then is to notice and
@@ -26,13 +28,13 @@ fix it quickly. This post will focus on the "notice" part by using
 
 ## ember-cli-sentry
 
-The [`ember-cli-sentry`][ember-cli-sentry] addon has been around since 2015
-and nicely integrates the [`raven-js`][raven-js] library with Ember.js.
-What is `raven-js`? It is the official browser JavaScript client for Sentry.
+The [`ember-cli-sentry`][ember-cli-sentry] addon has been around since 2015 and
+nicely integrates the [`raven-js`][raven-js] library with Ember.js. What is
+`raven-js`? It is the official browser JavaScript client for Sentry.
 
-Well... it **was** the official browser JavaScript client for Sentry. In 2018
-it has been replaced by [`@sentry/browser`][sentry-browser] with an entirely
-new API.
+Well... it **was** the official browser JavaScript client for Sentry. In 2018 it
+has been replaced by [`@sentry/browser`][sentry-browser] with an entirely new
+API.
 
 What does that mean for `ember-cli-sentry`? We don't know! We have been
 experimenting with `@sentry/browser` though and we are starting to think that a
@@ -77,8 +79,8 @@ to your server too, so that Sentry can access them.
 
 In case you don't want other people to be able to read your original source code
 you can also upload the sourcemaps directly to Sentry. If you use
-[`ember-cli-deploy`][ember-cli-deploy] to publish your apps then you can use
-the [`ember-cli-deploy-sentry`][ember-cli-deploy-sentry] addon to do this
+[`ember-cli-deploy`][ember-cli-deploy] to publish your apps then you can use the
+[`ember-cli-deploy-sentry`][ember-cli-deploy-sentry] addon to do this
 automatically for each deployment.
 
 ## Setting up `@sentry/browser`
@@ -221,12 +223,13 @@ Sentry.captureException(new Error('with stack trace!! ✨'));
 ## Adding Additional Context
 
 Sentry, by default, records the IP of the user that has experienced the error.
-But when your app has user accounts and an authentication system, it is much more
-useful to know which specific user this has happened to. `@sentry/browser`
+But when your app has user accounts and an authentication system, it is much
+more useful to know which specific user this has happened to. `@sentry/browser`
 allows us to add additional context to the events it sends to the server.
 
 We could do that manually in the `beforeSend()` hook, but it is much easier to
-use the [`configureScope()`](https://docs.sentry.io/enriching-error-data/scopes/?platform=browsernpm#configuring-the-scope)
+use the
+[`configureScope()`](https://docs.sentry.io/enriching-error-data/scopes/?platform=browsernpm#configuring-the-scope)
 function for this:
 
 <!-- prettier-ignore -->
@@ -241,7 +244,8 @@ Sentry.configureScope(scope => {
 
 This will automatically add the user information for all errors/events that
 follow after this call. If you only want to add such information for a single
-event you can use the [`withScope()`](https://docs.sentry.io/enriching-error-data/scopes/?platform=browsernpm#local-scopes)
+event you can use the
+[`withScope()`](https://docs.sentry.io/enriching-error-data/scopes/?platform=browsernpm#local-scopes)
 function instead.
 
 ## Testing
@@ -260,18 +264,20 @@ this.owner.register('service:raven', Service.extend({
 But with `@sentry/browser` this becomes a little more complicated since there is
 no service anymore that could be mocked like that. We have experimented with
 this and found that pushing an additional scope on the stack and configuring a
-mock client for that scope seems to result in a useful way to assert whether
-an exception was correctly reported.
+mock client for that scope seems to result in a useful way to assert whether an
+exception was correctly reported.
 
 The details of this require its own blog post though, since they are a little
 less straight-forward than what we described above.
 
-If you have questions, want to know more or need help setting all of this up
-for your apps please [contact us][contact]. We're happy to help!
+If you have questions, want to know more or need help setting all of this up for
+your apps please [contact us][contact]. We're happy to help!
 
 [ember-cli-sentry]: https://github.com/ember-cli-sentry/ember-cli-sentry
-[raven-js]: https://github.com/getsentry/sentry-javascript/tree/master/packages/raven-js
-[sentry-browser]: https://github.com/getsentry/sentry-javascript/tree/master/packages/browser
+[raven-js]:
+  https://github.com/getsentry/sentry-javascript/tree/master/packages/raven-js
+[sentry-browser]:
+  https://github.com/getsentry/sentry-javascript/tree/master/packages/browser
 [ember-cli-deploy]: https://github.com/ember-cli-deploy/ember-cli-deploy
 [ember-cli-deploy-sentry]: https://github.com/dschmidt/ember-cli-deploy-sentry
 [ember-simple-auth]: https://github.com/simplabs/ember-simple-auth

--- a/_posts/2019-07-24-july-monthly-update.md
+++ b/_posts/2019-07-24-july-monthly-update.md
@@ -5,10 +5,14 @@ github: mrmrcoleman
 twitter: mrmrcoleman
 topic: simplabs
 bio: 'Communications and Community Outreach Specialist'
-description: "Mark Coleman shares simplabs' update for July 2019, covering the release of our new website, new OSS releases and a number of upcoming events."
+description:
+  "Mark Coleman shares simplabs' update for July 2019, covering the release of
+  our new website, new OSS releases and a number of upcoming events."
 ---
 
-Welcome to the fourth installment of our monthly update. This one is later than expected but still packed with all the events and activities that have been happening at simplabs along with the things we're looking forward to. Enjoy.
+Welcome to the fourth installment of our monthly update. This one is later than
+expected but still packed with all the events and activities that have been
+happening at simplabs along with the things we're looking forward to. Enjoy.
 
 <!--break-->
 
@@ -16,66 +20,117 @@ Welcome to the fourth installment of our monthly update. This one is later than 
 
 ![Upcoming webinar - The ultimate marketers guide to modern web apps and why users are demanding more](/assets/images/posts/2019-07-24-july-monthly-update/simplabs-webinar-modern-web-apps-for-marketers.png#@600-1200)]
 
-On August 12th at 6pm UTC+2 we're running a webinar to help forward-looking marketers understand recent changes in web technology and how they can be used to create incredible experiences for their users.
+On August 12th at 6pm UTC+2 we're running a webinar to help forward-looking
+marketers understand recent changes in web technology and how they can be used
+to create incredible experiences for their users.
 
-From the site: _"The way that web apps are built has changed dramatically in recent years. Changes in devices, browsers and usage patterns have created a wave of innovation which is waiting to be used by forward looking marketing departments._
+From the site: _"The way that web apps are built has changed dramatically in
+recent years. Changes in devices, browsers and usage patterns have created a
+wave of innovation which is waiting to be used by forward looking marketing
+departments._
 
-_After this webinar you will understand why these changes are occurring, how technology is responding to this shift and crucially, how you can use these technologies to build incredible experiences for your users."_
+_After this webinar you will understand why these changes are occurring, how
+technology is responding to this shift and crucially, how you can use these
+technologies to build incredible experiences for your users."_
 
 ### New simplabs website
 
-We recently recreated our website in [Glimmer.js](https://glimmerjs.com/), the fast and light-weight UI components library, based on Ember.js' rendering engine. We will have a blog post online going into more details soon. Feel free to take a look around!
+We recently recreated our website in [Glimmer.js](https://glimmerjs.com/), the
+fast and light-weight UI components library, based on Ember.js' rendering
+engine. We will have a blog post online going into more details soon. Feel free
+to take a look around!
 
 ### New blog post from Tobias Bieniek
 
-[Tobias Bieniek](https://twitter.com/TobiasBieniek) recently released a new blog post entitled [Sentry error reporting for Ember.js](https://simplabs.com/blog/2019/07/15/sentry-and-ember/) which was positively received. You should check it out.
+[Tobias Bieniek](https://twitter.com/TobiasBieniek) recently released a new blog
+post entitled
+[Sentry error reporting for Ember.js](https://simplabs.com/blog/2019/07/15/sentry-and-ember/)
+which was positively received. You should check it out.
 
 ### New version of ember-intl-analyzer released
 
-First announced in the [May monthly update](https://simplabs.com/blog/2019/05/10/may-monthly-update), the ember-intl-analyzer CLI tool which analyzes your app code and finds unused translations for you has received an update. Supporta JS decorators now and will warn about missing translations. Check it out [on GitHub.](https://github.com/simplabs/ember-intl-analyzer)
+First announced in the
+[May monthly update](https://simplabs.com/blog/2019/05/10/may-monthly-update),
+the ember-intl-analyzer CLI tool which analyzes your app code and finds unused
+translations for you has received an update. Supporta JS decorators now and will
+warn about missing translations. Check it out
+[on GitHub.](https://github.com/simplabs/ember-intl-analyzer)
 
 ### Other news
 
-[Ricardo Mendes](https://twitter.com/locks) released a new episode of the Conversas em Código podcast, this time talking about [Internationalization, Flags, and Inputs](https://trello.com/c/8W25cdsV/28-episode-19-of-locks-portuguese-podcast).
+[Ricardo Mendes](https://twitter.com/locks) released a new episode of the
+Conversas em Código podcast, this time talking about
+[Internationalization, Flags, and Inputs](https://trello.com/c/8W25cdsV/28-episode-19-of-locks-portuguese-podcast).
 
 ## Upcoming Events
 
-_We're always interested in new speakers for the various meetups we're involved in. If you'd like to give a talk, [please get in touch.](/contact/)_
+_We're always interested in new speakers for the various meetups we're involved
+in. If you'd like to give a talk, [please get in touch.](/contact/)_
 
 ### EmberFest - October 17th & 18th
 
 [EmberFest](https://emberfest.eu/) is coming together nicely.
 
-Taking place in Copenhagen in October, EmberFestEU brings together the European Ember community for two days of talks and activities. The CFP closes on August 1st so if you'd like to give a presentation remember to get your submission in on time [here](https://cfp.emberfest.eu/events/emberfest-2019).
+Taking place in Copenhagen in October, EmberFestEU brings together the European
+Ember community for two days of talks and activities. The CFP closes on August
+1st so if you'd like to give a presentation remember to get your submission in
+on time [here](https://cfp.emberfest.eu/events/emberfest-2019).
 
-To attend [grab a ticket](https://emberfest.eu/) while you still can and keep an eye on the [Twitter account @EmberFest](https://twitter.com/EmberFest) for updates as the conference takes shape.
+To attend [grab a ticket](https://emberfest.eu/) while you still can and keep an
+eye on the [Twitter account @EmberFest](https://twitter.com/EmberFest) for
+updates as the conference takes shape.
 
 ### Chris Manson at Leeds JS
 
-On July 31st [Chris Manson](https://twitter.com/real_ate/) will be speaking at Leeds JS about [Empress](https://github.com/empress), which is the technology behind [empress-blog](https://github.com/empress/empress-blog) and [Guidemaker](https://github.com/empress/guidemaker) which powers the current Ember guides. [Check the full event details](https://leedsjs.com/events/2019-07-31/).
+On July 31st [Chris Manson](https://twitter.com/real_ate/) will be speaking at
+Leeds JS about [Empress](https://github.com/empress), which is the technology
+behind [empress-blog](https://github.com/empress/empress-blog) and
+[Guidemaker](https://github.com/empress/guidemaker) which powers the current
+Ember guides.
+[Check the full event details](https://leedsjs.com/events/2019-07-31/).
 
 ### Jessica Jordan speaking at EmberCamp
 
-On September 16th [Jessica Jordan](https://twitter.com/jjordan_dev) will be at [EmberCamp](http://embercamp.com/) in Chicago talking about how state management is easier than ever in Ember Octane! [Check the full schedule](http://embercamp.com/).
+On September 16th [Jessica Jordan](https://twitter.com/jjordan_dev) will be at
+[EmberCamp](http://embercamp.com/) in Chicago talking about how state management
+is easier than ever in Ember Octane!
+[Check the full schedule](http://embercamp.com/).
 
 ## Past Events
 
 ### Ember.js Berlin - Javascript for Beginners
 
-On May 24th and 25th [Jessica Jordan](https://twitter.com/jjordan_dev), [Samanta de Barros](https://twitter.com/sami_dbc) and [Chris Manson](https://twitter.com/real_ate/) ran a Javascript for beginners workshop in Berlin.
+On May 24th and 25th [Jessica Jordan](https://twitter.com/jjordan_dev),
+[Samanta de Barros](https://twitter.com/sami_dbc) and
+[Chris Manson](https://twitter.com/real_ate/) ran a Javascript for beginners
+workshop in Berlin.
 
-Day 1 was an installation party to make sure that everybody was set up for day 2 when attendees were guided through creating their first web application using EmberJS! The workshop was open to women and those who are non-binary, and was a great success.
+Day 1 was an installation party to make sure that everybody was set up for day 2
+when attendees were guided through creating their first web application using
+EmberJS! The workshop was open to women and those who are non-binary, and was a
+great success.
 
-We plan to run another session like this in the future, so keep an eye on the [@simplabs Twitter feed](https://twitter.com/simplabs) for more news.
+We plan to run another session like this in the future, so keep an eye on the
+[@simplabs Twitter feed](https://twitter.com/simplabs) for more news.
 
 ### Jessica Jordan at JSConfEU
 
-![JsConfEU](/assets/images/posts/2019-05-10-may-monthly-update/jsconfeu.png) On the 1st of June [Jessica Jordan](https://twitter.com/jjordan_dev) spoke at [JSConfEU](https://2019.jsconf.eu/) with her talk "Crafting Comics for Literally Everyone" in which she highlighted how you can craft an immersive webcomic experience that is accessible for blind, visually-impaired and sighted readers alike! You can watch the whole talk [on YouTube.](https://www.youtube.com/watch?v=BPmuR4mAQaw)
+![JsConfEU](/assets/images/posts/2019-05-10-may-monthly-update/jsconfeu.png) On
+the 1st of June [Jessica Jordan](https://twitter.com/jjordan_dev) spoke at
+[JSConfEU](https://2019.jsconf.eu/) with her talk "Crafting Comics for Literally
+Everyone" in which she highlighted how you can craft an immersive webcomic
+experience that is accessible for blind, visually-impaired and sighted readers
+alike! You can watch the whole talk
+[on YouTube.](https://www.youtube.com/watch?v=BPmuR4mAQaw)
 
 ### Ricardo Mendes talking at Commit Porto
 
-On the 22nd of June [Ricardo Mendes](https://twitter.com/locks) gave his talk "Thriving through the hype cycle: an Ember.js story" at [CommitPorto](https://commitporto.com/).
+On the 22nd of June [Ricardo Mendes](https://twitter.com/locks) gave his talk
+"Thriving through the hype cycle: an Ember.js story" at
+[CommitPorto](https://commitporto.com/).
 
 ### Jessica Jordan speaking at FullStackCon London
 
-[Jessica Jordan](https://twitter.com/jjordan_dev) spoke at [FullStackConf](https://skillsmatter.com/conferences/11213-fullstack-london-2019-the-conference-on-javascript-node-and-internet-of-things) in London with her talk "Crafting Comics for Literally Everyone".
+[Jessica Jordan](https://twitter.com/jjordan_dev) spoke at
+[FullStackConf](https://skillsmatter.com/conferences/11213-fullstack-london-2019-the-conference-on-javascript-node-and-internet-of-things)
+in London with her talk "Crafting Comics for Literally Everyone".

--- a/_posts/2019-11-11-why-companies-invest-in-oss.md
+++ b/_posts/2019-11-11-why-companies-invest-in-oss.md
@@ -5,14 +5,20 @@ github: jessica-jordan
 twitter: jjordan_dev
 topic: simplabs
 bio: 'Senior Frontend Engineer, Ember Learning Core team member'
-description: 'Jessica Jordan details how simplabs makes contributions to open-source software work as a regular practice and how companies can benefit from an investment into OSS.'
+description:
+  'Jessica Jordan details how simplabs makes contributions to open-source
+  software work as a regular practice and how companies can benefit from an
+  investment into OSS.'
 og:
   image: /assets/images/posts/2019-11-11-why-companies-invest-in-oss/og-image.png
 ---
 
-Less productivity, missed project deadlines and wasted money: that’s what you get for letting your developers work on open-source projects. Or do you really?
+Less productivity, missed project deadlines and wasted money: that’s what you
+get for letting your developers work on open-source projects. Or do you really?
 
-This blog post highlights on which levels contribution to open-source provides value to businesses and demonstrates why paying your team to spend time on OSS might be the best business decision you will make this year.
+This blog post highlights on which levels contribution to open-source provides
+value to businesses and demonstrates why paying your team to spend time on OSS
+might be the best business decision you will make this year.
 
 <!--break-->
 
@@ -20,80 +26,209 @@ This blog post highlights on which levels contribution to open-source provides v
 
 ## What Is Open-Source?
 
-Open-source describes a decentralised approach in which knowledge and material products are developed.
-Even though the open-source development model can be applied to many different types of products, I will only focus on the open-source development of **software** (OSS) in this post.
+Open-source describes a decentralised approach in which knowledge and material
+products are developed. Even though the open-source development model can be
+applied to many different types of products, I will only focus on the
+open-source development of **software** (OSS) in this post.
 
-The outcomes of open-source development are usually any or a combination of the following [[1](http://faculty.salisbury.edu/~xswang/Research/Papers/SERelated/OpenSource/p32-o_reilly.pdf)]:
+The outcomes of open-source development are usually any or a combination of the
+following
+[[1](http://faculty.salisbury.edu/~xswang/Research/Papers/SERelated/OpenSource/p32-o_reilly.pdf)]:
 
 - free software
 - publicly available source code of said software
 - related documentation which is publicly available and free
-- possibility to share and redistribute software and/or documentation in modified or non-modified manner as defined by the License
+- possibility to share and redistribute software and/or documentation in
+  modified or non-modified manner as defined by the License
 
-Open-source software has become an important corner stone of almost any business that operates today. According to a previous survey less than 3% of respondents mentioned that their business doesn't rely on OSS in any way and indicating that the vast majority of companies use OSS: either for product development or for running business infrastructure [[2](https://www.slideshare.net/blackducksoftware/2015-future-of-open-source-survey-results/9-SECTION2CORPORATEUSE2XSINCE_2010USE_OF_OPEN_SOURCE)]. It was estimated that in 2016 alone, about 95% of commercial software products world wide were including OSS components [[3](https://core.ac.uk/reader/41824124)].
+Open-source software has become an important corner stone of almost any business
+that operates today. According to a previous survey less than 3% of respondents
+mentioned that their business doesn't rely on OSS in any way and indicating that
+the vast majority of companies use OSS: either for product development or for
+running business infrastructure
+[[2](https://www.slideshare.net/blackducksoftware/2015-future-of-open-source-survey-results/9-SECTION2CORPORATEUSE2XSINCE_2010USE_OF_OPEN_SOURCE)].
+It was estimated that in 2016 alone, about 95% of commercial software products
+world wide were including OSS components
+[[3](https://core.ac.uk/reader/41824124)].
 
-The reasons for the popularity of OSS are manifold: OSS allows businesses to deliver more stable and more secure digital products in a shorter timespan. Additionally, overall cost for the development of these products is reduced, since part of the product development and maintenance is shared with a group of peers external to the business [[4](https://core.ac.uk/reader/41824081)].
+The reasons for the popularity of OSS are manifold: OSS allows businesses to
+deliver more stable and more secure digital products in a shorter timespan.
+Additionally, overall cost for the development of these products is reduced,
+since part of the product development and maintenance is shared with a group of
+peers external to the business [[4](https://core.ac.uk/reader/41824081)].
 
-The mere usage of OSS is already established as a commonly accepted practice for businesses. The sole use of OSS is also known as **OSS acquisition** [[4](https://core.ac.uk/reader/41824081)].
+The mere usage of OSS is already established as a commonly accepted practice for
+businesses. The sole use of OSS is also known as **OSS acquisition**
+[[4](https://core.ac.uk/reader/41824081)].
 
-The popularity of OSS acquisition is explained by its significant returns. But how does the acceptance of OSS acquisition relate to **OSS integration** - a business's practice to contribute back to the open-source projects they're using? Are there any benefits of investing money and developer time into engaging with open-source communities and co-create OSS with said communities? And if so, do these benefits outweigh the costs of cutting back on time spent directly on product and business development?
+The popularity of OSS acquisition is explained by its significant returns. But
+how does the acceptance of OSS acquisition relate to **OSS integration** - a
+business's practice to contribute back to the open-source projects they're
+using? Are there any benefits of investing money and developer time into
+engaging with open-source communities and co-create OSS with said communities?
+And if so, do these benefits outweigh the costs of cutting back on time spent
+directly on product and business development?
 
 ## Investment in OSS Is an Investment in Team Development
 
-Developers may spend time contributing to OSS by participating in a wide range of different tasks, including active development of open-source tools and software, writing documentation for OSS, managing projects, participating in community management and more.
+Developers may spend time contributing to OSS by participating in a wide range
+of different tasks, including active development of open-source tools and
+software, writing documentation for OSS, managing projects, participating in
+community management and more.
 
-Many of these tasks provide multi-level learning opportunities for employees in regards of their **technical skills**. Apart from offering a wide selection of tasks that meet contributors' needs and interests which help to expand an employee's skill set [[5](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.462.2007&rep=rep1&type=pdf)], OSS also provides the chance for mentorship. Developers who contribute to open-source can therefore deepen already existing technical skills and acquire entirely new ones. By picking up work tasks that meet their current experience level freely without the constraints that are oftentimes imposed in their day-to-day work, developers find a unique opportunity to expand their technical qualifications.
+Many of these tasks provide multi-level learning opportunities for employees in
+regards of their **technical skills**. Apart from offering a wide selection of
+tasks that meet contributors' needs and interests which help to expand an
+employee's skill set
+[[5](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.462.2007&rep=rep1&type=pdf)],
+OSS also provides the chance for mentorship. Developers who contribute to
+open-source can therefore deepen already existing technical skills and acquire
+entirely new ones. By picking up work tasks that meet their current experience
+level freely without the constraints that are oftentimes imposed in their
+day-to-day work, developers find a unique opportunity to expand their technical
+qualifications.
 
-As active members of open-source communities, developers may hone their **organisational skill set** by managing open-source projects, collaborating with globally distributed teams both online and offline and leading initiatives in an environment with a usually simple, clear-cut organisational structure [[6](https://digital-library.theiet.org/content/conferences/10.1049/ic_20040267)].
+As active members of open-source communities, developers may hone their
+**organisational skill set** by managing open-source projects, collaborating
+with globally distributed teams both online and offline and leading initiatives
+in an environment with a usually simple, clear-cut organisational structure
+[[6](https://digital-library.theiet.org/content/conferences/10.1049/ic_20040267)].
 
 ![team benefits open source investment](/assets/images/posts/2019-11-11-why-companies-invest-in-oss/oss-team-investment-illustration.png#plain@600-1200)
 
-Finally, when following an intrinsic motivation to contribute to OSS, engineering teams can benefit from open-source work in regards to well-being. Apart from an investment into their own professional capital by widening their skill set, participation in open-source communities oftentimes has altruistic motives - the ambition to give back to the community from which developers already have benefitted. A sense of belonging to a particular open-source community and wanting to be an active part of it as well as the recognition by community peers are driving factors for OSS contributions to developers [[7](https://aisel.aisnet.org/cgi/viewcontent.cgi?article=1559&context=jais)].
+Finally, when following an intrinsic motivation to contribute to OSS,
+engineering teams can benefit from open-source work in regards to well-being.
+Apart from an investment into their own professional capital by widening their
+skill set, participation in open-source communities oftentimes has altruistic
+motives - the ambition to give back to the community from which developers
+already have benefitted. A sense of belonging to a particular open-source
+community and wanting to be an active part of it as well as the recognition by
+community peers are driving factors for OSS contributions to developers
+[[7](https://aisel.aisnet.org/cgi/viewcontent.cgi?article=1559&context=jais)].
 
-The value that engineers themselves see in their contributions to open-source, has also been a central topic in a series of interviews of regular contributors to EmberJS - a JavaScript framework for building client-side single page applications. In the conversation with community members, some stated that the impact of their work on a wider ecosystem of framework users was perceived as motivating [[8](https://discuss.emberjs.com/t/i-contribute-to-ember-with-bekzod-khaitbaev/16085)]. Others mentioned professional growth in terms of team organisation and leadership as a primary goal for their OSS work [[9](https://discuss.emberjs.com/t/i-contribute-to-ember-with-jen-weber/16110)].
+The value that engineers themselves see in their contributions to open-source,
+has also been a central topic in a series of interviews of regular contributors
+to EmberJS - a JavaScript framework for building client-side single page
+applications. In the conversation with community members, some stated that the
+impact of their work on a wider ecosystem of framework users was perceived as
+motivating
+[[8](https://discuss.emberjs.com/t/i-contribute-to-ember-with-bekzod-khaitbaev/16085)].
+Others mentioned professional growth in terms of team organisation and
+leadership as a primary goal for their OSS work
+[[9](https://discuss.emberjs.com/t/i-contribute-to-ember-with-jen-weber/16110)].
 
-Being able to follow their intrinsic motivation, exercising autonomy and competence as part of contributing to OSS is key to increased work satisfaction for many developers [[7](https://aisel.aisnet.org/cgi/viewcontent.cgi?article=1559&context=jais)].
+Being able to follow their intrinsic motivation, exercising autonomy and
+competence as part of contributing to OSS is key to increased work satisfaction
+for many developers
+[[7](https://aisel.aisnet.org/cgi/viewcontent.cgi?article=1559&context=jais)].
 
 ## Investment in OSS Will Boost Your Talent Strategy
 
-A process for providing compensated work time for their engineers to work on OSS, benefits a company's talent strategy:
-Increased work satisfaction aids **talent retainment**. By being an active part of OSS communities, either by paying developers to contribute to open-source projects or sponsoring events or project initiatives, companies directly invest in their employer branding and expose their brand to large developer communities in a targeted manner. This helps immensely with identifying experienced talent whose skill set matches well with the requirements of a business's engineering projects [[10](https://opensource.org/node/1006)]. Developers who are interested in working at companies that encourage and facilitate learning and professional growth via OSS work are in turn motivated to join respective companies [[11](https://www.infoq.com/news/2019/03/open-source-benefits/)], indicating a compound effect of open-source focussed employer branding.
+A process for providing compensated work time for their engineers to work on
+OSS, benefits a company's talent strategy: Increased work satisfaction aids
+**talent retainment**. By being an active part of OSS communities, either by
+paying developers to contribute to open-source projects or sponsoring events or
+project initiatives, companies directly invest in their employer branding and
+expose their brand to large developer communities in a targeted manner. This
+helps immensely with identifying experienced talent whose skill set matches well
+with the requirements of a business's engineering projects
+[[10](https://opensource.org/node/1006)]. Developers who are interested in
+working at companies that encourage and facilitate learning and professional
+growth via OSS work are in turn motivated to join respective companies
+[[11](https://www.infoq.com/news/2019/03/open-source-benefits/)], indicating a
+compound effect of open-source focussed employer branding.
 
 ## How the Benefits of OSS Integration Outweigh the Costs
 
-Many companies hesitate to contribute in the context of OSS projects. Business owners need to compare the cost of several **downsides of OSS integration** against the potential benefits. Some of the disadvantages of OSS contribution include the risk of **loosing intellectual property** when open-sourcing internal software, the **cost for maintaining** one's own and external OSS projects and the risk to **reveal knowledge** about critical business processes to competitors.
+Many companies hesitate to contribute in the context of OSS projects. Business
+owners need to compare the cost of several **downsides of OSS integration**
+against the potential benefits. Some of the disadvantages of OSS contribution
+include the risk of **loosing intellectual property** when open-sourcing
+internal software, the **cost for maintaining** one's own and external OSS
+projects and the risk to **reveal knowledge** about critical business processes
+to competitors.
 
-Previous case studies were able to confirm that the benefits of OSS integration often outweigh its cost and that returns are especially significant if the projects are of interest to other businesses. [[12](https://www.researchgate.net/profile/Joachim_Henkel/publication/251228522_Open_Source_Software_from_Commercial_Firms_-_Tools_Complements_and_Collective_Invention/links/54c3bb140cf219bbe4ec1cf5/Open-Source-Software-from-Commercial-Firms-Tools-Complements-and-Collective-Invention.pdf)]. Businesses can employ profitable strategies by paying the **cost of OSS contribution** and benefitting from its returns on many levels.
+Previous case studies were able to confirm that the benefits of OSS integration
+often outweigh its cost and that returns are especially significant if the
+projects are of interest to other businesses.
+[[12](https://www.researchgate.net/profile/Joachim_Henkel/publication/251228522_Open_Source_Software_from_Commercial_Firms_-_Tools_Complements_and_Collective_Invention/links/54c3bb140cf219bbe4ec1cf5/Open-Source-Software-from-Commercial-Firms-Tools-Complements-and-Collective-Invention.pdf)].
+Businesses can employ profitable strategies by paying the **cost of OSS
+contribution** and benefitting from its returns on many levels.
 
 ## Investment in OSS in Practice
 
-Even if the benefits of OSS for training your team and improving your talent strategy seem promising, you may still wonder **how** you can implement a successful process for your business to contribute back to open-source. Adapting the process to short-term or long-term business needs is crucial to make the investment into OSS work alongside ongoing product development or infrastructure work.
+Even if the benefits of OSS for training your team and improving your talent
+strategy seem promising, you may still wonder **how** you can implement a
+successful process for your business to contribute back to open-source. Adapting
+the process to short-term or long-term business needs is crucial to make the
+investment into OSS work alongside ongoing product development or infrastructure
+work.
 
-As a consulting company, **simplabs** also operates under time and project constraints. Still, open-source is at the heart of our company's work and besides contributing to EmberJS via our core team engagements, we maintain over a dozen of tools and libraries written in JavaScript and other programming languages and which are well-adopted in the open-source community [[13](https://simplabs.com/expertise/ember/)]. Being aware that providing value for OSS is important, but takes time, we dedicate regular time for engineers and designers to work on open-source projects using the **20% time method**.
+As a consulting company, **simplabs** also operates under time and project
+constraints. Still, open-source is at the heart of our company's work and
+besides contributing to EmberJS via our core team engagements, we maintain over
+a dozen of tools and libraries written in JavaScript and other programming
+languages and which are well-adopted in the open-source community
+[[13](https://simplabs.com/expertise/ember/)]. Being aware that providing value
+for OSS is important, but takes time, we dedicate regular time for engineers and
+designers to work on open-source projects using the **20% time method**.
 
 ### How Does the 20% Time Method Work?
 
-The 20% time method allocates a fifth of an engineer's compensated working time for open-source projects and related activities, including development, community management or writing blog posts. At simplabs we ensure that each IT and design professional has access to 20% time and makes use of it on a weekly basis: this boils down to 4 days of client work and 1 day of 20% time in a regular work week. Projects that our consultants work on generate tangible outcomes which are shared with the team or the wider open-source community regularly. Some of these tangible outcomes among many others at our company include:
+The 20% time method allocates a fifth of an engineer's compensated working time
+for open-source projects and related activities, including development,
+community management or writing blog posts. At simplabs we ensure that each IT
+and design professional has access to 20% time and makes use of it on a weekly
+basis: this boils down to 4 days of client work and 1 day of 20% time in a
+regular work week. Projects that our consultants work on generate tangible
+outcomes which are shared with the team or the wider open-source community
+regularly. Some of these tangible outcomes among many others at our company
+include:
 
 - releases of company owned open-source projects, e.g. Ember addons
-- code contributions to open-source projects owned by other organizations, e.g. the EmberJS library or The Ember Times community newsletter
-- blog posts about best practices in software, design, marketing and other company expertises
-- organizing OSS community events, e.g. our Ember beginner's workshop for those underrepresented in tech or conferences such as Emberfest
+- code contributions to open-source projects owned by other organizations, e.g.
+  the EmberJS library or The Ember Times community newsletter
+- blog posts about best practices in software, design, marketing and other
+  company expertises
+- organizing OSS community events, e.g. our Ember beginner's workshop for those
+  underrepresented in tech or conferences such as Emberfest
 - presenting at international conferences such as EmberConf or ReactiveConf
 
-Using the 20% time method allows us as a company to provide time for **learning and training** to each team member **equally** and in good **balance** with the main tasks of our business. Allowing developers to choose the initiatives they want to work on freely is an important characteristic of our approach as well; this provides the greatest potential for professional growth that suits a team member's existing expertise and **inherent interests**. As a side effect, our hiring process benefits from these efforts both in terms of **talent acquisition** and **talent retention**. Finally, many of the outcomes of our team's 20% time contributes to awareness of the company's brand; which in turn is crucial for any B2B business's **client acquisition** process.
+Using the 20% time method allows us as a company to provide time for **learning
+and training** to each team member **equally** and in good **balance** with the
+main tasks of our business. Allowing developers to choose the initiatives they
+want to work on freely is an important characteristic of our approach as well;
+this provides the greatest potential for professional growth that suits a team
+member's existing expertise and **inherent interests**. As a side effect, our
+hiring process benefits from these efforts both in terms of **talent
+acquisition** and **talent retention**. Finally, many of the outcomes of our
+team's 20% time contributes to awareness of the company's brand; which in turn
+is crucial for any B2B business's **client acquisition** process.
 
 ## If Your Business Contributes to OSS, You Are in Good Company
 
-Many businesses already found a way to provide time for their engineering and product teams using either the 20% time method or differing approaches. According to the results of a recent survey about open-source adaptation in companies, 67% of respondents stated that they were contributing back to OSS [[14](https://www.slideshare.net/blackducksoftware/2016-future-of-open-source-survey-results)].
+Many businesses already found a way to provide time for their engineering and
+product teams using either the 20% time method or differing approaches.
+According to the results of a recent survey about open-source adaptation in
+companies, 67% of respondents stated that they were contributing back to OSS
+[[14](https://www.slideshare.net/blackducksoftware/2016-future-of-open-source-survey-results)].
 
-OSS development and engagement is hence already a well-adopted approach by businesses today and might even become increasingly popular in the future.
+OSS development and engagement is hence already a well-adopted approach by
+businesses today and might even become increasingly popular in the future.
 
 ## So Should You Pay Your Team to Work on OSS?
 
-In this post we took a look at the impact of dedicating time on contributing to open-source. If you want to benefit from the education and training opportunities that OSS offers or if you are in need to improve your business's talent strategy, it becomes clear that implementing a process that allows your engineers to work on OSS will set your business up for success.
+In this post we took a look at the impact of dedicating time on contributing to
+open-source. If you want to benefit from the education and training
+opportunities that OSS offers or if you are in need to improve your business's
+talent strategy, it becomes clear that implementing a process that allows your
+engineers to work on OSS will set your business up for success.
 
-If you have any questions on how to get started with contributing to open-source at your company, [send us a message](https://simplabs.com/contact/). You can also book [a workshop for your engineering team](https://simplabs.com/services/training/) to jump start the process of contributing.
+If you have any questions on how to get started with contributing to open-source
+at your company, [send us a message](https://simplabs.com/contact/). You can
+also book
+[a workshop for your engineering team](https://simplabs.com/services/training/)
+to jump start the process of contributing.
 
 ## Sources
 
@@ -112,4 +247,6 @@ If you have any questions on how to get started with contributing to open-source
 - [13: "Europe's leading Ember experts". simplabs. 2019.](https://simplabs.com/expertise/ember/)
 - [14: "2016 - Future of Open Source Survey Results". Black Duck by Synopsys. 2016](https://www.slideshare.net/blackducksoftware/2016-future-of-open-source-survey-results)
 
-This post is based on the talk ["That's what you get for letting your developers work on open-source"](https://speakerdeck.com/jessicajordanjs/thats-what-youre-gonna-get-for-letting-your-developers-work-on-open-source) at [HiveConf 2019](https://hive.honeypot.io/hiveconf-2019/).
+This post is based on the talk
+["That's what you get for letting your developers work on open-source"](https://speakerdeck.com/jessicajordanjs/thats-what-youre-gonna-get-for-letting-your-developers-work-on-open-source)
+at [HiveConf 2019](https://hive.honeypot.io/hiveconf-2019/).

--- a/_posts/2019-12-20-clarity-in-templates.md
+++ b/_posts/2019-12-20-clarity-in-templates.md
@@ -5,14 +5,20 @@ github: locks
 twitter: locks
 topic: ember
 bio: 'Senior Frontend Engineer, Ember Framework and Learning Core teams member'
-description: 'Ricardo Mendes explains how Ember templates have evolved in the path to Ember Octane to bring more clarity for developers.'
+description:
+  'Ricardo Mendes explains how Ember templates have evolved in the path to Ember
+  Octane to bring more clarity for developers.'
 og:
   image: /assets/images/posts/2019-12-20-clarity-in-templates/og-image.png
 ---
 
-When reading Ember templates, have you ever wondered where a certain dynamic value comes from? Is that dynamic value a property of the component, a named argument that was passed in, or even a helper?
+When reading Ember templates, have you ever wondered where a certain dynamic
+value comes from? Is that dynamic value a property of the component, a named
+argument that was passed in, or even a helper?
 
-In this blog post we will be discussing how recent Ember.js modernization efforts on the path to Ember Octane have brought features that help with this exact problem.
+In this blog post we will be discussing how recent Ember.js modernization
+efforts on the path to Ember Octane have brought features that help with this
+exact problem.
 
 <!--break-->
 
@@ -20,15 +26,34 @@ In this blog post we will be discussing how recent Ember.js modernization effort
 
 ## Ember Octane and editions
 
-As a framework that values stability and providing its users solid upgrade paths, Ember has accrued its fair share of idiosyncrasies. One of the more demonstrable consequences of this is the so called pit of incoherence, alluded to in the [opening keynote of EmberConf 2019](https://www.youtube.com/watch?v=zYwdBcmz6VI): APIs are introduced that move the framework to a new mental model, but that mental model isn't complete yet. This leaves users unsure of which APIs to use when, and how the interop might work.
+As a framework that values stability and providing its users solid upgrade
+paths, Ember has accrued its fair share of idiosyncrasies. One of the more
+demonstrable consequences of this is the so called pit of incoherence, alluded
+to in the
+[opening keynote of EmberConf 2019](https://www.youtube.com/watch?v=zYwdBcmz6VI):
+APIs are introduced that move the framework to a new mental model, but that
+mental model isn't complete yet. This leaves users unsure of which APIs to use
+when, and how the interop might work.
 
-This is where editions come into play. The main goal of editions is to document and present a new and coherent mental model that developers can adhere to, while keeping compatibility with existing APIs. This is done in one of two ways, either a new API that can coexist with existing ones is introduced, or an optional feature that users can opt into is introduced. This allows for new applications to have the optional features and default blueprints of the newer editions, while existing applications can update their codebase at their own pace.
+This is where editions come into play. The main goal of editions is to document
+and present a new and coherent mental model that developers can adhere to, while
+keeping compatibility with existing APIs. This is done in one of two ways,
+either a new API that can coexist with existing ones is introduced, or an
+optional feature that users can opt into is introduced. This allows for new
+applications to have the optional features and default blueprints of the newer
+editions, while existing applications can update their codebase at their own
+pace.
 
-In this blog post we will address some changes to templates that were introduced with Ember Octane in mind, the first planned edition for the Ember.js framework. You can read more about Octane in the [official edition page](https://emberjs.com/editions/octane)].
+In this blog post we will address some changes to templates that were introduced
+with Ember Octane in mind, the first planned edition for the Ember.js framework.
+You can read more about Octane in the
+[official edition page](https://emberjs.com/editions/octane)].
 
 ## Ambiguity
 
-In Ember templates, interpolation of dynamic values is done through curly braces, `{{}}`. Given this is the only syntax for dynamic values, there is an ambiguity problem at times. Let us look at a template:
+In Ember templates, interpolation of dynamic values is done through curly
+braces, `{{}}`. Given this is the only syntax for dynamic values, there is an
+ambiguity problem at times. Let us look at a template:
 
 ```hbs
 {{! app/templates/components/blog/post.hbs }}
@@ -46,13 +71,19 @@ In Ember templates, interpolation of dynamic values is done through curly braces
 {{/if}}
 ```
 
-Looking only at the template, can we be certain where `title` comes from? Whether `post-body` and `comment` are helpers or components? We can generously assume that `comment` is a component as it is receiving an action, but when scanning the file it is indistinguishable from `if`, `each`, and other templating constructs.
+Looking only at the template, can we be certain where `title` comes from?
+Whether `post-body` and `comment` are helpers or components? We can generously
+assume that `comment` is a component as it is receiving an action, but when
+scanning the file it is indistinguishable from `if`, `each`, and other
+templating constructs.
 
 We will work step by step to remove ambiguity where we can.
 
 ### Disambiguating properties
 
-We will start by marking which dynamic values come from the component's JavaScript. These are called properties. To do that we are going to consult the JavaScript file to see which properties it might define:
+We will start by marking which dynamic values come from the component's
+JavaScript. These are called properties. To do that we are going to consult the
+JavaScript file to see which properties it might define:
 
 ```js
 import Component from '@ember/component';
@@ -74,7 +105,8 @@ export default Component.extend({
 });
 ```
 
-We see that `title` is a computed property, and `commentsExpanded` is a boolean defined in the class definition, so we will update the template accordingly:
+We see that `title` is a computed property, and `commentsExpanded` is a boolean
+defined in the class definition, so we will update the template accordingly:
 
 ```hbs
 {{! app/templates/components/blog/post.hbs }}
@@ -92,20 +124,32 @@ We see that `title` is a computed property, and `commentsExpanded` is a boolean 
 {{/if}}
 ```
 
-The great thing about this feature is that all versions of Ember support it, so you can start annotating properties in your templates today. You can also enforce that no new implicit `this` are added to templates by configuring the appropriate [`ember-template-lint`](https://github.com/ember-template-lint/ember-template-lint) rule.
+The great thing about this feature is that all versions of Ember support it, so
+you can start annotating properties in your templates today. You can also
+enforce that no new implicit `this` are added to templates by configuring the
+appropriate
+[`ember-template-lint`](https://github.com/ember-template-lint/ember-template-lint)
+rule.
 
 ### Disambiguating named arguments
 
-Next we will turn our attention to named arguments. We give this name to values that we pass into components when we use them. Since components do not have access to the context where they are called in, this is the primary way to pass information into them.
+Next we will turn our attention to named arguments. We give this name to values
+that we pass into components when we use them. Since components do not have
+access to the context where they are called in, this is the primary way to pass
+information into them.
 
-To see what we are passing into our `blog/post` component, we need to see how it is used in our application. To do this, we will check a route template, namely the template for the `blog` route, where the component is used:
+To see what we are passing into our `blog/post` component, we need to see how it
+is used in our application. To do this, we will check a route template, namely
+the template for the `blog` route, where the component is used:
 
 ```hbs
 {{! app/templates/blog.hbs }}
 {{blog/post post=post onReportComment=(action 'onReportComment')}}
 ```
 
-We can see that when calling the component, we are passing in `post` and `onReportComment`. The syntax to mark them as named argument is a `@` prefix, so let us update our template:
+We can see that when calling the component, we are passing in `post` and
+`onReportComment`. The syntax to mark them as named argument is a `@` prefix, so
+let us update our template:
 
 ```hbs
 {{! app/templates/components/blog/post.hbs }}
@@ -123,19 +167,36 @@ We can see that when calling the component, we are passing in `post` and `onRepo
 {{/if}}
 ```
 
-We have improved our template a further step, now we can tell properties and named arguments apart. Next we will dive into component invocation.
+We have improved our template a further step, now we can tell properties and
+named arguments apart. Next we will dive into component invocation.
 
-If you wish to use named arguments in your application, you can use [`ember-named-arguments-polyfill`](https://github.com/rwjblue/ember-named-arguments-polyfill) for Ember.js versions older than 3.1.
+If you wish to use named arguments in your application, you can use
+[`ember-named-arguments-polyfill`](https://github.com/rwjblue/ember-named-arguments-polyfill)
+for Ember.js versions older than 3.1.
 
-Named arguments mostly apply to components, since they are the piece of Ember that is explicitly invoked by developers unlike route templates which the framework renders for you.
+Named arguments mostly apply to components, since they are the piece of Ember
+that is explicitly invoked by developers unlike route templates which the
+framework renders for you.
 
-Note that `@model` was introduced by [RFC #523 "Model Argument for Route Templates"](https://emberjs.github.io/rfcs/0523-model-argument-for-route-templates.html) so that you can refer directly to the model that was passed to a route template.
+Note that `@model` was introduced by
+[RFC #523 "Model Argument for Route Templates"](https://emberjs.github.io/rfcs/0523-model-argument-for-route-templates.html)
+so that you can refer directly to the model that was passed to a route template.
 
 ### Disambiguating components
 
-After the last change, it would be nice to have a way to disambiguate component invocations from other kinds of dynamic interpolations. Fortunately, a new syntax was introduced by [RFC #311 "Angle Bracket Invocation"](https://emberjs.github.io/rfcs/0311-angle-bracket-invocation.html), that allows us to do just that. Using angle bracket invocation also enables us to distinguish between named arguments passed to the component, and HTML attributes passed to the component. HTML attributes and `...attributes` will be covered in a future post.
+After the last change, it would be nice to have a way to disambiguate component
+invocations from other kinds of dynamic interpolations. Fortunately, a new
+syntax was introduced by
+[RFC #311 "Angle Bracket Invocation"](https://emberjs.github.io/rfcs/0311-angle-bracket-invocation.html),
+that allows us to do just that. Using angle bracket invocation also enables us
+to distinguish between named arguments passed to the component, and HTML
+attributes passed to the component. HTML attributes and `...attributes` will be
+covered in a future post.
 
-To update, we replace curly braces with an HTML-like `<>` syntax–hence angle bracket invocation,–using capital case for the name of the component, `::` instead of `/` for nested components, and prefixing named arguments with `@`. Here is how the above `blog` and `blog/post` templates look like once updated:
+To update, we replace curly braces with an HTML-like `<>` syntax–hence angle
+bracket invocation,–using capital case for the name of the component, `::`
+instead of `/` for nested components, and prefixing named arguments with `@`.
+Here is how the above `blog` and `blog/post` templates look like once updated:
 
 ```hbs
 {{! app/templates/blog.hbs }}
@@ -158,20 +219,39 @@ To update, we replace curly braces with an HTML-like `<>` syntax–hence angle b
 {{/if}}
 ```
 
-To use this feature in older versions of Ember and its dependencies, you can use [`ember-angle-bracket-invocation-polyfilll`](https://github.com/rwjblue/ember-angle-bracket-invocation-polyfill).
+To use this feature in older versions of Ember and its dependencies, you can use
+[`ember-angle-bracket-invocation-polyfilll`](https://github.com/rwjblue/ember-angle-bracket-invocation-polyfill).
 
-With just a couple of tweaks, we now have much more clarity when reading a template, and the need to consult additional files is lessened:
+With just a couple of tweaks, we now have much more clarity when reading a
+template, and the need to consult additional files is lessened:
 
-- `{{this.title}}` is a property that comes from the JavaScript file of the component;
+- `{{this.title}}` is a property that comes from the JavaScript file of the
+  component;
 - `<PostBody />` is a component invocation;
 - `{{@post}}` is a named argument that is passed to the component when invoked;
 - `{{this.commentsExpanded}}` is also a property;
 - `if` and `each` are templating constructs
-- `commentObject` is a block argument that is available inside the `each` block scope
+- `commentObject` is a block argument that is available inside the `each` block
+  scope
 - `<Comment />` is a component invocation
 
-These were not the only improvements made to Ember's templating engine, or even to components. Also introduced to the framework were the ability to pass HTML attributes to components and apply them with `...attributes`, a simplification of DOM event handling with the [`on`](https://emberjs.github.io/rfcs/0471-on-modifier.html) and [`fn`](https://emberjs.github.io/rfcs/0470-fn-helper.html) modifiers replacing `action`, the ability for users to create [custom element modifiers](https://github.com/ember-modifier/ember-modifier) like the built-in `action`, `on`, and `fn`, [rendering lifecycle element modifiers](https://github.com/emberjs/ember-render-modifiers), and [Glimmer components](https://emberjs.github.io/rfcs/0416-glimmer-components.html).
+These were not the only improvements made to Ember's templating engine, or even
+to components. Also introduced to the framework were the ability to pass HTML
+attributes to components and apply them with `...attributes`, a simplification
+of DOM event handling with the
+[`on`](https://emberjs.github.io/rfcs/0471-on-modifier.html) and
+[`fn`](https://emberjs.github.io/rfcs/0470-fn-helper.html) modifiers replacing
+`action`, the ability for users to create
+[custom element modifiers](https://github.com/ember-modifier/ember-modifier)
+like the built-in `action`, `on`, and `fn`,
+[rendering lifecycle element modifiers](https://github.com/emberjs/ember-render-modifiers),
+and
+[Glimmer components](https://emberjs.github.io/rfcs/0416-glimmer-components.html).
 
-These new features will be covered in upcoming posts, so be sure to keep an eye out for them!
+These new features will be covered in upcoming posts, so be sure to keep an eye
+out for them!
 
-If you are looking for help to update your codebase to these new idioms, or you want to level up your engineering team, make sure to [contact us](https://simplabs.com/contact/) so we can work together towards achieving your goals.
+If you are looking for help to update your codebase to these new idioms, or you
+want to level up your engineering team, make sure to
+[contact us](https://simplabs.com/contact/) so we can work together towards
+achieving your goals.

--- a/_posts/2020-01-31-how-to-over-engineer-a-static-page.md
+++ b/_posts/2020-01-31-how-to-over-engineer-a-static-page.md
@@ -5,7 +5,8 @@ github: marcoow
 twitter: marcoow
 topic: javascript
 bio: 'Founding Director of simplabs, author of Ember Simple Auth'
-description: 'Marco Otte-Witte on how we rebuilt simplabs.com and optimized it for maximum
+description:
+  'Marco Otte-Witte on how we rebuilt simplabs.com and optimized it for maximum
   performance leveraging static pre-rendering and client-side rehydration,
   advanced bundling and caching and service workers.'
 og:

--- a/_posts/2020-02-28-the-little-changes-that-helped-to-transform-an-RFC-into-emberjs-com.md
+++ b/_posts/2020-02-28-the-little-changes-that-helped-to-transform-an-RFC-into-emberjs-com.md
@@ -5,7 +5,10 @@ github: pichfl
 twitter: pichfl
 topic: design
 bio: 'Consultant for Design & Technology'
-description: 'Florian Pichler highlights details of the just released overhaul of the landing page for Ember.js, looking specifically at how a distributed team of volunteers can achieve consistent design.'
+description:
+  'Florian Pichler highlights details of the just released overhaul of the
+  landing page for Ember.js, looking specifically at how a distributed team of
+  volunteers can achieve consistent design.'
 og:
   image: /assets/images/posts/2020-02-28-the-little-changes-that-helped-to-transform-an-RFC-into-emberjs-com/og-image.png
 ---
@@ -31,17 +34,19 @@ final website.
 
 ![Side by side comparison of the original website mockup from the RFC and the final mockup created by me](/assets/images/posts/2020-02-28-the-little-changes-that-helped-to-transform-an-RFC-into-emberjs-com/before-after.jpg#full@1200-2761)
 
-<small>You can also download a [full sized comparision, side by side](https://user-images.githubusercontent.com/194641/75565735-c9559700-5a4e-11ea-8dd2-5bae88a694e0.jpg). Be warned, it is huge.</small>
+<small>You can also download a
+[full sized comparision, side by side](https://user-images.githubusercontent.com/194641/75565735-c9559700-5a4e-11ea-8dd2-5bae88a694e0.jpg).
+Be warned, it is huge.</small>
 
 ## Large changes
 
-After a discussion with the Ember Learning Core team, the "Try out" section was removed.
-There wasn't enough time left to create the section in a meaningful way and
-it didn't communicate the real strengths of Ember.js.
+After a discussion with the Ember Learning Core team, the "Try out" section was
+removed. There wasn't enough time left to create the section in a meaningful way
+and it didn't communicate the real strengths of Ember.js.
 
 We unfolded the tabs in the Batteries included section, so the core benefits of
-Ember are visible right away. This gave us a chance to add playful
-illustrations and lighten up the otherwise quite technical content.
+Ember are visible right away. This gave us a chance to add playful illustrations
+and lighten up the otherwise quite technical content.
 
 ## Little changes, big effort
 
@@ -72,10 +77,10 @@ layout organization to any element on a page.
 ![Slate gradient, Ember brand color with gradiated variations](/assets/images/posts/2020-02-28-the-little-changes-that-helped-to-transform-an-RFC-into-emberjs-com/gradient.png#@860-1720)
 
 The RFC mockup introduces a new slate color to mark a new era for Ember. The
-Ember red represents the community. The new slate stands for the
-professionalism and strong foundation in quality. In short, they are meant to
-symbolize that Ember's strength lies in its an amazing community and reliability
-for businesses.
+Ember red represents the community. The new slate stands for the professionalism
+and strong foundation in quality. In short, they are meant to symbolize that
+Ember's strength lies in its an amazing community and reliability for
+businesses.
 
 As you might have noticed, we are still lacking secondary colors, which are not
 settled yet and will become part of the second pass of changes to the Ember.js
@@ -104,19 +109,19 @@ Beyond the purely visual aspects of the design, I also introduced some
 lightweight CSS helpers for things like spacing, font sizes, grid and layout.
 Some of them were inspired by [Tailwind][tailwind], while others are explicitly
 narrow in their options to ensure overall consistency and to make them easier
-for contributors of the website to work with. Take a look at the
-[styleguide preview][styleguide-preview] to learn more about this.
+for contributors of the website to work with. Take a look at the [styleguide
+preview][styleguide-preview] to learn more about this.
 
 [tailwind]: https://tailwindcss.com
 [styleguide-preview]: https://deploy-preview-145--ember-styleguide.netlify.com/
 
 ## Thanks
 
-Allocated time donated by simplabs allowed me and others to bring the
-styleguide and overall design of the website to what you can see online now. I
-was very honored by being invited to this project and my design changes were
-just an ever so small piece of the huge effort that went into the website from
-every single human on this team.
+Allocated time donated by simplabs allowed me and others to bring the styleguide
+and overall design of the website to what you can see online now. I was very
+honored by being invited to this project and my design changes were just an ever
+so small piece of the huge effort that went into the website from every single
+human on this team.
 
 I'm glad we made it, and I'm looking forward to contributing more and updating
 all the other aspecs of the Ember.js website landscape soon.

--- a/_posts/2020-03-27-porting-a-site-to-ember-with-percy.md
+++ b/_posts/2020-03-27-porting-a-site-to-ember-with-percy.md
@@ -5,14 +5,16 @@ github: mansona
 twitter: real_ate
 topic: ember
 bio: 'Senior Software Engineer, Ember Learning Core Team member'
-description: 'Chris Manson details a novel way to use Percy for tracking approximation of a visual baseline when porting a site from one technology to another.'
+description:
+  'Chris Manson details a novel way to use Percy for tracking approximation of a
+  visual baseline when porting a site from one technology to another.'
 og:
   image: /assets/images/posts/2020-03-27-porting-a-site-to-ember-with-percy/og-image.png
 ---
 
 This article details a technique where the visual testing software
-[Percy](https://percy.io/) was used to port the old [Ember
-Guides](https://guides.emberjs.com/release/) to an entirely different
+[Percy](https://percy.io/) was used to port the old
+[Ember Guides](https://guides.emberjs.com/release/) to an entirely different
 technology, without anybody noticing.
 
 <!--break-->
@@ -21,12 +23,12 @@ technology, without anybody noticing.
 
 ## Motivation
 
-This was one of the first steps in the long road to _Emberify_ and
-redesign the Ember website by first converting the architecture away from an old
-(and hard to maintain) Ruby middleman app, to a modern Static Single Page
-Application that is a dream to contribute to! This technique was first used to
-convert the [Ember Guides](https://guides.emberjs.com) to an Ember app and was
-then later used to convert the main [Ember Website](https://emberjs.com).
+This was one of the first steps in the long road to _Emberify_ and redesign the
+Ember website by first converting the architecture away from an old (and hard to
+maintain) Ruby middleman app, to a modern Static Single Page Application that is
+a dream to contribute to! This technique was first used to convert the
+[Ember Guides](https://guides.emberjs.com) to an Ember app and was then later
+used to convert the main [Ember Website](https://emberjs.com).
 
 The technique described below is a slightly novel way of using Percy, instead of
 tracking changes over the course of an active project we are using Percy to
@@ -92,17 +94,17 @@ what the site used to look like against the current changes.
 ### Getting a copy of the existing site
 
 The first thing that we need in this process is a local copy of the existing
-site we are planning to port. If you look at the [documentation for using the
-Percy command line client](https://docs.percy.io/docs/command-line-client) it
-tells you that you should build your static site locally and then point the CLI
-client to the output folder.
+site we are planning to port. If you look at the
+[documentation for using the Percy command line client](https://docs.percy.io/docs/command-line-client)
+it tells you that you should build your static site locally and then point the
+CLI client to the output folder.
 
 As I briefly mentioned earlier, part of the issue with the old infrastructure
 for the Ember Guides was that it was so hard to contribute to that it was almost
-impossible to get working locally. If we can avoid having to run the
-Ruby middleman setup locally, that would be a better approach, so another
-way to get a static copy of the website would be to pretend that we're Google
-for a few minutes and just crawl the site to download it locally.
+impossible to get working locally. If we can avoid having to run the Ruby
+middleman setup locally, that would be a better approach, so another way to get
+a static copy of the website would be to pretend that we're Google for a few
+minutes and just crawl the site to download it locally.
 
 If you are on a Linux machine you probably have `wget` installed, it is a
 particularly useful tool to download single files quickly and easily. If you are
@@ -113,8 +115,8 @@ install it:
 brew install wget
 ```
 
-Before working on this project I didn't actually realise that, not only
-can you use `wget` to download single files but you can also use it to crawl and
+Before working on this project I didn't actually realise that, not only can you
+use `wget` to download single files but you can also use it to crawl and
 download entire websites! Here is the command that I'm using to download the
 entire [Ember Website](https://emberjs.com):
 
@@ -138,15 +140,15 @@ you are planning to run this on your own site I would recommend using the
 `--domains` option, and you might want to also look into `--reject-regex`.
 
 When crawling sites with something like `wget` things can very quickly get out
-of hand. If your site has external links to other domains and you don't
-limit the domains you want to download with `--domains` you can very quickly end
-up downloading the whole internet!
+of hand. If your site has external links to other domains and you don't limit
+the domains you want to download with `--domains` you can very quickly end up
+downloading the whole internet!
 
 `--reject-regex` is also a useful tool if you have some subfolders that have
 dynamically generated content. When we first ran this command on the Ember
 website the blog was available at https://emberjs.com/blog and had 220+ pages
-that would be downloaded in our crawl. 😬 Adding the following line to our `wget`
-command would have excluded that whole directory
+that would be downloaded in our crawl. 😬 Adding the following line to our
+`wget` command would have excluded that whole directory
 
 ```
 --reject-regex '/blog/*'
@@ -154,13 +156,13 @@ command would have excluded that whole directory
 
 ### Verifying all the pages are there
 
-After running the above command we have a folder `emberjs.com` that contains
-a static copy of the Ember Website. We now need to list all of the pages and
-make sure that we're happy that we've captured all of the necessary pages.
+After running the above command we have a folder `emberjs.com` that contains a
+static copy of the Ember Website. We now need to list all of the pages and make
+sure that we're happy that we've captured all of the necessary pages.
 
 Thankfully we used `--html-extension` which will make sure that all html files
-end with `.html` so we can run a simple `find` command in that folder to list the
-pages:
+end with `.html` so we can run a simple `find` command in that folder to list
+the pages:
 
 ```bash
 find . -iname '*.html'
@@ -203,14 +205,14 @@ the baseline around which all of the rest of the application will be built.
 
 ## Setting up Percy for the Ember Application
 
-The [official documentation for the Percy Ember
-integration](https://docs.percy.io/docs/ember) is fantastic and I would
-**highly** recommend that you check it out. We need to set up a very slightly
-custom implementation for our needs because we would like the snapshots that
-were generated from the Percy CLI to match the snapshots from the ember
-application. The simplest way to do this is for us to define the mapping
-manually, here is what that mapping looks like in the ember-website testing
-code:
+The
+[official documentation for the Percy Ember integration](https://docs.percy.io/docs/ember)
+is fantastic and I would **highly** recommend that you check it out. We need to
+set up a very slightly custom implementation for our needs because we would like
+the snapshots that were generated from the Percy CLI to match the snapshots from
+the ember application. The simplest way to do this is for us to define the
+mapping manually, here is what that mapping looks like in the ember-website
+testing code:
 
 ```javascript
 // This is used to map the current **new** routes to what they used to be in the
@@ -222,9 +224,15 @@ const pages = [
   { title: '/builds/canary/index.html', route: '/releases/canary' },
   { title: '/builds/release/index.html', route: '/releases/release' },
   { title: '/community/index.html', route: '/community/' },
-  { title: '/community/meetups-getting-started.html', route: '/community/meetups-getting-started/' },
+  {
+    title: '/community/meetups-getting-started.html',
+    route: '/community/meetups-getting-started/',
+  },
   { title: '/community/meetups.html', route: '/community/meetups/' },
-  { title: '/ember-community-survey-2019.html', route: '/ember-community-survey-2019/' },
+  {
+    title: '/ember-community-survey-2019.html',
+    route: '/ember-community-survey-2019/',
+  },
   { title: '/ember-users.html', route: '/ember-users/' },
   { title: '/guidelines.html', route: '/guidelines/' },
   { title: '/index.html', route: '/' },
@@ -257,9 +265,8 @@ for (let config of pages) {
 }
 ```
 
-Even though I've copied most of the implementation into this post you can [see
-it all in action directly in the source code of the ember-website
-project](https://github.com/ember-learn/ember-website/blob/401a638dbb65191d1273de8336525bf9df6b53bc/tests/acceptance/visual-regression-test.js#L1)
+Even though I've copied most of the implementation into this post you can
+[see it all in action directly in the source code of the ember-website project](https://github.com/ember-learn/ember-website/blob/401a638dbb65191d1273de8336525bf9df6b53bc/tests/acceptance/visual-regression-test.js#L1)
 
 ## Open a PR, Iterate on the design, Ship when green
 
@@ -271,13 +278,12 @@ pushed to your master branch. Once you open the PR, if you have followed the
 Percy installation instructions correctly, Percy will start to build your visual
 diff.
 
-The examples shown in this post have been leading up to [an
-actual PR on the ember-website
-project](https://github.com/ember-learn/ember-website/pull/185) and you will see
-in the CI checks for that PR that the initial Percy build is failing. If you saw
-the visual diff you would have seen that there was quite some work that needed
-to be done before this was ready to go live, but I never said that this would do
-all the work for you! 😂
+The examples shown in this post have been leading up to
+[an actual PR on the ember-website project](https://github.com/ember-learn/ember-website/pull/185)
+and you will see in the CI checks for that PR that the initial Percy build is
+failing. If you saw the visual diff you would have seen that there was quite
+some work that needed to be done before this was ready to go live, but I never
+said that this would do all the work for you! 😂
 
 What Percy is really giving you here is the confidence to know when the project
 is ready to be shipped. If you can constrain the requirements to "make it look

--- a/package.json
+++ b/package.json
@@ -121,6 +121,13 @@
         "options": {
           "singleQuote": false
         }
+      },
+      {
+        "files": "*.md",
+        "options": {
+          "printWidth": 80,
+          "proseWrap": "always"
+        }
       }
     ]
   },


### PR DESCRIPTION
This makes the files (in particular blog posts) more uniform in style and – which is more important in my opinion even – makes reviews much nicer. With super long lines, it's very hard to comment on a particular part of a sentences when that is located on character 500 of the respective line. Also using Github's suggestions is very hard with these long lines. With everything wrapped after 80 characters that all becomes much simpler.