### PR TITLE
add meta description to facilitation post

### DIFF
--- a/_posts/2020-05-04-facilitate-client-onboarding.md
+++ b/_posts/2020-05-04-facilitate-client-onboarding.md
@@ -5,7 +5,9 @@ github: ghislaineguerin
 twitter: ghislaineguerin
 topic: design
 bio: 'Process Designer and Facilitator'
-description: ''
+description:
+  'Ghislaine Guerin presents techniques for getting the most out of kick-off
+  meetings.'
 og:
   image: /assets/images/posts/2020-05-04-facilitate-client-onboarding/og-image.png
 ---


### PR DESCRIPTION
This adds a meta description to the kick-off meeting facilitation blog post since that is currently missing.

closes #1299 