### PR TITLE
Add plausible analytics

### DIFF
--- a/lib/analytics/index.js
+++ b/lib/analytics/index.js
@@ -8,7 +8,7 @@ module.exports = {
   },
 
   contentFor(type) {
-    if (type === 'head-footer') {
+    if (process.env.CONTEXT === 'production' && type === 'head-footer') {
       return `
         <script async defer data-domain="simplabs.com" src="https://plausible.io/js/plausible.js"></script>
       `;

--- a/lib/analytics/index.js
+++ b/lib/analytics/index.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = {
+  name: require('./package').name,
+
+  isDevelopingAddon() {
+    return true;
+  },
+
+  contentFor(type) {
+    if (type === 'head-footer') {
+      return `
+        <script async defer data-domain="simplabs.com" src="https://plausible.io/js/plausible.js"></script>
+      `;
+    }
+
+    return '';
+  },
+};

--- a/lib/analytics/package.json
+++ b/lib/analytics/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "analytics",
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
   "private": true,
   "ember-addon": {
     "paths": [
+      "lib/analytics",
       "lib/generate-appearances-archive",
       "lib/generate-blog",
       "lib/generate-calendar",


### PR DESCRIPTION
Netlify analytics is pretty limited and does not actually work for SPAs. We only ever get to see the first page that a visitor requests but since Netlify will not actually see any more requests as the user navigates the page, we cannot know whether users visit any of the other pages as well.

[Plausible analytics](https://plausible.io/) seems to be a great alternative – it's cheap, privacy-friendly (hosted in EU, doesn't track any private data, doesn't set cookies – not even Safari reports it as a tracker) and simple.

<img width="1120" alt="Bildschirmfoto 2020-11-17 um 09 32 20" src="https://user-images.githubusercontent.com/1510/99365615-d144b800-28b7-11eb-888b-2f640746019a.png">
