### PR TITLE
Close pro-bono applications

### DIFF
--- a/_posts/2020-11-09-pro-bono-open-call.md
+++ b/_posts/2020-11-09-pro-bono-open-call.md
@@ -68,9 +68,6 @@ We will offer one of the following services:
 - Willing to share the project on their social media
 - Nice to have: in the sustainability, mobility, or education space
 
-## Apply now
+## Thank you for applying
 
-In order to apply, simply
-[fill out this form](https://forms.gle/4DLs5ETzXWtfP38u8). We are excited to get
-to know you and collaborate with you. **We have extended our application
-deadline to November 29, 2020**.
+**Pro-bono applications have closed on November 29, 2020.**


### PR DESCRIPTION
Remove the application form link and clearly state applications are now closed in order to any avoid confusion.