### PR TITLE
fix meta description on qonto case study

### DIFF
--- a/src/ui/components/PageCaseStudyQonto/template.hbs
+++ b/src/ui/components/PageCaseStudyQonto/template.hbs
@@ -3,7 +3,7 @@
     @active="work"
     @title="Qonto Case Study"
     @documentTitle="Co-Engineering the Future of Banking for SMEs | Work"
-    @description="Trainline is Europe’s leading rail and coach platform. We helped them deliver a high-performance mobile web app, along with an improved engineering process."
+    @description="Qonto is a european B2B Neobank for freelancers and SMEs. We helped their team deliver mission critical features and scale sustainably."
   >
     <HeaderContent @label="Qonto Case Study" @headline="Co-Engineering the Future of Banking for SMEs" />
   </Header>


### PR DESCRIPTION
This fixes the meta description on the Qonto case study page which is currently wrongly using the same text as the Trainline case study.

closes #1297 