### PR TITLE
send contact email via heroku server

### DIFF
--- a/src/ui/components/FormContact/component-test.ts
+++ b/src/ui/components/FormContact/component-test.ts
@@ -29,7 +29,7 @@ module('Component: FormContact', function(hooks) {
   test('it submits', async function(assert) {
     await render(hbs`<PageContact />`);
 
-    this.server.post('https://simplabs-com-contact-emails.now.sh/api/send', request => {
+    this.server.post('https://simplabs-com-contact-form.herokuapp.com/api/send', request => {
       assert.equal(request.method, 'POST');
       assert.equal(request.requestHeaders['content-type'], 'application/json');
       assert.deepEqual(JSON.parse(request.requestBody), {

--- a/src/ui/components/FormContact/component.ts
+++ b/src/ui/components/FormContact/component.ts
@@ -57,7 +57,7 @@ export default class FormContact extends Component {
   }
 
   private async sendMessage(name, email, message) {
-    return fetch('https://simplabs-com-contact-emails.now.sh/api/send', {
+    return fetch('https://simplabs-com-contact-form.herokuapp.com/api/send', {
       body: JSON.stringify({ name, email, message }),
       cache: 'no-cache',
       headers: {


### PR DESCRIPTION
This delivers emails from the contact form via a heroku server. Running a server there is the same price as using a Vercel function but has the benefit that we can consolidate all of our stuff with one provider which makes things simpler.

**Once this is live, we need to cancel the Vercel subscription**