### PR TITLE
Remove jsdom from markdown processing pipeline

### DIFF
--- a/_posts/2015-08-07-rails-api-auth.md
+++ b/_posts/2015-08-07-rails-api-auth.md
@@ -11,12 +11,12 @@ topic: ruby
 ---
 
 We are happy to announce the first public release of the
-[rails_api_auth gem](https://github.com/simplabs/rails_api_auth). rails*api_auth
-is a \*\*lightweight Rails Engine that implements the *"Resource Owner Password
-Credentials Grant"\_ OAuth 2.0 flow** as well as Facebook authentication and is
-**built for usage in API projects\*\*. If you’re building a client side
-application with e.g. a browser MVC like [Ember.js](http://emberjs.com) (where
-you might be using
+[`rails_api_auth` gem](https://github.com/simplabs/rails_api_auth).
+`rails_api_auth` is a **lightweight Rails Engine that implements the _"Resource
+Owner Password Credentials Grant"_ OAuth 2.0 flow** as well as Facebook
+authentication and is **built for usage in API projects**. If you’re building a
+client side application with e.g. a browser MVC like
+[Ember.js](http://emberjs.com) (where you might be using
 [Ember Simple Auth](https://github.com/simplabs/ember-simple-auth) which works
 great with rails_api_auth of course), a mobile app or anything else that’s
 backed by a Rails-based API, rails_api_auth is for you.

--- a/_posts/2019-07-24-july-monthly-update.md
+++ b/_posts/2019-07-24-july-monthly-update.md
@@ -18,7 +18,7 @@ happening at simplabs along with the things we're looking forward to. Enjoy.
 
 ## News
 
-![Upcoming webinar - The ultimate marketers guide to modern web apps and why users are demanding more](/assets/images/posts/2019-07-24-july-monthly-update/simplabs-webinar-modern-web-apps-for-marketers.png#@600-1200)]
+![Upcoming webinar - The ultimate marketers guide to modern web apps and why users are demanding more](/assets/images/posts/2019-07-24-july-monthly-update/simplabs-webinar-modern-web-apps-for-marketers.png#@600-1200)
 
 On August 12th at 6pm UTC+2 we're running a webinar to help forward-looking
 marketers understand recent changes in web technology and how they can be used

--- a/lib/generate-blog/lib/components-builder.js
+++ b/lib/generate-blog/lib/components-builder.js
@@ -219,16 +219,6 @@ function replaceWithFigure(dom, element, content) {
 
 function htmlizeBody(content) {
   let html = htmlizeMarkdown(content, (dom) => {
-    dom.querySelectorAll('p > img').forEach((img) => {
-      let paragraph = img.parentElement;
-
-      if (paragraph.children.length === 1) {
-        replaceWithFigure(dom, paragraph, img);
-      } else {
-        img.setAttribute('blog-post:class', 'image');
-      }
-    });
-
     dom.querySelectorAll('p > a > img:only-child').forEach((img) => {
       replaceWithFigure(dom, img.parentElement.parentElement, img.parentElement);
     });

--- a/lib/generate-blog/lib/components-builder.js
+++ b/lib/generate-blog/lib/components-builder.js
@@ -180,49 +180,8 @@ function sortNewestFirst(posts) {
   return _.chain(posts).sortBy('meta.date').reverse().value();
 }
 
-function replaceWithFigure(dom, element, content) {
-  let figure = dom.createElement('figure');
-  let img = content;
-  let figureClass = 'figure';
-
-  if (img.tagName !== 'IMG') {
-    img = content.querySelector('img');
-  }
-
-  let imageData = parseImageDirectives(img.src);
-  if (imageData.sizes) {
-    img.removeAttribute('src');
-    img.srcset = `${imageData.sizes.small.src} ${imageData.sizes.small.size}w, ${imageData.sizes.large.src} ${imageData.sizes.large.size}w`;
-    img.sizes = `(max-width: 887px) ${imageData.sizes.small.size}px, ${imageData.sizes.large.size}px`;
-  } else {
-    img.src = imageData.src;
-  }
-
-  if (imageData.kind === 'full') {
-    img.setAttribute('figure:class', 'content-full');
-
-    figureClass = 'figure-plain';
-  } else if (imageData.kind === 'plain') {
-    img.setAttribute('figure:class', 'content-centered');
-
-    figureClass = 'figure-plain';
-  } else {
-    img.setAttribute('figure:class', 'content-centered');
-  }
-
-  figure.setAttribute('blog-post:class', figureClass);
-  figure.appendChild(content);
-
-  element.parentElement.insertBefore(figure, element);
-  element.parentElement.removeChild(element);
-}
-
 function htmlizeBody(content) {
-  let html = htmlizeMarkdown(content, (dom) => {
-    dom.querySelectorAll('p > a > img:only-child').forEach((img) => {
-      replaceWithFigure(dom, img.parentElement.parentElement, img.parentElement);
-    });
-  });
+  let html = htmlizeMarkdown(content);
 
   let [, body] = splitPostContent(html);
 
@@ -237,40 +196,4 @@ function htmlizeExcerpt(content) {
 
 function splitPostContent(content) {
   return content.split(BREAK_MARKER);
-}
-
-function parseImageDirectives(src) {
-  let match = src.match(/#(full|plain)?(@(\d+)-(\d+))?$/);
-  let bareSrc = src.replace(/#[^#]*$/, '');
-  let directives = {
-    src: bareSrc,
-  };
-
-  if (!match) {
-    return directives;
-  }
-
-  let [, kind, , smallSize, largeSize] = match;
-
-  if (kind) {
-    directives.kind = kind;
-  }
-
-  if (smallSize && largeSize) {
-    let buildSrcForSize = (size) => bareSrc.replace(/(\.(\w){3,4})/, `@${size}$1`);
-    let smallImage = buildSrcForSize(smallSize);
-    let largeImage = buildSrcForSize(largeSize);
-    directives.sizes = {
-      small: {
-        size: smallSize,
-        src: smallImage,
-      },
-      large: {
-        size: largeSize,
-        src: largeImage,
-      },
-    };
-  }
-
-  return directives;
 }

--- a/lib/generate-blog/lib/components-builder.js
+++ b/lib/generate-blog/lib/components-builder.js
@@ -245,10 +245,6 @@ function htmlizeBody(content) {
       replaceWithFigure(dom, img.parentElement.parentElement, img.parentElement);
     });
 
-    dom.querySelectorAll('table').forEach((table) => {
-      wrapNode(dom, table, 'typography', 'table');
-    });
-
     dom.querySelectorAll('iframe').forEach((iframe) => {
       iframe.setAttribute('blog-post:class', 'embedd-iframe');
       wrapNode(dom, iframe, 'blog-post', 'embedd');

--- a/lib/generate-blog/lib/components-builder.js
+++ b/lib/generate-blog/lib/components-builder.js
@@ -180,18 +180,6 @@ function sortNewestFirst(posts) {
   return _.chain(posts).sortBy('meta.date').reverse().value();
 }
 
-function wrapNode(dom, node, blockName, className, element = 'div') {
-  let wrapper = dom.createElement(element);
-  let parent = node.parentElement;
-
-  wrapper.setAttribute(`${blockName}:class`, className);
-
-  parent.insertBefore(wrapper, node);
-  parent.removeChild(node);
-
-  wrapper.appendChild(node);
-}
-
 function replaceWithFigure(dom, element, content) {
   let figure = dom.createElement('figure');
   let img = content;
@@ -243,11 +231,6 @@ function htmlizeBody(content) {
 
     dom.querySelectorAll('p > a > img:only-child').forEach((img) => {
       replaceWithFigure(dom, img.parentElement.parentElement, img.parentElement);
-    });
-
-    dom.querySelectorAll('iframe').forEach((iframe) => {
-      iframe.setAttribute('blog-post:class', 'embedd-iframe');
-      wrapNode(dom, iframe, 'blog-post', 'embedd');
     });
   });
 

--- a/lib/markdown-content/htmlize-markdown.js
+++ b/lib/markdown-content/htmlize-markdown.js
@@ -5,19 +5,21 @@ const marked = require('marked');
 const jsdom = require('jsdom');
 const highlightjs = require('highlight.js');
 
-const Renderer = new marked.Renderer();
-Renderer.code = function (code, language) {
-  let highlighted = code;
-  if (language) {
-    highlighted = highlightjs.highlight(language, code).value;
-  }
+const renderer = {
+  code(code, language) {
+    let highlighted = code;
+    if (language) {
+      highlighted = highlightjs.highlight(language, code).value;
+    }
 
-  return `<pre source:scope><code>${highlighted}</code></pre>`;
+    return `<pre source:scope><code>${highlighted}</code></pre>`;
+  }
 };
+marked.use({ renderer });
 
 module.exports = function htmlizeMarkdown(source, callback = null) {
   source = preventBundleFingerprintReplacement(source);
-  let html = marked(source, { renderer: Renderer });
+  let html = marked(source);
   html = manipulateDom(html, (dom) => {
     blockifyClasses(dom);
     dom.querySelectorAll('a').forEach((a) => {

--- a/lib/markdown-content/htmlize-markdown.js
+++ b/lib/markdown-content/htmlize-markdown.js
@@ -11,9 +11,14 @@ const renderer = {
     if (language) {
       highlighted = highlightjs.highlight(language, code).value;
     }
+    highlighted = blockifyClasses(highlighted);
 
     return `<pre source:scope><code>${highlighted}</code></pre>`;
-  }
+  },
+
+  html(html) {
+    return blockifyClasses(html);
+  },
 };
 marked.use({ renderer });
 
@@ -21,7 +26,6 @@ module.exports = function htmlizeMarkdown(source, callback = null) {
   source = preventBundleFingerprintReplacement(source);
   let html = marked(source);
   html = manipulateDom(html, (dom) => {
-    blockifyClasses(dom);
     dom.querySelectorAll('a').forEach((a) => {
       if (a.href.startsWith('/')) {
         a.dataset.internal = true;
@@ -43,15 +47,8 @@ function manipulateDom(html, callback) {
   return dom.window.document.body.innerHTML;
 }
 
-function blockifyClasses(dom) {
-  let classedElements = dom.querySelectorAll('[class]');
-  for (let element of classedElements) {
-    let klasses = element.classList.values();
-    for (let klass of klasses) {
-      element.setAttribute('block:class', klass);
-    }
-    element.removeAttribute('class');
-  }
+function blockifyClasses(html) {
+  return html.replace(/(\s)class="/gm, '$1block:class="');
 }
 
 function encodeCurlies(content) {

--- a/lib/markdown-content/htmlize-markdown.js
+++ b/lib/markdown-content/htmlize-markdown.js
@@ -17,6 +17,7 @@ const renderer = {
   },
 
   html(html) {
+    html = html.replace(/<iframe(.*)iframe>/gm, '<div class="embedd"><iframe class="embedd-iframe"$1iframe></div>');
     return blockifyClasses(html);
   },
 

--- a/lib/markdown-content/htmlize-markdown.js
+++ b/lib/markdown-content/htmlize-markdown.js
@@ -55,36 +55,16 @@ marked.use({ renderer });
 
 const walkTokens = (token) => {
   if (token.type === 'paragraph') {
-    if (token.tokens.length === 1 && token.tokens[0].type === 'image') {
-      let src = token.tokens[0].href;
-      let imageData = parseImageDirectives(src);
-      let img, imgClass, figureClass;
-
-      if (imageData.kind === 'full') {
-        imgClass = 'content-full';
-        figureClass = 'figure-plain';
-      } else if (imageData.kind === 'plain') {
-        imgClass = 'content-centered';
-        figureClass = 'figure-plain';
-      } else {
-        imgClass = 'content-centered';
-        figureClass = 'figure';
+    let paragraph = token;
+    if (paragraph.tokens.length === 1 && paragraph.tokens[0].type === 'image') {
+      let image = paragraph.tokens[0];
+      wrapInFigure(paragraph, image);
+    } else if (paragraph.tokens.length === 1 && paragraph.tokens[0].type === 'link') {
+      let link = paragraph.tokens[0];
+      if (link.tokens.length === 1 && link.tokens[0].type === 'image') {
+        let image = link.tokens[0];
+        wrapInFigure(paragraph, image, link);
       }
-
-      if (imageData.sizes) {
-        let srcset = `${imageData.sizes.small.src} ${imageData.sizes.small.size}w, ${imageData.sizes.large.src} ${imageData.sizes.large.size}w`;
-        let sizes = `(max-width: 887px) ${imageData.sizes.small.size}px, ${imageData.sizes.large.size}px`;
-        img = `<img srcset="${srcset}" sizes="${sizes}" figure:class="${imgClass}">`;
-      } else {
-        img = `<img src="${src}" figure:class="${imgClass}">`;
-      }
-
-      token.type = 'html';
-      delete token.raw;
-      delete token.tokens;
-      token.inLink = false;
-      token.inRawBlock = false;
-      token.text = `<figure blog-post:class="${figureClass}">${img}</figure>`;
     }
   }
 };
@@ -160,4 +140,39 @@ function parseImageDirectives(src) {
   }
 
   return directives;
+}
+
+function wrapInFigure(paragraphToken, imageToken, linkToken = null) {
+  let src = imageToken.href;
+  let imageData = parseImageDirectives(src);
+  let img, imgClass, figureClass;
+
+  if (imageData.kind === 'full') {
+    imgClass = 'content-full';
+    figureClass = 'figure-plain';
+  } else if (imageData.kind === 'plain') {
+    imgClass = 'content-centered';
+    figureClass = 'figure-plain';
+  } else {
+    imgClass = 'content-centered';
+    figureClass = 'figure';
+  }
+
+  if (imageData.sizes) {
+    let srcset = `${imageData.sizes.small.src} ${imageData.sizes.small.size}w, ${imageData.sizes.large.src} ${imageData.sizes.large.size}w`;
+    let sizes = `(max-width: 887px) ${imageData.sizes.small.size}px, ${imageData.sizes.large.size}px`;
+    img = `<img srcset="${srcset}" sizes="${sizes}" figure:class="${imgClass}">`;
+  } else {
+    img = `<img src="${src}" figure:class="${imgClass}">`;
+  }
+
+  for (let key of Object.keys(paragraphToken)) {
+    delete paragraphToken[key];
+  }
+  paragraphToken.type = 'html';
+  paragraphToken.inLink = false;
+  paragraphToken.inRawBlock = false;
+
+  let figureContent = linkToken ? renderer.link(linkToken.href, linkToken.title, img) : img;
+  paragraphToken.text = `<figure blog-post:class="${figureClass}">${figureContent}</figure>`;
 }

--- a/lib/markdown-content/htmlize-markdown.js
+++ b/lib/markdown-content/htmlize-markdown.js
@@ -2,7 +2,6 @@
 'use strict';
 
 const marked = require('marked');
-const jsdom = require('jsdom');
 const highlightjs = require('highlight.js');
 
 const renderer = {
@@ -70,22 +69,11 @@ const walkTokens = (token) => {
 };
 marked.use({ walkTokens });
 
-module.exports = function htmlizeMarkdown(source, callback = null) {
+module.exports = function htmlizeMarkdown(source) {
   source = preventBundleFingerprintReplacement(source);
   let html = marked(source);
-  html = manipulateDom(html, (dom) => {
-    if (callback) {
-      callback(dom);
-    }
-  });
   return encodeCurlies(html);
 };
-
-function manipulateDom(html, callback) {
-  let dom = new jsdom.JSDOM(html);
-  callback(dom.window.document);
-  return dom.window.document.body.innerHTML;
-}
 
 function blockifyClasses(html) {
   return html.replace(/(\s)class="/gm, '$1block:class="');

--- a/lib/markdown-content/htmlize-markdown.js
+++ b/lib/markdown-content/htmlize-markdown.js
@@ -35,6 +35,13 @@ const renderer = {
 
     return `${a}>${text}</a>`;
   },
+
+  table(header, body) {
+    if (body) {
+      body = `<tbody>${body}</tbody>`;
+    }
+    return `<table typography:class="table"><thead>${header}</thead>${body}</table>`;
+  },
 };
 marked.use({ renderer });
 

--- a/lib/markdown-content/htmlize-markdown.js
+++ b/lib/markdown-content/htmlize-markdown.js
@@ -19,6 +19,22 @@ const renderer = {
   html(html) {
     return blockifyClasses(html);
   },
+
+  link(href, title, text) {
+    let a = `<a href="${href}"`;
+
+    if (href.startsWith('/')) {
+      a = `${a} data-internal`;
+    } else if (!href.startsWith('https://simplabs.com')) {
+      a = `${a} target="_blank" rel="noopener"`;
+    }
+
+    if (title) {
+      a = `${a} tite="${title}"`;
+    }
+
+    return `${a}>${text}</a>`;
+  },
 };
 marked.use({ renderer });
 
@@ -26,14 +42,6 @@ module.exports = function htmlizeMarkdown(source, callback = null) {
   source = preventBundleFingerprintReplacement(source);
   let html = marked(source);
   html = manipulateDom(html, (dom) => {
-    dom.querySelectorAll('a').forEach((a) => {
-      if (a.href.startsWith('/')) {
-        a.dataset.internal = true;
-      } else if (!a.href.startsWith('https://simplabs.com')) {
-        a.target = '_blank';
-        a.rel = 'noopener';
-      }
-    });
     if (callback) {
       callback(dom);
     }

--- a/lib/markdown-content/htmlize-markdown.js
+++ b/lib/markdown-content/htmlize-markdown.js
@@ -43,8 +43,52 @@ const renderer = {
     }
     return `<table typography:class="table"><thead>${header}</thead>${body}</table>`;
   },
+
+  image(href, title, text) {
+    if (title) {
+      title = ` title="${title}"`;
+    }
+    return `<img src="${href}" alt="${text}"${title} blog-post:class="image">`;
+  },
 };
 marked.use({ renderer });
+
+const walkTokens = (token) => {
+  if (token.type === 'paragraph') {
+    if (token.tokens.length === 1 && token.tokens[0].type === 'image') {
+      let src = token.tokens[0].href;
+      let imageData = parseImageDirectives(src);
+      let img, imgClass, figureClass;
+
+      if (imageData.kind === 'full') {
+        imgClass = 'content-full';
+        figureClass = 'figure-plain';
+      } else if (imageData.kind === 'plain') {
+        imgClass = 'content-centered';
+        figureClass = 'figure-plain';
+      } else {
+        imgClass = 'content-centered';
+        figureClass = 'figure';
+      }
+
+      if (imageData.sizes) {
+        let srcset = `${imageData.sizes.small.src} ${imageData.sizes.small.size}w, ${imageData.sizes.large.src} ${imageData.sizes.large.size}w`;
+        let sizes = `(max-width: 887px) ${imageData.sizes.small.size}px, ${imageData.sizes.large.size}px`;
+        img = `<img srcset="${srcset}" sizes="${sizes}" figure:class="${imgClass}">`;
+      } else {
+        img = `<img src="${src}" figure:class="${imgClass}">`;
+      }
+
+      token.type = 'html';
+      delete token.raw;
+      delete token.tokens;
+      token.inLink = false;
+      token.inRawBlock = false;
+      token.text = `<figure blog-post:class="${figureClass}">${img}</figure>`;
+    }
+  }
+};
+marked.use({ walkTokens });
 
 module.exports = function htmlizeMarkdown(source, callback = null) {
   source = preventBundleFingerprintReplacement(source);
@@ -80,4 +124,40 @@ function encodeCurlies(content) {
 // https://github.com/simplabs/simplabs.github.io/issues/630 for reference.
 function preventBundleFingerprintReplacement(source) {
   return source.replace(/app\.js/g, 'app\u200b.js').replace(/app\.css/g, 'app\u200b.css');
+}
+
+function parseImageDirectives(src) {
+  let match = src.match(/#(full|plain)?(@(\d+)-(\d+))?$/);
+  let bareSrc = src.replace(/#[^#]*$/, '');
+  let directives = {
+    src: bareSrc,
+  };
+
+  if (!match) {
+    return directives;
+  }
+
+  let [, kind, , smallSize, largeSize] = match;
+
+  if (kind) {
+    directives.kind = kind;
+  }
+
+  if (smallSize && largeSize) {
+    let buildSrcForSize = (size) => bareSrc.replace(/(\.(\w){3,4})/, `@${size}$1`);
+    let smallImage = buildSrcForSize(smallSize);
+    let largeImage = buildSrcForSize(largeSize);
+    directives.sizes = {
+      small: {
+        size: smallSize,
+        src: smallImage,
+      },
+      large: {
+        size: largeSize,
+        src: largeImage,
+      },
+    };
+  }
+
+  return directives;
 }


### PR DESCRIPTION
This removes jsdom from the markdown processing pipeline which lets us drop some code and should also speed up the build process as well as make it less likely to fail (jsdom seems to leak memory and we have experienced problems with that previously).