### PR TITLE
remove whitespace around quotes in shape

### DIFF
--- a/src/ui/components/ShapeQuoteCardstack/stylesheet.css
+++ b/src/ui/components/ShapeQuoteCardstack/stylesheet.css
@@ -1,7 +1,3 @@
-@block typography from "../../styles/blocks/typography.block.css";
-
 :scope {
   block-name: ShapeQuoteCardstack;
 }
-
-@export typography;

--- a/src/ui/components/ShapeQuoteCardstack/template.hbs
+++ b/src/ui/components/ShapeQuoteCardstack/template.hbs
@@ -4,13 +4,9 @@
     @sizes="(max-width: 887px) 600px, 1200px"
     @srcAlt="Cardstack"
   >
-    <p>
-      <q typography:class="quote" lang="en">
-        I've had the opportunity to work alongside the simplabs team on both their client-facing work for Cardstack and their open source contributions. They are experts in Ember and they are a team that takes good software-development practice seriously.
-      </q>
-    </p>
-    <p typography:class="small">
-      Ed Faulkner, Cardstack Lead Developer and member of the Ember.js Steering Committee
-    </p>
+    <ShapeQuoteContent
+      @text="I've had the opportunity to work alongside the simplabs team on both their client-facing work for Cardstack and their open source contributions. They are experts in Ember and they are a team that takes good software-development practice seriously."
+      @source="Ed Faulkner, Cardstack Lead Developer and member of the Ember.js Steering Committee"
+    />
   </ShapeFeatureContent>
 </ShapeFeature>

--- a/src/ui/components/ShapeQuoteContent/component-test.ts
+++ b/src/ui/components/ShapeQuoteContent/component-test.ts
@@ -1,0 +1,15 @@
+import hbs from '@glimmer/inline-precompile';
+import { render } from '@glimmer/test-helpers';
+import { setupRenderingTest } from '../../../utils/test-helpers/setup-rendering-test';
+
+const { module, test } = QUnit;
+
+module('Component: ShapeQuoteContent', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    await render(hbs`<ShapeQuoteContent @source="Person, Title, Company">simplabs is so awesome!</ShapeQuoteContent>`);
+
+    assert.ok(this.containerElement.querySelector('q'));
+  });
+});

--- a/src/ui/components/ShapeQuoteContent/component-test.ts
+++ b/src/ui/components/ShapeQuoteContent/component-test.ts
@@ -8,7 +8,7 @@ module('Component: ShapeQuoteContent', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    await render(hbs`<ShapeQuoteContent @source="Person, Title, Company">simplabs is so awesome!</ShapeQuoteContent>`);
+    await render(hbs`<ShapeQuoteContent @source="Person, Title, Company" @text="simplabs is so awesome!" />`);
 
     assert.ok(this.containerElement.querySelector('q'));
   });

--- a/src/ui/components/ShapeQuoteContent/stylesheet.css
+++ b/src/ui/components/ShapeQuoteContent/stylesheet.css
@@ -1,0 +1,7 @@
+@block typography from "../../styles/blocks/typography.block.css";
+
+:scope {
+  block-name: ShapeQuoteContent;
+}
+
+@export typography;

--- a/src/ui/components/ShapeQuoteContent/template.hbs
+++ b/src/ui/components/ShapeQuoteContent/template.hbs
@@ -1,0 +1,7 @@
+<p>
+  {{! prettier-ignore }}
+  <q typography:class="quote" lang="en">{{~@text~}}</q>
+</p>
+<p typography:class="small">
+  {{@source}}
+</p>

--- a/src/ui/components/ShapeQuoteQonto/stylesheet.css
+++ b/src/ui/components/ShapeQuoteQonto/stylesheet.css
@@ -1,7 +1,3 @@
-@block typography from "../../styles/blocks/typography.block.css";
-
 :scope {
   block-name: ShapeQuoteQonto;
 }
-
-@export typography;

--- a/src/ui/components/ShapeQuoteQonto/template.hbs
+++ b/src/ui/components/ShapeQuoteQonto/template.hbs
@@ -4,13 +4,9 @@
     @sizes="(max-width: 887px) 600px, 1200px"
     @srcAlt="Qonto"
   >
