### PR TITLE
Disable check for canonical URL in Lighthouse

### DIFF
--- a/.lighthouserc.js
+++ b/.lighthouserc.js
@@ -4,7 +4,7 @@ module.exports = {
   ci: {
     collect: {
       settings: {
-        skipAudits: ['is-on-https', 'redirects-http', 'uses-http2', 'uses-webp-images'],
+        skipAudits: ['is-on-https', 'redirects-http', 'uses-http2', 'uses-webp-images', 'canonical'],
       },
     },
     assert: {
@@ -13,6 +13,7 @@ module.exports = {
         'redirects-http': 'off',
         'uses-http2': 'off',
         'uses-webp-images': 'off',
+        'canonical': 'off'
       },
     },
   },


### PR DESCRIPTION
This disables the check for `<link rel="canonical" href="…">` for Lighthouse in CI as the check makes no sense in this setup – we set the `href` to `https://simplabs.com/…` but serve the page from `localhost` in CI so we get an error although everything is going to be fine in production.