### PR TITLE
validate os-image files exist

### DIFF
--- a/lib/generate-blog/lib/components-builder.js
+++ b/lib/generate-blog/lib/components-builder.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const assert = require('assert');
+const path = require('path');
+const fs = require('fs-extra');
 
 const dateformat = require('dateformat');
 const _ = require('lodash');
@@ -131,6 +133,10 @@ module.exports = class ComponentsBuilder extends BaseComponentsBuilder {
     assert(
       !ogImage || ogImage.endsWith('/og-image.png'),
       `Post "${post.meta.title}" does has an og:image named "${ogImage}"; the og:image must be named "og-image.png".`,
+    );
+    assert(
+      !ogImage || fs.existsSync(path.join(__dirname, '../../../public', ogImage)),
+      `Post "${post.meta.title}" uses an og:image that does not exist: "${ogImage}".`,
     );
 
     return {


### PR DESCRIPTION
This validates that `og:image` files that are used in blog posts actually exist. This would have prevented the but that was fixed in #1139. It should be fine to only do this for the `og:image` since unlike for all other image references, a broken link would not show up in Percy here.