### PR TITLE
add badge to playbook link in footer

### DIFF
--- a/src/ui/components/Footer/stylesheet.css
+++ b/src/ui/components/Footer/stylesheet.css
@@ -6,7 +6,7 @@
 
 :scope {
   block-name: Footer;
-  font-size: 1.75rem;
+  font-size: 2rem;
   line-height: 1.5;
   color: var(--color-muted);
   z-index: 100;
@@ -78,6 +78,17 @@
 .item {
   padding: 0.5rem 0;
   white-space: nowrap;
+}
+
+.badge {
+  font-size: 1.75rem;
+  line-height: 1.5;
+  background-color: var(--color-accent);
+  color: var(--color-text-inverted);
+  display: inline-block;
+  text-transform: uppercase;
+  padding: 0.25rem 1.25rem;
+  margin-left: 1rem;
 }
 
 .link,

--- a/src/ui/components/Footer/template.hbs
+++ b/src/ui/components/Footer/template.hbs
@@ -57,6 +57,9 @@
           <li block:class="item">
             <a href="/playbook/" block:class="link" data-internal>
               Our Playbook
+              <span block:class="badge">
+                New
+              </span>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
This adds a _"NEW"_ badge to playbook link in the footer:

<img width="206" alt="Bildschirmfoto 2021-02-11 um 17 42 06" src="https://user-images.githubusercontent.com/1510/107668007-77724500-6c90-11eb-8e90-3c8ef3eaeb4b.png">

This also updates the font sizes to be closer to what we have in the Sketch file. They seem to be extremely small currently? Let me know if we should rather keep them as they are.

addresses part of #1224 