-    <p>
-      <q typography:class="quote" lang="en">
-        simplabs are well known as the Ember.js experts and they absolutely live up to the expectations. They had an immediate as well as significant positive impact on both our velocity and quality of output.
-      </q>
-    </p>
-    <p typography:class="small">
-      Marc-Antoine Lacroix, Qonto CTO
-    </p>
+    <ShapeQuoteContent
+      @text="simplabs are well known as the Ember.js experts and they absolutely live up to the expectations. They had an immediate as well as significant positive impact on both our velocity and quality of output."
+      @source="Marc-Antoine Lacroix, Qonto CTO"
+    />
   </ShapeFeatureContent>
 </ShapeFeature>

--- a/src/ui/components/ShapeQuoteTimify/stylesheet.css
+++ b/src/ui/components/ShapeQuoteTimify/stylesheet.css
@@ -1,7 +1,3 @@
-@block typography from "../../styles/blocks/typography.block.css";
-
 :scope {
   block-name: ShapeQuoteTimify;
 }
-
-@export typography;

--- a/src/ui/components/ShapeQuoteTimify/template.hbs
+++ b/src/ui/components/ShapeQuoteTimify/template.hbs
@@ -4,13 +4,9 @@
     @sizes="(max-width: 887px) 600px, 1200px"
     @srcAlt="Timify"
   >
-    <p>
-      <q typography:class="quote" lang="en">
-        simplabs' experienced engineers delivered a solid and well architected foundation for our web app. They also helped us establish best practices and a lean process internally. Working with them was a pleasure.
-      </q>
-    </p>
-    <p typography:class="small">
-      Andreas Knürr, Timify CEO
-    </p>
+    <ShapeQuoteContent
+      @text="simplabs' experienced engineers delivered a solid and well architected foundation for our web app. They also helped us establish best practices and a lean process internally. Working with them was a pleasure."
+      @source="Andreas Knürr, Timify CEO"
+    />
   </ShapeFeatureContent>
 </ShapeFeature>

--- a/src/ui/components/ShapeQuoteTrainline/stylesheet.css
+++ b/src/ui/components/ShapeQuoteTrainline/stylesheet.css
@@ -1,7 +1,3 @@
-@block typography from "../../styles/blocks/typography.block.css";
-
 :scope {
   block-name: ShapeQuoteTrainline;
 }
-
-@export typography;

--- a/src/ui/components/ShapeQuoteTrainline/template.hbs
+++ b/src/ui/components/ShapeQuoteTrainline/template.hbs
@@ -4,13 +4,9 @@
     @sizes="(max-width: 887px) 604px, 1208px"
     @srcAlt="Trainline"
   >
-    <p>
-      <q typography:class="quote" lang="en">
-        We started working with simplabs to build a state-of-the-art mobile web app from the ground up and it was an absolute success! Not only are they web specialists, but their expertise in development practices and agile processes made our collaboration an absolute delight.
-      </q>
-    </p>
-    <p typography:class="small">
-      Carl Andersson, General Manager of Trainline international
-    </p>
+    <ShapeQuoteContent
+      @text="We started working with simplabs to build a state-of-the-art mobile web app from the ground up and it was an absolute success! Not only are they web specialists, but their expertise in development practices and agile processes made our collaboration an absolute delight."
+      @source="Carl Andersson, General Manager of Trainline international"
+    />
   </ShapeFeatureContent>
 </ShapeFeature>

--- a/src/ui/styles/blocks/typography.block.css
+++ b/src/ui/styles/blocks/typography.block.css
@@ -61,6 +61,14 @@
   font-style: italic;
 }
 
+.quote::before {
+  margin-right: -0.5rem;
+}
+
+.quote::after {
+  margin-left: -0.5rem;
+}
+
 .tag {
   text-decoration: none;
   display: inline-block;

--- a/src/ui/styles/blocks/typography.block.css
+++ b/src/ui/styles/blocks/typography.block.css
@@ -61,14 +61,6 @@
   font-style: italic;
 }
 
-.quote::before {
-  margin-right: -0.5rem;
-}
-
-.quote::after {
-  margin-left: -0.5rem;
-}
-
 .tag {
   text-decoration: none;
   display: inline-block;


### PR DESCRIPTION
This removes the whitespace around quotes in shapes that is a result of the template formatting we apply (and enforce via Prettier).

| Before | After |
|-------|---------|
| <img width="645" alt="before" src="https://user-images.githubusercontent.com/1510/98918914-80574d00-24ce-11eb-9b8f-cd142610deb0.png"> | <img width="389" alt="ater" src="https://user-images.githubusercontent.com/1510/98918924-83ead400-24ce-11eb-8036-2ab8fb10ee06.png"> |

closes #996 