### PR TITLE
Replace dateformat with native Date and Intl.DateTimeFormat APIs

### DIFF
--- a/lib/generate-blog/lib/components-builder.js
+++ b/lib/generate-blog/lib/components-builder.js
@@ -4,7 +4,6 @@ const assert = require('assert');
 const path = require('path');
 const fs = require('fs-extra');
 
-const dateformat = require('dateformat');
 const _ = require('lodash');
 
 const collectPosts = require('./collect-posts');
@@ -157,9 +156,9 @@ module.exports = class ComponentsBuilder extends BaseComponentsBuilder {
       description: post.meta.description,
       excerpt: htmlizeExcerpt(post.content),
       body: htmlizeBody(post.content),
-      date: dateformat(post.meta.date, 'mmmm d, yyyy'),
-      year: dateformat(post.meta.date, 'yyyy'),
-      isoDate: dateformat(post.meta.date, 'isoUtcDateTime'),
+      date: new Intl.DateTimeFormat('en', { dateStyle: 'long' }).format(post.meta.date),
+      year: post.meta.date.getFullYear(),
+      isoDate: post.meta.date.toISOString(),
       path: `/blog/${post.queryPath}/`,
       topic: post.meta.topic,
       teaserImage: post.meta['teaser-image'],

--- a/lib/generate-blog/lib/feed-builder.js
+++ b/lib/generate-blog/lib/feed-builder.js
@@ -3,7 +3,6 @@
 const path = require('path');
 
 const fs = require('fs-extra');
-const dateformat = require('dateformat');
 const marked = require('marked');
 const Entities = require('html-entities');
 const BroccoliPlugin = require('broccoli-caching-writer');
@@ -39,7 +38,7 @@ function generateFeed(posts) {
     <feed xmlns="http://www.w3.org/2005/Atom">
       <link href="${SITE_URL}/feed.xml" rel="self" type="application/atom+xml"/>
       <link href="${SITE_URL}/" rel="alternate" type="text/html"/>
-      <updated>${dateformat(new Date(), 'isoUtcDateTime')}</updated>
+      <updated>${new Date().toISOString()}</updated>
       <id>${SITE_URL}/feed.xml</id>
       <title>simplabs</title>
       <subtitle>Solid Solutions for Ambitious Projects</subtitle>
@@ -55,7 +54,7 @@ function generateFeed(posts) {
       <entry>
         <title>${post.meta.title}</title>
         <link href="${url}" rel="alternate" type="text/html" title="${post.meta.title}"/>
-        <published>${dateformat(post.meta.date, 'isoUtcDateTime')}</published>
+        <published>${post.meta.date.toISOString()}</published>
         <id>${url}</id>
         <content type="html" xml:base="${url}">
           ${content}

--- a/lib/generate-calendar/lib/components-builder.js
+++ b/lib/generate-calendar/lib/components-builder.js
@@ -1,6 +1,4 @@
 'use strict';
-
-const dateformat = require('dateformat');
 const _ = require('lodash');
 
 const collectEvents = require('./collect-events');
@@ -38,7 +36,7 @@ module.exports = class ComponentsBuilder extends BaseComponentsBuilder {
       return {
         meta: {
           ...event.meta,
-          date: dateformat(event.meta.date, 'mmmm d, yyyy'),
+          date: new Intl.DateTimeFormat('en', { dateStyle: 'long' }).format(event.meta.date),
         },
         content: htmlizeMarkdown(event.content),
       };

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "broken-link-checker": "^0.7.8",
     "clean-css": "^5.1.5",
     "colors": "^1.4.0",
-    "dateformat": "^4.5.1",
     "ember-cli": "^3.28.0",
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-inject-live-reload": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5176,11 +5176,6 @@ date-time@^2.1.0:
   dependencies:
     time-zone "^1.0.0"
 
-dateformat@^4.5.1:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.5.1.tgz#c20e7a9ca77d147906b6dc2261a8be0a5bd2173c"
-  integrity sha512-OD0TZ+B7yP7ZgpJf5K2DIbj3FZvFvxgFUuaqA/V5zTjAtAAXZ1E8bktHxmAGs4x5b7PflqA9LeQ84Og7wYtF7Q==
-
 debug@2.6.9, debug@^2.1.0, debug@^2.1.1, debug@^2.1.2, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
The new v5 major version of dateformat is available as ESM-only which is causing us some problems in the build.
It seemed easier to replace usages with native APIs than to figure out how we could import dateformat.

Closes https://github.com/simplabs/simplabs.github.io/pull/1587.