### PR TITLE
fix typo

### DIFF
--- a/src/ui/components/PageCaseStudyQonto/template.hbs
+++ b/src/ui/components/PageCaseStudyQonto/template.hbs
@@ -3,7 +3,7 @@
     @active="work"
     @title="Qonto Case Study"
     @documentTitle="Co-Engineering the Future of Banking for SMEs | Work"
-    @description="Trainline is Europe’s leading rail and coach platform. We helper them deliver a high-performance mobile web app, along with an improved engineering process."
+    @description="Trainline is Europe’s leading rail and coach platform. We helped them deliver a high-performance mobile web app, along with an improved engineering process."
   >
     <HeaderContent @label="Qonto Case Study" @headline="Co-Engineering the Future of Banking for SMEs" />
   </Header>


### PR DESCRIPTION
This fixes a typo in the meta description of the Trainline case study.

> … We helpe~r~d them…