### PR TITLE
fix alt text on all markdown images

### DIFF
--- a/lib/markdown-content/htmlize-markdown.js
+++ b/lib/markdown-content/htmlize-markdown.js
@@ -157,9 +157,9 @@ function wrapInFigure(paragraphToken, imageToken, linkToken = null) {
   if (imageData.sizes) {
     let srcset = `${imageData.sizes.small.src} ${imageData.sizes.small.size}w, ${imageData.sizes.large.src} ${imageData.sizes.large.size}w`;
     let sizes = `(max-width: 887px) ${imageData.sizes.small.size}px, ${imageData.sizes.large.size}px`;
-    img = `<img srcset="${srcset}" sizes="${sizes}" figure:class="${imgClass}">`;
+    img = `<img alt="${imageToken.text}" srcset="${srcset}" sizes="${sizes}" figure:class="${imgClass}">`;
   } else {
-    img = `<img src="${src}" figure:class="${imgClass}">`;
+    img = `<img alt="${imageToken.text}" src="${src}" figure:class="${imgClass}">`;
   }
 
   for (let key of Object.keys(paragraphToken)) {


### PR DESCRIPTION
I noticed this when I was reviewing #271 using Voiceover on Mac, none of the images had the alt text that I defined. 

For example the following markdown wouldn't work as expected: 

```markdown
![Screenshot of Fork with a number of branches](/assets/images/posts/2021-03-31-keeping-a-clean-git-history/fork-screenshot.png)
```

I have tested this PR locally and it works as expected now with Voiceover on Mac 👍 