### PR TITLE
add missing class

### DIFF
--- a/src/ui/styles/blocks/blog-post.block.css
+++ b/src/ui/styles/blocks/blog-post.block.css
@@ -314,6 +314,7 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
 .hljs-meta-keyword,
 .hljs-selector-pseudo,
 .hljs-selector-attr,
+.hljs-code,
 .xml,
 .javascript {
 }


### PR DESCRIPTION
Some blog posts for some reason need the CSS class `hljs-code` to be present and its absence causes a build error. No questions please – I'm not fully aware why that class is needed, it seems some code snippets cause highlight.js to generate HTML that references that particular class.

see #1580 