### PR TITLE
Case study qonto page design issues

### DIFF
--- a/src/ui/components/ShapeWork/stylesheet.css
+++ b/src/ui/components/ShapeWork/stylesheet.css
@@ -211,4 +211,20 @@
   }
 }
 
+@media (max-width: 888px) {
+  :scope {
+    background: var(--shape-color);
+    color: var(--color-text-inverted);
+  }
+
+  :scope .content {
+    background: var(--shape-color);
+    color: var(--color-text-inverted);
+  }
+
+  :scope .small {
+    color: var(--color-text-inverted);
+  }
+}
+
 @export typography;

--- a/src/ui/components/ShapeWork/template.hbs
+++ b/src/ui/components/ShapeWork/template.hbs
@@ -1,4 +1,4 @@
-<div block:reverse={{@reverse}} block:center={{@center}}>
+<div block:reverse={{@reverse}} block:center={{@center}} style="{{this.shapeStyle}}">
   {{#if @logo}}
     <div block:class="logo">
       <img block:class="logo-img" src="{{@logo}}" alt="{{@logoAlt}}" />


### PR DESCRIPTION
1- `<ShapeWork>` svg clip on the image on mobile doesnt apply to the container.

2- Couldn't figure out a way to properly style `.small` with css-blocks when its yielded to `<ShapeWork>` without introducing a custom css styling to the pages. Another option is:
I can refactor the <ShapeWork /> component to accept both quote text and quote person as attributes than we can have a specific styling on the component with css-blocks.

Preview: https://percy.io/simplabs-com/simplabs.com/builds/6494240 [view it on mobile]