### PR TITLE
render clients in ClientsGrid in specified order

### DIFF
--- a/src/ui/components/ClientsGrid/component-test.ts
+++ b/src/ui/components/ClientsGrid/component-test.ts
@@ -8,26 +8,15 @@ module('Component: ClientsGrid', function(hooks) {
   setupRenderingTest(hooks);
 
   test('it renders', async function(assert) {
-    /*
-     * You may pass data into the component through arguments set on the
-     * `testContext`
-     *
-     * For example:
-     *
-     * ```
-     * this.foo = { foo: '123' };
-     *
-     * await render(hbs`<ClientsGrid @foo={{this.foo}} />`)
-     *
-     * // or
-     *
-     * this.foo = 'bar';
-     * await render(hbs`<p>{{this.foo}}</p>`);
-     *
-     * assert.dom('p').text('bar');
-     * ```
-     */
     await render(hbs`<ClientsGrid />`);
+
     assert.ok(this.containerElement.querySelector('div'));
+  });
+
+  test('it preserves the order of the specified clients', async function(assert) {
+    await render(hbs`<ClientsGrid @only="erdil,loconet" />`);
+
+    assert.ok(this.containerElement.querySelectorAll('figcaption')[0].textContent.includes('ERDiL'));
+    assert.ok(this.containerElement.querySelectorAll('figcaption')[1].textContent.includes('LoCoNET'));
   });
 });

--- a/src/ui/components/ClientsGrid/component.ts
+++ b/src/ui/components/ClientsGrid/component.ts
@@ -138,7 +138,7 @@ export default class ClientsGrid extends Component {
     let clients = allClients;
     let included = this.included;
     if (included.length > 0) {
-      clients = clients.filter(client => included.includes(client.id));
+      clients = included.map(i => clients.find(client => client.id === i));
     }
 
     return clients;


### PR DESCRIPTION
The `<ClientsGrid>` component allows rendering only a particular set of clients but will not respect the order that these clients are specified in (instead it renders the set in the order they appear in an internal data structure of that component). This changes that so that e.g.

```hbs
<ClientsGrid @only="erdil,loconet" />
```

will in fact first render ERDiL, then LoCoNET.