### PR TITLE
bump engines.node to 12 as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "typescript": "~4.3.5"
   },
   "engines": {
-    "node": ">= 4.0"
+    "node": ">= 12.0"
   },
   "private": true,
   "ember-addon": {


### PR DESCRIPTION
This should make Netlify use Node 12, and thus go back to a green build.