### PR TITLE
use youtube-nocookie for all video embeds

### DIFF
--- a/_posts/2018-07-03-building-a-pwa-with-glimmer-js.md
+++ b/_posts/2018-07-03-building-a-pwa-with-glimmer-js.md
@@ -73,7 +73,7 @@ that works and why it results in very small bundle sizes as well as super fast
 initial and update renders, watch the talk I gave at the
 [Ember.js Munich](https://www.meetup.com/Ember-js-Munich/) meetup last year:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/vIRZDCyfOJc?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/vIRZDCyfOJc?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 
 ## Building Breethe with Glimmer.js
 

--- a/_posts/2018-07-24-from-spa-to-pwa.md
+++ b/_posts/2018-07-24-from-spa-to-pwa.md
@@ -48,7 +48,7 @@ for a long time, it never really took off until recently. In fact, Steve Jobs
 himself introduced the idea at WWDC 2007, just shortly after the unveiling of
 the orignal iPhone:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/y1B2c3ZD9fk?start=4451" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/y1B2c3ZD9fk?start=4451" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
 
 Unfortunately that idea was one of the few of Jobs' that never really took off.
 In fact, Apple released the first native SDK for the iPhone in 2008. That change

--- a/_videos/2020-12-02-built-to-last-christina-roinzheim-not-less-but-better.md
+++ b/_videos/2020-12-02-built-to-last-christina-roinzheim-not-less-but-better.md
@@ -1,5 +1,5 @@
 ---
-videoUrl: https://www.youtube.com/embed/esRwdhlwIw8
+videoUrl: https://www.youtube-nocookie.com/embed/esRwdhlwIw8
 kind: built-to-last
 label: 'Built to Last #1: Expert insights'
 title: Christina Roizheim, co-founder of not less but better

--- a/_videos/2020-12-10-the-three-pillars-of-successful-digital-product-development.md
+++ b/_videos/2020-12-10-the-three-pillars-of-successful-digital-product-development.md
@@ -1,5 +1,5 @@
 ---
-videoUrl: https://www.youtube.com/embed/3K9jQfpkGWU
+videoUrl: https://www.youtube-nocookie.com/embed/3K9jQfpkGWU
 kind: talk
 label: Talk with Marco Otte-Witte
 title: The three pillars of successful digital product development

--- a/_videos/2020-12-15-built-to-last-karol-domagalski-upfit.md
+++ b/_videos/2020-12-15-built-to-last-karol-domagalski-upfit.md
@@ -1,5 +1,5 @@
 ---
-videoUrl: https://www.youtube.com/embed/pI8p2_MyIyg
+videoUrl: https://www.youtube-nocookie.com/embed/pI8p2_MyIyg
 kind: built-to-last
 label: 'Built to Last #2: Expert insights'
 title: Karol Domagalski, founder & CEO of Upfit

--- a/_videos/2020-12-29-built-to-last-joel-kelly-eve.md
+++ b/_videos/2020-12-29-built-to-last-joel-kelly-eve.md
@@ -1,5 +1,5 @@
 ---
-videoUrl: https://www.youtube.com/embed/o5Jv3kZ-Tks
+videoUrl: https://www.youtube-nocookie.com/embed/o5Jv3kZ-Tks
 kind: built-to-last
 label: 'Built to Last #3: Expert insights'
 title: Joel Kelly, founder & CEO of Eve

--- a/_videos/2021-01-13-built-to-last-peter-arnold-enterango.md
+++ b/_videos/2021-01-13-built-to-last-peter-arnold-enterango.md
@@ -1,5 +1,5 @@
 ---
-videoUrl: https://www.youtube.com/embed/SKRIYNjhbgg
+videoUrl: https://www.youtube-nocookie.com/embed/SKRIYNjhbgg
 kind: built-to-last
 label: 'Built to Last #4: Expert insights'
 title: Peter Arnold, CEO and co-founder of EnterAnGo

--- a/_videos/2021-02-18-built-to-last-aymeric-augustin-qonto.md
+++ b/_videos/2021-02-18-built-to-last-aymeric-augustin-qonto.md
@@ -1,5 +1,5 @@
 ---
-videoUrl: https://www.youtube.com/embed/EAeD0pkUoLk
+videoUrl: https://www.youtube-nocookie.com/embed/EAeD0pkUoLk
 kind: built-to-last
 label: 'Built to Last #5: Expert insights'
 title: Aymeric Augustin, CTO of Qonto

--- a/_videos/2021-03-17-built-to-last-khalid-maliki.md
+++ b/_videos/2021-03-17-built-to-last-khalid-maliki.md
@@ -1,5 +1,5 @@
 ---
-videoUrl: https://www.youtube.com/embed/eT7G_V6l4qw
+videoUrl: https://www.youtube-nocookie.com/embed/eT7G_V6l4qw
 kind: built-to-last
 label: 'Built to Last #6: Expert insights'
 title: Khalid Maliki, co-founder of Tykn

--- a/_videos/2021-04-27-built-to-last-yoran-brondsema.md
+++ b/_videos/2021-04-27-built-to-last-yoran-brondsema.md
@@ -1,5 +1,5 @@
 ---
-videoUrl: https://www.youtube.com/embed/0OgDmmthe48
+videoUrl: https://www.youtube-nocookie.com/embed/0OgDmmthe48
 kind: built-to-last
 label: 'Built to Last #7: Expert insights'
 title: Yoran Brondsema, co-founder and CTO of Sutori


### PR DESCRIPTION
This is based on the documentation here: https://support.google.com/youtube/answer/171780?visit_id=637563189687636677-2621067568&rd=1#zippy=%2Cturn-on-privacy-enhanced-mode for "Privacy enhanced mode" 

Essentially if we just do a normal youtube embed then we need a cookie banner again 🙈  so this fixes that 👍 

We should probably have a lint rule to make sure that this stays the case? 