### PR TITLE
add subtle border around blog post videos

### DIFF
--- a/src/ui/styles/blocks/blog-post.block.css
+++ b/src/ui/styles/blocks/blog-post.block.css
@@ -62,6 +62,8 @@
   max-width: 100%;
   margin-top: 3rem;
   margin-bottom: 3rem;
+  border: 1px solid #ddd;
+  box-sizing: border-box;
 }
 
 .content-post {


### PR DESCRIPTION
Per recommendation of @marhigh this PR adds a subtle border around videos that are part of a blog post article.

**Example:** 
<img width="844" alt="Screenshot 2021-01-28 at 18 13 30" src="https://user-images.githubusercontent.com/334789/106173787-9b179480-6194-11eb-9f68-7c0c5679a7e7.png">
