### PR TITLE
Align shape angles

### DIFF
--- a/src/ui/components/Header/stylesheet.css
+++ b/src/ui/components/Header/stylesheet.css
@@ -181,8 +181,8 @@
     width: 100%;
     padding-bottom: 25%;
     margin-top: -1px;
-    -webkit-clip-path: polygon(0 50%, 100% 100%, 100% 0, 0 0);
-    clip-path: polygon(0 50%, 100% 100%, 100% 0, 0 0);
+    -webkit-clip-path: polygon(0 35%, 100% 100%, 100% 0, 0 0);
+    clip-path: polygon(0 35%, 100% 100%, 100% 0, 0 0);
   }
 
   .nav-item,

--- a/src/ui/components/Header/stylesheet.css
+++ b/src/ui/components/Header/stylesheet.css
@@ -112,20 +112,21 @@
 :scope[backgroundVariation='pointed'] .background-bottom {
   margin-top: 6rem;
   width: 100%;
-  padding-bottom: 16.5%;
   margin-top: -1px;
   grid-column: 1/-1;
   background-color: var(--color-background);
 }
 
 :scope[backgroundVariation='inclined'] .background-bottom {
+  padding-bottom: 16.5%;
   -webkit-clip-path: polygon(0 0, 0 calc(100% + 1px), 100% calc(100% + 1px));
   clip-path: polygon(0 0, 0 calc(100% + 1px), 100% calc(100% + 1px));
 }
 
 :scope[backgroundVariation='pointed'] .background-bottom {
-  -webkit-clip-path: polygon(0 100%, 100% 100%, 100% 15%, 77.5% 100%, 0 15%);
-  clip-path: polygon(0 100%, 100% 100%, 100% 15%, 77.5% 100%, 0 15%);
+  padding-top: 15%;
+  -webkit-clip-path: polygon(0 100%, 100% 100%, 100% 36%, 60% 100%, 0 33%);
+  clip-path: polygon(0 100%, 100% 100%, 100% 36%, 60% 100%, 0 33%);
 }
 
 @media (max-width: 887px) {
@@ -208,8 +209,8 @@
 
   :scope[backgroundVariation='pointed'] .background-bottom {
     margin-top: -50%;
-    -webkit-clip-path: polygon(0 100%, 100% 100%, 100% 55%, 0 0);
-    clip-path: polygon(0 100%, 100% 100%, 100% 55%, 0 0);
+    -webkit-clip-path: polygon(0 100%, 100% 100%, 100% 35%, 0 0);
+    clip-path: polygon(0 100%, 100% 100%, 100% 35%, 0 0);
   }
 }
 

--- a/src/ui/components/Header/stylesheet.css
+++ b/src/ui/components/Header/stylesheet.css
@@ -104,19 +104,23 @@
   background-color: var(--color-light);
 }
 
