### PR TITLE
Fix scrolling after navigation

### DIFF
--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -33,6 +33,8 @@ export default class Simplabs extends Component {
 
   private document: HTMLDocument;
 
+  private currentLink: HTMLAnchorElement = null;
+
   private loadingProgressInterval: number;
 
   @tracked
@@ -63,6 +65,7 @@ export default class Simplabs extends Component {
         after: () => {
           this._setCanonicalUrl(path);
           this._scrollToSuitableOffset();
+          this.currentLink = null;
         },
         already: () => {
           this._scrollToSuitableOffset();
@@ -114,6 +117,7 @@ export default class Simplabs extends Component {
 
           if (link && link.dataset.internal !== undefined) {
             event.preventDefault();
+            this.currentLink = link;
             this.router.navigate(link.getAttribute('href'));
           }
         }
@@ -223,7 +227,7 @@ export default class Simplabs extends Component {
   }
 
   private _scrollToSuitableOffset() {
-    if (!this.appState.isSSR) {
+    if (!this.appState.isSSR && this.currentLink) {
       let { hash } = window.location;
       let element;
       if (hash) {

--- a/src/ui/components/Simplabs/component.ts
+++ b/src/ui/components/Simplabs/component.ts
@@ -232,7 +232,7 @@ export default class Simplabs extends Component {
       if (element) {
         element.scrollIntoView();
       } else {
-        window.scrollTo(0, 0);
+        window.setTimeout(() => window.scrollTo(0, 0));
       }
     }
   }


### PR DESCRIPTION
This fixes 2 problems with the current scroll-after-link behavior where we scroll to the top after navigation.

* first we are currently scrolling to the top **synchronously** when the navigation happens which is **before** rendering has completed so you'll see the top of the **current** page for a very short time before the navigation is actually performed and the page re-renders with the new current component:

https://user-images.githubusercontent.com/1510/115446739-eda6a100-a217-11eb-953b-30fbba11cc8c.mov

This fixes that by wrapping `window.scrollTo(0, 0);` in a `window.setTimeout` so that the rendering can complete before we scroll.
* also we're currently scrolling to the top after **any** kind of navigation but in reality when using the back/next buttons you **don't** want the page to scroll but remain your previous scroll position. This fixes that by tracking the link that triggered the current navigation and if there is none it doesn't scroll.