### PR TITLE
Remove underline on footer links hover

### DIFF
--- a/src/ui/components/Footer/stylesheet.css
+++ b/src/ui/components/Footer/stylesheet.css
@@ -82,15 +82,25 @@
 
 .link,
 .link:link,
-.link:visited {
+.link:visited,
+.title-link,
+.title-link:link,
+.title-link:visited {
   display: block;
   text-decoration: none;
   color: inherit;
-  padding: 0.5rem 0;
 }
 
-.link:hover {
+.link:hover,
+.title-link:hover {
   color: var(--color-accent);
+  background: none;
+}
+
+.link,
+.link:link,
+.link:visited {
+  padding: 0.5rem 0;
 }
 
 .note {

--- a/src/ui/components/Footer/template.hbs
+++ b/src/ui/components/Footer/template.hbs
@@ -17,7 +17,7 @@
     <nav block:class="nav">
       <div block:class="block">
         <h3 block:class="title">
-          <a href="/services/" data-internal>
+          <a href="/services/" data-internal block:class="title-link">
             Services
           </a>
         </h3>
@@ -63,7 +63,7 @@
       </div>
       <div block:class="block">
         <h3 block:class="title">
-          <a href="/work/" data-internal>
+          <a href="/work/" data-internal block:class="title-link">
             Work
           </a>
         </h3>


### PR DESCRIPTION
This removes the underline when hovering over links in the footer:

| Before | After |
|--------|------|
|  <img width="105" alt="107344551-df733080-6ac2-11eb-895f-c2a781a93edc" src="https://user-images.githubusercontent.com/1510/107429020-b767e980-6b23-11eb-901c-e8f7f7e920b1.png"> | <img width="111" alt="Bildschirmfoto 2021-02-09 um 22 10 12" src="https://user-images.githubusercontent.com/1510/107429041-be8ef780-6b23-11eb-9c6d-e6119bb5c1de.png"> |

closes #1451 