### PR TITLE
Update client logos on homepage

### DIFF
--- a/src/ui/components/PageHomepage/stylesheet.css
+++ b/src/ui/components/PageHomepage/stylesheet.css
@@ -9,6 +9,10 @@
   composes: 'layout';
 }
 
+.logo {
+  max-width: 15rem;
+}
+
 @media (max-width: 888px) {
   .padding-right-1 {
     padding-right: 0;

--- a/src/ui/components/PageHomepage/template.hbs
+++ b/src/ui/components/PageHomepage/template.hbs
@@ -25,7 +25,13 @@
       </h2>
       <ul list:class="logos">
         <li list:class="logo">
+          <img src="/assets/images/logos/qonto.svg" alt="Qonto" />
+        </li>
+        <li list:class="logo">
           <img src="/assets/images/logos/trainline.svg" alt="Trainline" />
+        </li>
+        <li list:class="logo">
+          <img src="/assets/images/logos/timify.svg" alt="Timify" />
         </li>
         <li list:class="logo">
           <img src="/assets/images/logos/cardstack.svg" alt="Cardstack" />
@@ -35,9 +41,6 @@
         </li>
         <li list:class="logo">
           <img src="/assets/images/logos/experteer.svg" alt="Experteer" />
-        </li>
-        <li list:class="logo">
-          <img src="/assets/images/logos/qonto.svg" alt="Qonto" />
         </li>
       </ul>
     </section>

--- a/src/ui/components/PageHomepage/template.hbs
+++ b/src/ui/components/PageHomepage/template.hbs
@@ -25,22 +25,22 @@
       </h2>
       <ul list:class="logos">
         <li list:class="logo">
-          <img src="/assets/images/logos/qonto.svg" alt="Qonto" />
+          <img src="/assets/images/logos/qonto.svg" block:class="logo" alt="Qonto" />
         </li>
         <li list:class="logo">
-          <img src="/assets/images/logos/trainline.svg" alt="Trainline" />
+          <img src="/assets/images/logos/trainline.svg" block:class="logo" alt="Trainline" />
         </li>
         <li list:class="logo">
-          <img src="/assets/images/logos/timify.svg" alt="Timify" />
+          <img src="/assets/images/logos/timify.svg" block:class="logo" alt="Timify" />
         </li>
         <li list:class="logo">
-          <img src="/assets/images/logos/cardstack.svg" alt="Cardstack" />
+          <img src="/assets/images/logos/cardstack.svg" block:class="logo" alt="Cardstack" />
         </li>
         <li list:class="logo">
-          <img src="/assets/images/logos/generali.svg" alt="Generali" />
+          <img src="/assets/images/logos/generali.svg" block:class="logo" alt="Generali" />
         </li>
         <li list:class="logo">
-          <img src="/assets/images/logos/experteer.svg" alt="Experteer" />
+          <img src="/assets/images/logos/experteer.svg" block:class="logo" alt="Experteer" />
         </li>
       </ul>
     </section>


### PR DESCRIPTION
This updates the client logos on the homepage to:

* include the Timify logo
* make them slightly narrower to respond to smaller viewports better

## Screenshots

![localhost_4200_](https://user-images.githubusercontent.com/1510/91153845-08dd0300-e6c1-11ea-8c8a-b409ea916661.png)
![localhost_4200_(iPhone X)](https://user-images.githubusercontent.com/1510/91153848-0a0e3000-e6c1-11ea-8683-fec192416a57.png)

closes #1241 