### PR TITLE
load Google analytics script directly

### DIFF
--- a/lib/google-analytics/index.js
+++ b/lib/google-analytics/index.js
@@ -14,12 +14,14 @@ module.exports = {
 
     if (type === 'body-footer') {
       return `
-        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-53237918-1"></script>
         <script>
-          window.dataLayer = window.dataLayer || [];
-          function gtag(){dataLayer.push(arguments);}
-          gtag('js', new Date());
-          gtag('config', 'UA-53237918-1');
+          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+          })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+          
+          ga('create', 'UA-53237918-1', 'auto');
+          ga('send', 'pageview');
         </script>
       `;
     }


### PR DESCRIPTION
This loads the Google Analytics script directly instead of via Google Tag Manager which we don't need anyway.

closes #1162