### PR TITLE
Fix font loading

### DIFF
--- a/lib/global-css/css/baseline.css
+++ b/lib/global-css/css/baseline.css
@@ -56,7 +56,6 @@ body {
   padding: 0;
   border: 0;
   font-family: 'Nunito Sans', sans-serif;
-  font-display: swap;
   color: var(--color-muted);
 }
 

--- a/lib/global-css/css/fonts.css
+++ b/lib/global-css/css/fonts.css
@@ -1,6 +1,7 @@
 /* latin-ext */
 @font-face {
   font-family: 'Nunito Sans';
+  font-display: swap;
   font-style: normal;
   font-weight: 300;
   src: local('Nunito Sans Light'), local('NunitoSans-Light'),
@@ -10,6 +11,7 @@
 /* latin */
 @font-face {
   font-family: 'Nunito Sans';
+  font-display: swap;
   font-style: normal;
   font-weight: 300;
   src: local('Nunito Sans Light'), local('NunitoSans-Light'),
@@ -20,6 +22,7 @@
 /* latin-ext */
 @font-face {
   font-family: 'Nunito Sans';
+  font-display: swap;
   font-style: normal;
   font-weight: 400;
   src: local('Nunito Sans Regular'), local('NunitoSans-Regular'),
@@ -29,6 +32,7 @@
 /* latin */
 @font-face {
   font-family: 'Nunito Sans';
+  font-display: swap;
   font-style: normal;
   font-weight: 400;
   src: local('Nunito Sans Regular'), local('NunitoSans-Regular'),
@@ -39,6 +43,7 @@
 /* latin-ext */
 @font-face {
   font-family: 'Nunito Sans';
+  font-display: swap;
   font-style: normal;
   font-weight: 700;
   src: local('Nunito Sans Bold'), local('NunitoSans-Bold'),
@@ -48,6 +53,7 @@
 /* latin */
 @font-face {
   font-family: 'Nunito Sans';
+  font-display: swap;
   font-style: normal;
   font-weight: 700;
   src: local('Nunito Sans Bold'), local('NunitoSans-Bold'),

--- a/src/ui/components/CookieBanner/stylesheet.css
+++ b/src/ui/components/CookieBanner/stylesheet.css
@@ -8,7 +8,6 @@
   color: #979797;
   font-size: 2rem;
   font-family: 'Nunito Sans', sans-serif;
-  font-display: swap;
   overflow: hidden;
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.15), 0 4px 6px -2px rgba(0, 0, 0, 0.1), 0 0 1px 0 rgba(0, 0, 0, 0.15);
 }

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -10,6 +10,13 @@
     <link rel="preload" href="{{rootURL}}recent.js" as="script">
     <link rel="preload" href="{{rootURL}}app.js" as="script">
 
+    <link rel="preload" href="{{rootURL}}assets/fonts/nunito-sans/light-latin-ext.woff2" as="font" crossorigin="anonymous">
+    <link rel="preload" href="{{rootURL}}assets/fonts/nunito-sans/light-latin.woff2" as="font" crossorigin="anonymous">
+    <link rel="preload" href="{{rootURL}}assets/fonts/nunito-sans/regular-latin-ext.woff2" as="font" crossorigin="anonymous">
+    <link rel="preload" href="{{rootURL}}assets/fonts/nunito-sans/regular-latin.woff2" as="font" crossorigin="anonymous">
+    <link rel="preload" href="{{rootURL}}assets/fonts/nunito-sans/bold-latin-ext.woff2" as="font" crossorigin="anonymous">
+    <link rel="preload" href="{{rootURL}}assets/fonts/nunito-sans/bold-latin.woff2" as="font" crossorigin="anonymous">
+
     <link rel="stylesheet" href="{{rootURL}}app.css">
 
     {{content-for "head-footer"}}

--- a/src/ui/styles/blocks/screen.block.css
+++ b/src/ui/styles/blocks/screen.block.css
@@ -2,7 +2,6 @@
   block-name: screen;
 
   font-family: 'Nunito Sans', sans-serif;
-  font-display: swap;
   color: var(--color-muted);
   overflow: hidden;
 }


### PR DESCRIPTION
This preloads the webfonts that will otherwise only be discoverd late once the CSS is parsed.

This also fixes the `font-display: swap;` rule which is actually only allowed within `@font-face { … }` blocks and was hence ineffective the way we were using it…

closes #1165 