### PR TITLE
Fix book position on mobile playbook download shape

### DIFF
--- a/src/ui/components/ShapePlaybook/stylesheet.css
+++ b/src/ui/components/ShapePlaybook/stylesheet.css
@@ -60,7 +60,7 @@
 
 @media (max-width: 887px) {
   :scope {
-    margin: calc(60rem - 15%) 0 0 0;
+    margin: calc(40rem - 15%) 0 0 0;
   }
 
   .content {
@@ -70,7 +70,7 @@
   .img-wrapper {
     grid-column: 2/-2;
     order: 1;
-    margin: -60rem 0 5rem 0;
+    margin: -40rem 0 5rem 0;
   }
 
   .container {


### PR DESCRIPTION
This fixes the position of the book on the mobile version of the playbook download page in Safari.

| Before | After |
|---|---|
|![80216280-19f80380-863e-11ea-9917-55762de0b29b](https://user-images.githubusercontent.com/1510/80222489-39dff500-8647-11ea-8271-bd5c9078e911.png)|<img width="440" alt="Bildschirmfoto 2020-04-24 um 16 19 41" src="https://user-images.githubusercontent.com/1510/80222620-6dbb1a80-8647-11ea-92ad-e9444e998bc8.png">|

closes #1069 