### PR TITLE
better filename for playbook download

### DIFF
--- a/src/ui/components/ShapePlaybook/template.hbs
+++ b/src/ui/components/ShapePlaybook/template.hbs
@@ -6,7 +6,7 @@
           Increase focus and stability in your products now
         </p>
         <a
-          href="https://github.com/simplabs/playbook/releases/download/1.0/book.pdf"
+          href="https://github.com/simplabs/playbook/releases/download/1.0/simplabs-Playbook.pdf"
           button:scope
           block:class="download"
         >


### PR DESCRIPTION
Currently the name of the playbook PDF is just `book.pdf` which is not great as users end up with a file on their computer with a very generic name. This changes the filename to `simplabs-Playbook.pdf`.

Once this is merged, we can remove the extra `book.pdf` asset from https://github.com/simplabs/playbook/releases/tag/1.0