### PR TITLE
improve tagline on homepage

### DIFF
--- a/src/ui/components/PageHomepage/template.hbs
+++ b/src/ui/components/PageHomepage/template.hbs
@@ -5,13 +5,13 @@
   >
     <HeaderContent>
       <h1 typography:class="display">
-        Solid Solutions for
+        Guiding projects and teams
         <span typography:class="nowrap">
-          Ambitious Projects
+          to sustainable success
         </span>
       </h1>
       <p typography:class="lead">
-        We deliver ambitious digital products on the web and mobile for our clients to rely on. Our expert team manages projects from idea to release, covering strategy, design and engineering.
+        simplabs is a digital product consultancy that designs and develops web applications. We realize projects with clients across the globe and teach them how along the way.
       </p>
     </HeaderContent>
   </Header>


### PR DESCRIPTION
This improves the tagline to be more concise and more clearly express what we deliver, making sure the aspect of mentoring and leveling up companies and teams is includes as well:

![localhost_4200_](https://user-images.githubusercontent.com/1510/92004129-21dd5800-ed42-11ea-9f17-32b220df4a7f.png)
![localhost_4200_ (1)](https://user-images.githubusercontent.com/1510/92004135-230e8500-ed42-11ea-8981-6f3a45209fca.png)