+:scope[backgroundVariation='inclined'] {
+  margin-bottom: 5rem;
+}
+
 :scope[backgroundVariation='inclined'] .background-bottom,
 :scope[backgroundVariation='pointed'] .background-bottom {
   margin-top: 6rem;
   width: 100%;
-  padding-bottom: 12.5%;
+  padding-bottom: 16.5%;
   margin-top: -1px;
   grid-column: 1/-1;
   background-color: var(--color-background);
 }
 
 :scope[backgroundVariation='inclined'] .background-bottom {
-  -webkit-clip-path: polygon(0 0, 0 100%, 100% 100%);
-  clip-path: polygon(0 0, 0 100%, 100% 100%);
+  -webkit-clip-path: polygon(0 0, 0 calc(100% + 1px), 100% calc(100% + 1px));
+  clip-path: polygon(0 0, 0 calc(100% + 1px), 100% calc(100% + 1px));
 }
 
 :scope[backgroundVariation='pointed'] .background-bottom {
@@ -127,6 +131,10 @@
 @media (max-width: 887px) {
   :scope {
     margin-bottom: 12rem;
+  }
+
+  :scope[backgroundVariation='inclined'] {
+    margin-bottom: 5rem;
   }
 
   :scope,

--- a/src/ui/components/HeaderContent/stylesheet.css
+++ b/src/ui/components/HeaderContent/stylesheet.css
@@ -4,7 +4,6 @@
 :scope {
   block-name: HeaderContent;
   margin-top: 6rem;
-  margin-bottom: 3rem;
   position: relative;
   grid-column: 1/-1;
   --shape-color: var(--color-accent);
@@ -70,9 +69,14 @@
   width: auto;
 }
 
+:scope[attachment='blue-ribbon'],
+:scope[attachment='image'] {
+  margin-bottom: 5rem;
+}
+
 :scope[attachment='blue-ribbon'] .image-wrapper {
-  clip-path: polygon(40% 0, 100% 20%, 100% 90%, 60% 98.5%, 0 90%, 0 10%);
-  -webkit-clip-path: polygon(40% 0, 100% 20%, 100% 90%, 60% 98.5%, 0 90%, 0 10%);
+  clip-path: polygon(40% 0, 100% 19%, 100% 87.5%, 60% 100%, 0 87.5%, 0 12.5%);
+  -webkit-clip-path: polygon(40% 0, 100% 19%, 100% 87.5%, 60% 100%, 0 87.5%, 0 12.5%);
   padding-bottom: 80%;
 }
 

--- a/src/ui/components/HeaderContent/stylesheet.css
+++ b/src/ui/components/HeaderContent/stylesheet.css
@@ -85,8 +85,8 @@
 }
 
 :scope[attachment='image'] .image-wrapper {
-  clip-path: polygon(0 10%, 0 90%, 100% 100%, 100% 0);
-  -webkit-clip-path: polygon(0 10%, 0 90%, 100% 100%, 100% 0);
+  clip-path: polygon(0 19.25%, 0 86%, 100% 100%, 100% 0);
+  -webkit-clip-path: polygon(0 19.25%, 0 86%, 100% 100%, 100% 0);
   padding-bottom: 120%;
 }
 
@@ -109,12 +109,6 @@
 
   :scope[attachment='blue-ribbon'] .image-wrapper {
     grid-column: 2/-2;
-  }
-
-  :scope[attachment='image'] .image-wrapper {
-    clip-path: polygon(0 14%, 0 86%, 100% 99%, 100% 1%);
-    -webkit-clip-path: polygon(0 14%, 0 86%, 100% 99%, 100% 1%);
-    padding-bottom: 100%;
   }
 
   .background {

--- a/src/ui/components/HeaderContent/stylesheet.css
+++ b/src/ui/components/HeaderContent/stylesheet.css
@@ -26,17 +26,17 @@
 
 .top {
   width: 100%;
-  padding-top: 15%;
+  padding-top: 21%;
   margin-bottom: -1px;
   background: var(--shape-color);
 
-  clip-path: polygon(100% 100%, 100% 20%, 90% 0px, 0 100%);
-  -webkit-clip-path: polygon(100% 100%, 100% 20%, 90% 0px, 0 100%);
+  clip-path: polygon(100% 100%, 100% 12%, 90% 0px, 0 100%);
+  -webkit-clip-path: polygon(100% 100%, 100% 12%, 90% 0px, 0 100%);
 }
 
 .bottom {
   width: 100%;
-  padding-bottom: 13%;
+  padding-bottom: 16.5%;
   margin-top: -1px;
   background: var(--shape-color);
 

--- a/src/ui/components/HeaderContent/stylesheet.css
+++ b/src/ui/components/HeaderContent/stylesheet.css
@@ -36,12 +36,12 @@
 
 .bottom {
   width: 100%;
-  padding-bottom: 12.5%;
+  padding-bottom: 13%;
   margin-top: -1px;
   background: var(--shape-color);
 
-  clip-path: polygon(-1% 0, 100% 0, 100% 100%);
-  -webkit-clip-path: polygon(-1% 0, 100% 0, 100% 100%);
+  clip-path: polygon(0 0, 100% 0, 100% 100%);
+  -webkit-clip-path: polygon(0 0, 100% 0, 100% 100%);
 }
 
 .middle {

--- a/src/ui/components/ShapeFeature/stylesheet.css
+++ b/src/ui/components/ShapeFeature/stylesheet.css
@@ -46,6 +46,10 @@
   :scope {
     margin: 11rem 0 0 0;
   }
+
+  .middle {
+    padding-bottom: 4rem;
+  }
 }
 
 @media (min-width: 888px) {

--- a/src/ui/components/ShapeFeature/stylesheet.css
+++ b/src/ui/components/ShapeFeature/stylesheet.css
@@ -20,27 +20,26 @@
 
 .top {
   width: 100%;
-  padding-top: 15%;
+  padding-top: 14.5%;
   margin-bottom: -1px;
   background: var(--shape-color);
 
-  clip-path: polygon(40% 0%, 100% calc(100% - 1px), 100% 100%, 0 100%, 0 calc(50% - 1px));
-  -webkit-clip-path: polygon(40% 0%, 100% calc(100% - 1px), 100% 100%, 0 100%, 0 calc(50% - 1px));
+  clip-path: polygon(40% 0%, 100% calc(100% - 1px), 100% 100%, 0 100%, 0 calc(65% - 1px));
+  -webkit-clip-path: polygon(40% 0%, 100% calc(100% - 1px), 100% 100%, 0 100%, 0 calc(65% - 1px));
 }
 
 .bottom {
   width: 100%;
-  padding-bottom: 8%;
+  padding-bottom: 10%;
   margin-top: -1px;
   background: var(--shape-color);
 
-  clip-path: polygon(100% 0, 100% 1px, 57% 100%, 0 1px, 0 0);
-  -webkit-clip-path: polygon(100% 0, 100% 1px, 57% 100%, 0 1px, 0 0);
+  clip-path: polygon(100% 0, 100% 4%, 60% 100%, 0 1px, 0 0);
+  -webkit-clip-path: polygon(100% 0, 100% 4%, 60% 100%, 0 1px, 0 0);
 }
 
 .middle {
   background: var(--shape-color);
-  padding-bottom: 4rem;
 }
 
 @media (max-width: 887px) {

--- a/src/ui/components/ShapeFeatureContent/stylesheet.css
+++ b/src/ui/components/ShapeFeatureContent/stylesheet.css
@@ -31,15 +31,19 @@
   display: block;
   margin-top: -20rem;
   margin-bottom: 5rem;
+  padding-top: 80%;
+  position: relative;
 
-  clip-path: polygon(40% 0, 100% 20%, 100% 86.5%, 60% 100%, 0 86.5%, 0 13%);
-  -webkit-clip-path: polygon(40% 0, 100% 20%, 100% 86.5%, 60% 100%, 0 86.5%, 0 13%);
+  clip-path: polygon(40% 0, 100% 19%, 100% 87.5%, 60% 100%, 0 86.5%, 0 12.5%);
+  -webkit-clip-path: polygon(40% 0, 100% 19%, 100% 87.5%, 60% 100%, 0 86.5%, 0 12.5%);
   grid-column: 2/-2;
 }
 
 .img {
   width: 100%;
   height: 100%;
+  position: absolute;
+  top: 0;
 
   object-fit: cover;
 }

--- a/src/ui/components/ShapeFeatureContent/stylesheet.css
+++ b/src/ui/components/ShapeFeatureContent/stylesheet.css
@@ -34,8 +34,8 @@
   padding-top: 80%;
   position: relative;
 
-  clip-path: polygon(40% 0, 100% 19%, 100% 87.5%, 60% 100%, 0 86.5%, 0 12.5%);
-  -webkit-clip-path: polygon(40% 0, 100% 19%, 100% 87.5%, 60% 100%, 0 86.5%, 0 12.5%);
+  clip-path: polygon(40% 0, 100% 19%, 100% 87.5%, 60% 100%, 0 87.5%, 0 12.5%);
+  -webkit-clip-path: polygon(40% 0, 100% 19%, 100% 87.5%, 60% 100%, 0 87.5%, 0 12.5%);
   grid-column: 2/-2;
 }
 

--- a/src/ui/components/ShapeFeatureContent/stylesheet.css
+++ b/src/ui/components/ShapeFeatureContent/stylesheet.css
@@ -11,6 +11,7 @@
   display: grid;
   column-gap: var(--col-gap);
   grid-column: 1/-1;
+  margin-bottom: 0;
 }
 
 .content {
@@ -31,8 +32,8 @@
   margin-top: -20rem;
   margin-bottom: 5rem;
 
-  clip-path: polygon(31% 0, 100% 20%, 100% 92%, 60% 100%, 0 90%, 0 7%);
-  -webkit-clip-path: polygon(31% 0, 100% 20%, 100% 92%, 60% 100%, 0 90%, 0 7%);
+  clip-path: polygon(40% 0, 100% 20%, 100% 86.5%, 60% 100%, 0 86.5%, 0 13%);
+  -webkit-clip-path: polygon(40% 0, 100% 20%, 100% 86.5%, 60% 100%, 0 86.5%, 0 13%);
   grid-column: 2/-2;
 }
 
@@ -77,7 +78,7 @@
 
   .content {
     grid-column: 4/-1;
-    padding: 5rem 5rem 0 5rem;
+    padding: 0 5rem;
   }
 
   .tagline {

--- a/src/ui/components/ShapeFeatureContent/stylesheet.css
+++ b/src/ui/components/ShapeFeatureContent/stylesheet.css
@@ -60,8 +60,9 @@
   .img-wrapper {
     grid-column: 2/-2;
     margin-left: 0;
-    clip-path: polygon(31% 0, 100% 30%, 100% 88%, 60% 100%, 0 87%, 0 10%);
-    -webkit-clip-path: polygon(31% 0, 100% 30%, 100% 88%, 60% 100%, 0 87%, 0 10%);
+    padding-top: 60%;
+    clip-path: polygon(40% 0, 100% 25%, 100% 84.5%, 60% 100%, 0 84.5%, 0 16%);
+    -webkit-clip-path: polygon(40% 0, 100% 25%, 100% 84.5%, 60% 100%, 0 84.5%, 0 16%);
   }
 }
 

--- a/src/ui/components/ShapeImage/stylesheet.css
+++ b/src/ui/components/ShapeImage/stylesheet.css
@@ -11,13 +11,13 @@
 }
 
 :scope[align='left'] {
-  -webkit-clip-path: polygon(100% 20%, 100% 91%, 30% 100%, 0 97%, 0 0);
-  clip-path: polygon(100% 20%, 100% 91%, 30% 100%, 0 97%, 0 0);
+  -webkit-clip-path: polygon(100% 14%, 100% 86%, 30% 100%, 0 96%, 0 0);
+  clip-path: polygon(100% 14%, 100% 86%, 30% 100%, 0 96%, 0 0);
 }
 
 :scope[align='right'] {
-  -webkit-clip-path: polygon(80% 0, 100% 5%, 100% 100%, 0 90%, 0 14%);
-  clip-path: polygon(80% 0, 100% 5%, 100% 100%, 0 90%, 0 14%);
+  -webkit-clip-path: polygon(80% 0, 100% 4.4%, 100% 100%, 0 86%, 0 18%);
+  clip-path: polygon(80% 0, 100% 4.4%, 100% 100%, 0 86%, 0 18%);
 }
 
 @export fluid-image;

--- a/src/ui/components/WorkWithUs/stylesheet.css
+++ b/src/ui/components/WorkWithUs/stylesheet.css
@@ -18,16 +18,16 @@
   background: var(--color-light);
   padding-top: 15%;
   width: 100%;
-  -webkit-clip-path: polygon(55% 100%, 100% 40%, 100% 100%, 0 100%, 0 40%);
-  clip-path: polygon(55% 100%, 100% 40%, 100% 100%, 0 100%, 0 40%);
+  -webkit-clip-path: polygon(60% 100%, 100% 36%, 100% 100%, 0 100%, 0 33%);
+  clip-path: polygon(60% 100%, 100% 36%, 100% 100%, 0 100%, 0 33%);
 }
 
 .bottom {
   background: var(--color-background);
   width: 100%;
   padding-top: 10%;
-  -webkit-clip-path: polygon(75% 0, 100% 80%, 100% 100%, 0 100%, 0 80%);
-  clip-path: polygon(75% 0, 100% 80%, 100% 100%, 0 100%, 0 80%);
+  -webkit-clip-path: polygon(75% 0, 100% 80%, 100% 100%, 0 100%, 0 96%);
+  clip-path: polygon(40% 0, 100% 80%, 100% 100%, 0 100%, 0 96%);
   margin-top: -8%;
   position: relative;
   z-index: 1;


### PR DESCRIPTION
Currently all of the different shape angles are a bit different and they do not lign up properly. Also some depend on viewport width and for some viewport sizes lines might be visibly non-parallel which makes the entire design look bad I think, e.g.:

<img width="1883" alt="Bildschirmfoto 2020-04-09 um 15 35 53" src="https://user-images.githubusercontent.com/1510/78900919-dc10b200-7a77-11ea-98e8-4551a0b9cb0e.png">

This makes **all** of the angles independent of viewport width and makes sure they are aligned and we don't have 10 different angles which look bad if non-parallel elements follow each other or are nested.

With the changes in this PR the above shape looks like this:

<img width="1802" alt="Bildschirmfoto 2020-04-09 um 15 37 35" src="https://user-images.githubusercontent.com/1510/78901077-17ab7c00-7a78-11ea-9968-960d3a50d1a1.png">
