### PR TITLE
Fix alt attributes

### DIFF
--- a/src/ui/components/PageContact/template.hbs
+++ b/src/ui/components/PageContact/template.hbs
@@ -50,7 +50,13 @@
       Come by
     </h2>
     <p block:class="map">
-      <img block:class="map-image" src="/assets/images/contact/map.png" width="588" height="350" />
+      <img
+        block:class="map-image"
+        src="/assets/images/contact/map.png"
+        width="588"
+        height="350"
+        alt="Map showing simplabs' office location at Hans-Sachs-Str. 12, 80469 München, Germany"
+      />
       <svg block:class="map-pin" height="71" viewBox="0 0 57 71" width="57" xmlns="http://www.w3.org/2000/svg">
         <path
           d="m48.5630967 8.62661428c11.2241363 11.57921762 11.2241363 30.10596592.1496551 41.53079392l-20.2034454 20.8425918-20.20344549-20.8425918c-11.07448121-11.424828-11.07448121-29.9515763 0-41.37640435l.14965515-.15438957c11.07448124-11.42482807 28.88344424-11.57921764 40.10758064 0-.1496552-.15438956-.1496552-.15438956 0 0z"

--- a/src/ui/components/PagePlaybook/template.hbs
+++ b/src/ui/components/PagePlaybook/template.hbs
@@ -50,6 +50,7 @@
         sizes="(max-width: 887px) 600px, 1200px"
         fluid-image:class="image-clipped"
         block:class="illustration"
+        alt=""
       />
     </div>
   </div>
@@ -151,6 +152,7 @@
         sizes="(max-width: 887px) 600px, 1200px"
         fluid-image:class="image-clipped"
         block:class="illustration"
+        alt=""
       />
     </div>
   </div>

--- a/src/ui/components/ShapePlaybook/template.hbs
+++ b/src/ui/components/ShapePlaybook/template.hbs
@@ -18,7 +18,7 @@
           block:class="img"
           srcset="/assets/images/work/playbook@600.png 600w, /assets/images/work/playbook@1200.png 1200w"
           sizes="(max-width: 887px) 600px, 1200px"
-          alt="simplabs Playbook"
+          alt=""
         />
       </div>
     </figure>


### PR DESCRIPTION
This adds missing `alt` attributes and removes on that was unnecessarily added to a decorative element.

closes #1167 