### PR TITLE
Flatten client logos on mobile work page

### DIFF
--- a/src/ui/components/PageWork/stylesheet.css
+++ b/src/ui/components/PageWork/stylesheet.css
@@ -13,6 +13,10 @@
   .qonto-screenshot-desktop {
     display: none;
   }
+
+  .logo-shape {
+    padding-bottom: 50%;
+  }
 }
 
 @media (min-width: 888px) {

--- a/src/ui/components/PageWork/template.hbs
+++ b/src/ui/components/PageWork/template.hbs
@@ -9,7 +9,7 @@
   </Header>
 
   <div layout:class="bleed-left" offset:class="after-5">
-    <ShapeImage @srcset="/assets/images/work/qonto.svg" @align="left" />
+    <ShapeImage @srcset="/assets/images/work/qonto.svg" @align="left" @variant="mobile-flat" />
   </div>
   <div layout:class="split-trailing" offset:class="after-5">
     <h2>
@@ -48,7 +48,7 @@
 
   <div layout:scope>
     <div layout:class="bleed-right" offset:class="after-5" block:class="trainline-logo">
-      <ShapeImage @srcset="/assets/images/work/trainline.svg" @align="right" />
+      <ShapeImage @srcset="/assets/images/work/trainline.svg" @align="right" @variant="mobile-flat" />
     </div>
     <div layout:class="split-leading" offset:class="after-12" block:class="trainline-text">
       <h2>
@@ -83,7 +83,7 @@
   <ClientsGrid @only="dim3,timify,embedd,expedition,trainline,ringler,neighbourhoodie,loconet,erdil" />
 
   <div layout:class="bleed-left" offset:class="after-5">
-    <ShapeImage @srcset="/assets/images/work/timify.svg" @align="left" />
+    <ShapeImage @srcset="/assets/images/work/timify.svg" @align="left" @variant="mobile-flat" />
   </div>
   <div layout:class="split-trailing" offset:class="after-5">
     <h2>

--- a/src/ui/components/ShapeImage/stylesheet.css
+++ b/src/ui/components/ShapeImage/stylesheet.css
@@ -19,4 +19,20 @@
   clip-path: polygon(80% 0, 100% 4.4%, 100% 100%, 0 86%, 0 18%);
 }
 
+@media (max-width: 887px) {
+  :scope[variant='mobile-flat'] {
+    padding-bottom: 50%;
+  }
+
+  :scope[variant='mobile-flat'][align='left'] {
+    -webkit-clip-path: polygon(100% 21%, 100% 85%, 30% 100%, 0 96%, 0 0);
+    clip-path: polygon(100% 21%, 100% 85%, 30% 100%, 0 96%, 0 0);
+  }
+
+  :scope[variant='mobile-flat'][align='right'] {
+    -webkit-clip-path: polygon(80% 0, 100% 4.4%, 100% 100%, 0 78%, 0 18%);
+    clip-path: polygon(80% 0, 100% 4.4%, 100% 100%, 0 78%, 0 18%);
+  }
+}
+
 @export fluid-image;

--- a/src/ui/components/ShapeImage/template.hbs
+++ b/src/ui/components/ShapeImage/template.hbs
@@ -1,3 +1,3 @@
-<div block:scope block:align={{@align}}>
+<div block:scope block:align={{@align}} block:variant={{@variant}}>
   <img fluid-image:class="image-clipped" srcset={{@srcset}} sizes={{@sizes}} alt="" />
 </div>


### PR DESCRIPTION
This flattens the client logos on the mobile version of the /work page. Currently they have the same height in the mobile version as in the desktop version which looks a bit strange and takes most of the available viewport height:

| Before | After |
|--------|-------|
| ![simplabs com_(iPhone X)](https://user-images.githubusercontent.com/1510/91156874-ec42ca00-e6c4-11ea-9659-425548d12697.png) | ![localhost_4200_work_(iPhone X)](https://user-images.githubusercontent.com/1510/91156883-ef3dba80-e6c4-11ea-98bb-daf3e9bff8e0.png) |

closes #1243