### PR TITLE
Add support for autoplaying video "image"

### DIFF
--- a/lib/markdown-content/htmlize-markdown.js
+++ b/lib/markdown-content/htmlize-markdown.js
@@ -30,7 +30,7 @@ const renderer = {
     }
 
     if (title) {
-      a = `${a} tite="${title}"`;
+      a = `${a} title="${title}"`;
     }
 
     return `${a}>${text}</a>`;
@@ -95,7 +95,7 @@ function preventBundleFingerprintReplacement(source) {
 }
 
 function parseImageDirectives(src) {
-  let match = src.match(/#(full|plain)?(@(\d+)-(\d+))?$/);
+  let match = src.match(/#(full|plain|video)?(@(\d+)-(\d+))?$/);
   let bareSrc = src.replace(/#[^#]*$/, '');
   let directives = {
     src: bareSrc,
@@ -138,7 +138,7 @@ function wrapInFigure(paragraphToken, imageToken, linkToken = null) {
   if (imageData.kind === 'full') {
     imgClass = 'content-full';
     figureClass = 'figure-plain';
-  } else if (imageData.kind === 'plain') {
+  } else if (imageData.kind === 'plain' || imageData.kind === 'video') {
     imgClass = 'content-centered';
     figureClass = 'figure-plain';
   } else {
@@ -161,6 +161,12 @@ function wrapInFigure(paragraphToken, imageToken, linkToken = null) {
   paragraphToken.inLink = false;
   paragraphToken.inRawBlock = false;
 
-  let figureContent = linkToken ? renderer.link(linkToken.href, linkToken.title, img) : img;
+  let figureContent = img;
+  if (imageData.kind === 'video') {
+    figureContent = `<video src="${src}" blog-post:class="video" playsinline autoplay muted loop role="presentation">${imageToken.text}</video>`;
+  } else if (linkToken) {
+    figureContent = renderer.link(linkToken.href, linkToken.title, img);
+  }
+
   paragraphToken.text = `<figure blog-post:class="${figureClass}">${figureContent}</figure>`;
 }


### PR DESCRIPTION
This adds support to the markdown for a `![Title](/src/video.mp4#video)` syntax. The "Title" will be used as if it were an alt text inside the video tag. I've marked the video element as role="presentation" to make screenreaders ignore it.