### PR TITLE
send contact email via Zeit function

### DIFF
--- a/src/ui/components/FormContact/component-test.ts
+++ b/src/ui/components/FormContact/component-test.ts
@@ -29,7 +29,7 @@ module('Component: FormContact', function(hooks) {
   test('it submits', async function(assert) {
     await render(hbs`<PageContact />`);
 
-    this.server.post('https://guqdu9qkgf.execute-api.eu-central-1.amazonaws.com/production', request => {
+    this.server.post('https://simplabs-com-contact-emails.now.sh/api/send', request => {
       assert.equal(request.method, 'POST');
       assert.equal(request.requestHeaders['content-type'], 'application/json');
       assert.deepEqual(JSON.parse(request.requestBody), {

--- a/src/ui/components/FormContact/component.ts
+++ b/src/ui/components/FormContact/component.ts
@@ -57,7 +57,7 @@ export default class FormContact extends Component {
   }
 
   private async sendMessage(name, email, message) {
-    return fetch('https://guqdu9qkgf.execute-api.eu-central-1.amazonaws.com/production', {
+    return fetch('https://simplabs-com-contact-emails.now.sh/api/send', {
       body: JSON.stringify({ name, email, message }),
       cache: 'no-cache',
       headers: {


### PR DESCRIPTION
This sends the contact form emails via a Zeit function instead of the AWS Lambda.