### PR TITLE
change URL of Ember route for better SEO

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,6 @@ jobs:
       - name: build
         run: yarn build
 
-      - run: yarn run lhci autorun --collect.staticDistDir=./dist --collect.url=http://localhost/ --collect.url=http://localhost/blog/ --collect.url=http://localhost/services/ --collect.url=http://localhost/blog/ --collect.url=http://localhost/expertise/ember/ --collect.url=http://localhost/playbook/ --collect.url=http://localhost/contact/ --upload.target=temporary-public-storage
+      - run: yarn run lhci autorun --collect.staticDistDir=./dist --collect.url=http://localhost/ --collect.url=http://localhost/blog/ --collect.url=http://localhost/services/ --collect.url=http://localhost/blog/ --collect.url=http://localhost/ember-consulting/ --collect.url=http://localhost/playbook/ --collect.url=http://localhost/contact/ --upload.target=temporary-public-storage
         env:
           LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}

--- a/_posts/2019-11-11-why-companies-invest-in-oss.md
+++ b/_posts/2019-11-11-why-companies-invest-in-oss.md
@@ -169,7 +169,7 @@ constraints. Still, open-source is at the heart of our company's work and
 besides contributing to EmberJS via our core team engagements, we maintain over
 a dozen of tools and libraries written in JavaScript and other programming
 languages and which are well-adopted in the open-source community
-[[13](/expertise/ember/)]. Being aware that providing value for OSS is
+[[13](/ember-consulting/)]. Being aware that providing value for OSS is
 important, but takes time, we dedicate regular time for engineers and designers
 to work on open-source projects using the **20% time method**.
 
@@ -243,7 +243,7 @@ process of contributing.
 - [10: "Open Source in 2019". Open Source Initiative. 2019](https://opensource.org/node/1006)
 - [11: "Open Source Benefits to Innovation and Organizational Agility". Shaaron A Alvares. 2019.](https://www.infoq.com/news/2019/03/open-source-benefits/)
 - - [12: "Open Source Software from Commercial Firms – Tools, Complements, and Collective Invention ". Joachim Henkel. 2003](https://www.researchgate.net/profile/Joachim_Henkel/publication/251228522_Open_Source_Software_from_Commercial_Firms_-_Tools_Complements_and_Collective_Invention/links/54c3bb140cf219bbe4ec1cf5/Open-Source-Software-from-Commercial-Firms-Tools-Complements-and-Collective-Invention.pdf)
-- [13: "Europe's leading Ember experts". simplabs. 2019.](/expertise/ember/)
+- [13: "Europe's leading Ember experts". simplabs. 2019.](/ember-consulting/)
 - [14: "2016 - Future of Open Source Survey Results". Black Duck by Synopsys. 2016](https://www.slideshare.net/blackducksoftware/2016-future-of-open-source-survey-results)
 
 This post is based on the talk

--- a/_posts/2020-01-31-how-to-over-engineer-a-static-page.md
+++ b/_posts/2020-01-31-how-to-over-engineer-a-static-page.md
@@ -186,7 +186,7 @@ Our site now has a multitude of bundles:
   [calendar](/calendar/) or [talks catalog](/talks/)
 - a bundle that contains a component that lists the most recent blog posts for a
   particular topic that; that component gets included on
-  [pages within the main site](/expertise/ember/)
+  [pages within the main site](/ember-consulting/)
 
 ### Bundles and Caching
 
@@ -300,7 +300,7 @@ By spending a significant (and maybe unreasonable) amount of time and energy we
 ended up with the highly optimized site you're looking at. The downside is we
 ended up with our own custom static site generator essentially that we now need
 to maintain ourselves (one of the reasons why we recommend using a fully
-integrated framework like [Ember.js](/expertise/ember/) instead of compiling
+integrated framework like [Ember.js](/ember-consulting/) instead of compiling
 your own custom framework out of a bunch of micro libraries). However, it was
 definitely an interesting experiment and we hope you take some inspiration out
 of the patterns and mechanisms we describe in this post. If you are struggling

--- a/config/routes-map.js
+++ b/config/routes-map.js
@@ -68,7 +68,7 @@ module.exports = function () {
     '/cases/trainline': { component: 'PageCaseStudyTrainline' },
     '/cases/qonto': { component: 'PageCaseStudyQonto' },
     '/contact': { component: 'PageContact' },
-    '/expertise/ember': { component: 'PageEmberExpertise' },
+    '/ember-consulting': { component: 'PageEmberExpertise' },
     '/expertise/elixir-phoenix': { component: 'PageElixirExpertise' },
     '/imprint': {
       component: 'PageLegalImprint',

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,10 +15,13 @@
   from = "/training/"
   to = "/services/training/"
 
-# redirect old ember page
+# redirect old ember pages
 [[redirects]]
   from = "/ember/"
-  to = "/expertise/ember/"
+  to = "/ember-consulting/"
+[[redirects]]
+  from = "/expertise/ember/"
+  to = "/ember-consulting/"
 
 # redirect old clients page
 [[redirects]]

--- a/src/ui/components/CardEmberExpertise/template.hbs
+++ b/src/ui/components/CardEmberExpertise/template.hbs
@@ -4,7 +4,7 @@
   @src="/assets/images/card/ember.svg"
   @alt="Ember.js"
 >
-  <ArrowLink @href="/expertise/ember/">
+  <ArrowLink @href="/ember-consulting/">
     Learn more
   </ArrowLink>
 </Card>

--- a/src/ui/components/CardEmberSponsors/template.hbs
+++ b/src/ui/components/CardEmberSponsors/template.hbs
@@ -11,7 +11,7 @@
     </a>
     of the Ember.js project along with international brands like LinkedIn and Yahoo.
   </p>
-  <ArrowLink @href="/expertise/ember/">
+  <ArrowLink @href="/ember-consulting/">
     Learn why we care about Ember.js
   </ArrowLink>
 </Card>

--- a/src/ui/components/Footer/template.hbs
+++ b/src/ui/components/Footer/template.hbs
@@ -45,7 +45,7 @@
         </h3>
         <ul block:class="items">
           <li block:class="item">
-            <a href="/expertise/ember/" block:class="link" data-internal>
+            <a href="/ember-consulting/" block:class="link" data-internal>
               Ember.js
             </a>
           </li>

--- a/src/ui/components/PageTeamAugmentation/template.hbs
+++ b/src/ui/components/PageTeamAugmentation/template.hbs
@@ -75,7 +75,7 @@
     <p typography:class="lead">
       We are strongly engaged in open source with several team members on the Ember.js core team and a number of libraries that we maintain ourselves. Our experts are internationally known for their work on all parts of the software development process, often sharing their knowledge at conferences and events across the globe.
     </p>
-    <ArrowLink @href="/expertise/ember/">
+    <ArrowLink @href="/ember-consulting/">
       Read more about our involvement with Ember
     </ArrowLink>
   </div>


### PR DESCRIPTION
This changes the path of our Ember page for better SEO:

```
/expertise/ember/ -> /ember-consulting/
```

**Once this is merged we need to update the Google Adwords campaign as well.**