### PR TITLE
use 2 columns layout for more case studies teaser

### DIFF
--- a/src/ui/components/PageWork/stylesheet.css
+++ b/src/ui/components/PageWork/stylesheet.css
@@ -7,16 +7,6 @@
   composes: 'layout';
 }
 
-.more {
-  margin-bottom: 8rem;
-  margin-left: 0;
-  list-style: none;
-}
-
-.more-headline {
-  margin-bottom: 3rem;
-}
-
 @export typography;
 @export layout;
 @export offset;

--- a/src/ui/components/PageWork/template.hbs
+++ b/src/ui/components/PageWork/template.hbs
@@ -61,28 +61,28 @@
     @key="boldTimify"
   />
 
-  <div layout:class="main" offset:class="after-21">
+  <div layout:class="full">
     <h2>
       More Case Studies
     </h2>
-    <ul>
-      <li block:class="more">
-        <h3 typography:class="h4">
-          A modern UI for an open-source router firmware
-        </h3>
-        <ArrowLink @href="/cases/ddwrt/">
-          Read Case Study
-        </ArrowLink>
-      </li>
-      <li block:class="more">
-        <h3 typography:class="h4" block:class="more-headline">
-          An online travel magazine for global citizens
-        </h3>
-        <ArrowLink @href="/cases/expedition/">
-          Read Case Study
-        </ArrowLink>
-      </li>
-    </ul>
+  </div>
+  <div layout:scope offset:class="after-21">
+    <div layout:class="split-leading">
+      <h3 typography:class="h4">
+        A modern UI for an open-source router firmware
+      </h3>
+      <ArrowLink @href="/cases/ddwrt/">
+        Read Case Study
+      </ArrowLink>
+    </div>
+    <div layout:class="split-trailing">
+      <h3 typography:class="h4">
+        An online travel magazine for global citizens
+      </h3>
+      <ArrowLink @href="/cases/expedition/">
+        Read Case Study
+      </ArrowLink>
+    </div>
   </div>
   <ShapeAcrossPlaybook />
   <WorkWithUs @teamMember="ghislaine" />


### PR DESCRIPTION
This changes the teasers to the other case studies on the work page to use a 2 column layout on desktop:

<img width="1399" alt="Bildschirmfoto 2020-04-08 um 11 20 56" src="https://user-images.githubusercontent.com/1510/78767600-19e3dc80-798b-11ea-8b77-cc72eb8bbd55.png">

On mobile viewports the teasers appear in 1 column still:

<img width="616" alt="Bildschirmfoto 2020-04-08 um 11 21 02" src="https://user-images.githubusercontent.com/1510/78767626-2405db00-798b-11ea-9ef8-43f2e65547da.png">

addresses part of #1003 