### PR TITLE
copy change for qonto case study page

### DIFF
--- a/src/ui/components/PageCaseStudyQonto/template.hbs
+++ b/src/ui/components/PageCaseStudyQonto/template.hbs
@@ -96,7 +96,7 @@
       />
 
       <figcaption>
-        trainline sells tickets for 150 different carriers across 36 countries via their mobile app.
+        Qonto is a business account for freelancers, startups and SMEs. We shared our expertise to help build a product used by over 75000 customers.
       </figcaption>
     </figure>
     <p>


### PR DESCRIPTION
There was a copy error in the qonto case study page, this PR fixes it.