### PR TITLE
feat: update this-week-in-open-source to v0.4.0

### DIFF
--- a/config/this-week-in-open-source.config.json
+++ b/config/this-week-in-open-source.config.json
@@ -1,4 +1,5 @@
 {
+    "exclude_closed_not_merged": true,
     "users": [
         "marcoow",
         "locks",


### PR DESCRIPTION
- Updates binary to v0.4.0
- Configures it to exclude PRs that were closed before merging.