### PR TITLE
Add this-week-in-open-source executable script

### DIFF
--- a/config/this-week-in-open-source.config.json
+++ b/config/this-week-in-open-source.config.json
@@ -1,0 +1,97 @@
+{
+    "users": [
+        "marcoow",
+        "locks",
+        "zeppelin",
+        "Turbo87",
+        "pichfl",
+        "nickschot",
+        "mansona",
+        "oscard0m",
+        "Mikek2252",
+        "inesilva",
+        "BobrImperator",
+        "candunaj"
+    ],
+    "labels": [
+        {
+            "name": "Rust",
+            "repos": [
+                "Turbo87/aprs-parser-rs",
+                "hyperium/http",
+                "rust-lang/cargo"
+            ]
+        },
+        {
+            "name": "crates.io",
+            "repos": [
+                "conduit-rust/conduit-hyper",
+                "rust-lang/crates.io"
+            ]
+        },
+        {
+            "name": "Ember.js",
+            "repos": [
+                "Authmaker/authmaker-ember-simple-auth",
+                "buschtoens/ember-link",
+                "ember-cli/ember-cli",
+                "ember-cli/ember-cli",
+                "ember-cli/ember-exam",
+                "ember-learn/ember-api-docs",
+                "ember-learn/ember-blog",
+                "ember-learn/ember-styleguide",
+                "ember-learn/ember-website",
+                "ember-learn/empress-blog-ember-template",
+                "ember-learn/guides-source",
+                "emberjs/core-notes",
+                "emberjs/data",
+                "emberjs/ember-ordered-set",
+                "emberjs/ember-string",
+                "emberjs/ember.js",
+                "empress/broccoli-static-site-json",
+                "empress/ember-cli-notifications",
+                "empress/ember-cli-showdown",
+                "empress/ember-showdown-prism",
+                "empress/empress-blog",
+                "empress/empress-blog-casper-template",
+                "empress/field-guide",
+                "mansona/ember-body-class",
+                "mansona/ember-cli-notifications",
+                "nickschot/ember-mobile-menu",
+                "simplabs/ember-cookies",
+                "simplabs/ember-error-route",
+                "simplabs/ember-intl-analyzer",
+                "simplabs/ember-promise-modals",
+                "simplabs/ember-simple-auth",
+                "simplabs/qunit-dom",
+                "zeppelin/ember-click-outside"
+            ]
+        },
+        {
+            "name": "JavaScript",
+            "repos": [
+                "TelemetryDeck/JavaScriptSDK",
+                "commitizen/cz-conventional-changelog",
+                "mansona/lint-to-the-future",
+                "mansona/lint-to-the-future-eslint",
+                "oscard0m/npm-snapshot",
+                "remy/nodemon",
+                "storybookjs/eslint-plugin-storybook",
+                "storybookjs/storybook",
+                "strapi/strapi"
+            ]
+        },
+        {
+            "name": "simplabs's playbook",
+            "repos": [
+                "simplabs/playbook"
+            ]
+        },
+        {
+            "name": "Ruby",
+            "repos": [
+                "rubyforgood/Flaredown"
+            ]
+        }
+    ]
+}

--- a/config/this-week-in-open-source.config.json
+++ b/config/this-week-in-open-source.config.json
@@ -13,6 +13,21 @@
         "BobrImperator",
         "candunaj"
     ],
+    "exclude": [
+        "cardstack/animations-experiment",
+        "konfettiev/konfetti-muenchen.de",
+        "qonto/ember-amount-input",
+        "qonto/ember-autofocus-modifier",
+        "qonto/ember-phone-input",
+        "simplabs/simplabs.github.io",
+        "simplabs/this-week-in-open-source",
+        "mansona/test-copy-file-dest",
+        "oscard0m/web",
+        "BobrImperator/tilex",
+        "emberfest/emberfest.github.io",
+        "mansona/ember-paper",
+        "mansona/rfcs"
+    ],
     "labels": [
         {
             "name": "Rust",
@@ -64,7 +79,14 @@
                 "simplabs/ember-promise-modals",
                 "simplabs/ember-simple-auth",
                 "simplabs/qunit-dom",
-                "zeppelin/ember-click-outside"
+                "zeppelin/ember-click-outside",
+                "simplabs/ember-hbs-minifier",
+                "simplabs/ember-test-selectors",
+                "ember-learn/deprecation-app",
+                "empress/rfc-process-mdbook-template",
+                "empress/rfc-process",
+                "jelhan/ember-cli-browser-navigation-button-test-helpers",
+                "miguelcobain/ember-paper"
             ]
         },
         {
@@ -78,7 +100,18 @@
                 "remy/nodemon",
                 "storybookjs/eslint-plugin-storybook",
                 "storybookjs/storybook",
-                "strapi/strapi"
+                "strapi/strapi",
+                "mansona/express-autoroute-json",
+                "mansona/express-autoroute-json"
+            ]
+        },
+        {
+            "name": "Octokit",
+            "repos": [
+                "octokit/plugin-throttling.js",
+                "octokit/core.js",
+                "octokit/octokit.js",
+                "octokit/webhooks.js"
             ]
         },
         {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "format:hbs": "prettier --write --parser glimmer '**/*.hbs'",
     "format:md": "prettier --write '**/*md'",
     "format": "yarn run format:ts; yarn run format:js; yarn run format:hbs; yarn run format:css; yarn run format:md",
-    "percy": "percy exec -- node scripts/percy.js"
+    "percy": "percy exec -- node scripts/percy.js",
+    "this-week": "./bin/this-week-in-open-source --config-path=config/this-week-in-open-source.config.json"
   },
   "devDependencies": {
     "@babel/core": "^7.17.5",


### PR DESCRIPTION
- Adds a compiled executable of `this-week-in-open-source` v0.2.0 https://github.com/simplabs/this-week-in-open-source
- Adds alias referencing `./bin/this-week-in-open-source` to package.json
- Adds configuration for `this-week-in-open-source`

How to run:
- Generate Github Personal Token https://github.com/simplabs/this-week-in-open-source#ratelimit (the program still runs without the token, but you'll most likely hit a rate-limit which might cause the program to exit without generating anything)
- Open the location of the repository inside terminal
- Run command: `GITHUB_PERSONAL_TOKEN=<your-token> yarn this-week -after --date=2021-12-01`
- File called `2021-12-01.md` should be generated.