### PR TITLE
Rename legal entity to Mainmatter GmbH

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,5 @@ Chrome Inspector to do so.**
 
 ## Copyright
 
-Copyright &copy; 2019 simplabs GmbH (https://simplabs.com), released under the
+Copyright &copy; 2019 Mainmatter GmbH (https://simplabs.com), released under the
 [Creative Commons Attribution-NonCommercial 4.0 International license](https://creativecommons.org/licenses/by-nc/4.0/).

--- a/lib/generate-blog/lib/templates/list-page/template.hbs
+++ b/lib/generate-blog/lib/templates/list-page/template.hbs
@@ -10,7 +10,7 @@
       "@type": "Organization",
       "name": "simplabs",
       "url": "{{siteUrl}}",
-      "legalName": "simplabs GmbH",
+      "legalName": "Mainmatter GmbH",
       "logo": {
         "@type": "ImageObject",
         "url": "{{siteUrl}}/assets/images/logos/simplabs.png"
@@ -20,7 +20,7 @@
       "@type": "Organization",
       "name": "simplabs",
       "url": "{{siteUrl}}",
-      "legalName": "simplabs GmbH",
+      "legalName": "Mainmatter GmbH",
       "logo": {
         "@type": "ImageObject",
         "url": "{{siteUrl}}/assets/images/logos/simplabs.png"

--- a/lib/generate-blog/lib/templates/post/template.hbs
+++ b/lib/generate-blog/lib/templates/post/template.hbs
@@ -26,7 +26,7 @@
         "@type": "Organization",
         "name": "simplabs",
         "url": "{{siteUrl}}",
-        "legalName": "simplabs GmbH",
+        "legalName": "Mainmatter GmbH",
         "logo": {
           "@type": "ImageObject",
           "url": "{{siteUrl}}/assets/images/logos/simplabs.png"
@@ -36,7 +36,7 @@
         "@type": "Organization",
         "name": "simplabs",
         "url": "{{siteUrl}}",
-        "legalName": "simplabs GmbH",
+        "legalName": "Mainmatter GmbH",
         "logo": {
           "@type": "ImageObject",
           "url": "{{siteUrl}}/assets/images/logos/simplabs.png"

--- a/lib/head-data/index.js
+++ b/lib/head-data/index.js
@@ -15,7 +15,7 @@ module.exports = {
       return `
         <meta name="language" content="en" />
         <meta name="content-language" content="en" />
-        <meta name="publisher" content="simplabs GmbH" />
+        <meta name="publisher" content="Mainmatter GmbH" />
         <meta property="fb:admins" content="699569440119973" />
         <meta property="og:site_name" content="simplabs" />
         <meta name="twitter:site" content="@simplabs">

--- a/src/ui/components/Footer/template.hbs
+++ b/src/ui/components/Footer/template.hbs
@@ -5,7 +5,7 @@
         <img fluid-image:class="image" src="/assets/images/logos/simplabs.svg" alt="simplabs" />
       </a>
       <p block:class="note">
-        © 2014-2021 simplabs GmbH
+        © 2014-2021 Mainmatter GmbH
       </p>
       <p block:class="note">
         Made in

--- a/src/ui/components/PageLegalImprint/template.hbs
+++ b/src/ui/components/PageLegalImprint/template.hbs
@@ -10,7 +10,7 @@
       Responsible according to §6 MDStV:
     </p>
     <address typography:class="p">
-      simplabs GmbH
+      Mainmatter GmbH
       <br />
       +49 89 452 139 03‬
       <br />

--- a/src/ui/components/PageLegalPrivacy/template.hbs
+++ b/src/ui/components/PageLegalPrivacy/template.hbs
@@ -5,22 +5,23 @@
   <div layout:class="full" offset:class="after-21">
     <p>
       We are very delighted that you have shown interest in our enterprise. Data protection is of a particularly high
-      priority for the management of the simplabs GmbH. The use of the Internet pages of the simplabs GmbH is possible
-      without any indication of personal data; however, if a data subject wants to use special enterprise services via
-      our website, processing of personal data could become necessary. If the processing of personal data is necessary
-      and there is no statutory basis for such processing, we generally obtain consent from the data subject.
+      priority for the management of the Mainmatter GmbH. The use of the Internet pages of the Mainmatter GmbH is
+      possible without any indication of personal data; however, if a data subject wants to use special enterprise
+      services via our website, processing of personal data could become necessary. If the processing of personal data
+      is necessary and there is no statutory basis for such processing, we generally obtain consent from the data
+      subject.
     </p>
     <p>
       The processing of personal data, such as the name, address, e-mail address, or telephone number of a data subject
       shall always be in line with the General Data Protection Regulation (GDPR), and in accordance with the
-      country-specific data protection regulations applicable to the simplabs GmbH. By means of this data protection
+      country-specific data protection regulations applicable to the Mainmatter GmbH. By means of this data protection
       declaration, our enterprise would like to inform the general public of the nature, scope, and purpose of the
       personal data we collect, use and process. Furthermore, data subjects are informed, by means of this data
       protection declaration, of the rights to which they are entitled.
     </p>
     <p>
-      As the controller, the simplabs GmbH has implemented numerous technical and organizational measures to ensure the
-      most complete protection of personal data processed through this website. However, Internet-based data
+      As the controller, the Mainmatter GmbH has implemented numerous technical and organizational measures to ensure
+      the most complete protection of personal data processed through this website. However, Internet-based data
       transmissions may in principle have security gaps, so absolute protection may not be guaranteed. For this reason,
       every data subject is free to transfer personal data to us via alternative means, e.g. by telephone.
     </p>
@@ -28,10 +29,10 @@
       1. Definitions
     </h3>
     <p>
-      The data protection declaration of the simplabs GmbH is based on the terms used by the European legislator for the
-      adoption of the General Data Protection Regulation (GDPR). Our data protection declaration should be legible and
-      understandable for the general public, as well as our customers and business partners. To ensure this, we would
-      like to first explain the terminology used.
+      The data protection declaration of the Mainmatter GmbH is based on the terms used by the European legislator for
+      the adoption of the General Data Protection Regulation (GDPR). Our data protection declaration should be legible
+      and understandable for the general public, as well as our customers and business partners. To ensure this, we
+      would like to first explain the terminology used.
     </p>
     <p>
       In this data protection declaration, we use, inter alia, the following terms:
@@ -137,7 +138,7 @@
       applicable in Member states of the European Union and other provisions related to data protection is:
     </p>
     <address typography:class="p">
-      simplabs GmbH
+      Mainmatter GmbH
       <br />
       +49 89 452 139 03‬
       <br />
@@ -153,7 +154,7 @@
       2. Name and Address of the controller
     </h3>
     <p>
-      The Internet pages of the simplabs GmbH use cookies. Cookies are text files that are stored in a computer system
+      The Internet pages of the Mainmatter GmbH use cookies. Cookies are text files that are stored in a computer system
       via an Internet browser.
     </p>
     <p>
@@ -164,7 +165,7 @@
       other cookies. A specific Internet browser can be recognized and identified using the unique cookie ID.
     </p>
     <p>
-      Through the use of cookies, the simplabs GmbH can provide the users of this website with more user-friendly
+      Through the use of cookies, the Mainmatter GmbH can provide the users of this website with more user-friendly
       services that would not be possible without the cookie setting.
     </p>
     <p>
@@ -186,7 +187,7 @@
       4. Collection of general data and information
     </h3>
     <p>
-      The website of the simplabs GmbH collects a series of general data and information when a data subject or
+      The website of the Mainmatter GmbH collects a series of general data and information when a data subject or
       automated system calls up the website. This general data and information are stored in the server log files.
       Collected may be (1) the browser types and versions used, (2) the operating system used by the accessing system,
       (3) the website from which an accessing system reaches our website (so-called referrers), (4) the sub-websites,
@@ -195,11 +196,11 @@
       in the event of attacks on our information technology systems.
     </p>
     <p>
-      When using these general data and information, the simplabs GmbH does not draw any conclusions about the data
+      When using these general data and information, the Mainmatter GmbH does not draw any conclusions about the data
       subject. Rather, this information is needed to (1) deliver the content of our website correctly, (2) optimize the
       content of our website as well as its advertisement, (3) ensure the long-term viability of our information
       technology systems and website technology, and (4) provide law enforcement authorities with the information
-      necessary for criminal prosecution in case of a cyber-attack. Therefore, the simplabs GmbH analyzes anonymously
+      necessary for criminal prosecution in case of a cyber-attack. Therefore, the Mainmatter GmbH analyzes anonymously
       collected data and information statistically, with the aim of increasing the data protection and data security of
       our enterprise, and to ensure an optimal level of protection for the personal data we process. The anonymous data
       of the server log files are stored separately from all personal data provided by a data subject.
@@ -208,7 +209,7 @@
       5. Contact possibility via the website
     </h3>
     <p>
-      The website of the simplabs GmbH contains information that enables a quick electronic contact to our enterprise,
+      The website of the Mainmatter GmbH contains information that enables a quick electronic contact to our enterprise,
       as well as direct communication with us, which also includes a general address of the so-called electronic mail
       (e-mail address). If a data subject contacts the controller by e-mail or via a contact form, the personal data
       transmitted by the data subject are automatically stored. Such personal data transmitted on a voluntary basis by a
@@ -338,15 +339,15 @@
     </ul>
     <p>
       If one of the aforementioned reasons applies, and a data subject wishes to request the erasure of personal data
-      stored by the simplabs GmbH, he or she may, at any time, contact any employee of the controller. An employee of
-      simplabs GmbH shall promptly ensure that the erasure request is complied with immediately.
+      stored by the Mainmatter GmbH, he or she may, at any time, contact any employee of the controller. An employee of
+      Mainmatter GmbH shall promptly ensure that the erasure request is complied with immediately.
     </p>
     <p>
       Where the controller has made personal data public and is obliged pursuant to Article 17(1) to erase the personal
       data, the controller, taking account of available technology and the cost of implementation, shall take reasonable
       steps, including technical measures, to inform other controllers processing the personal data that the data
       subject has requested erasure by such controllers of any links to, or copy or replication of, those personal data,
-      as far as processing is not required. An employees of the simplabs GmbH will arrange the necessary measures in
+      as far as processing is not required. An employees of the Mainmatter GmbH will arrange the necessary measures in
       individual cases.
     </p>
     <h4>
@@ -376,8 +377,8 @@
     </ul>
     <p>
       If one of the aforementioned conditions is met, and a data subject wishes to request the restriction of the
-      processing of personal data stored by the simplabs GmbH, he or she may at any time contact any employee of the
-      controller. The employee of the simplabs GmbH will arrange the restriction of the processing.
+      processing of personal data stored by the Mainmatter GmbH, he or she may at any time contact any employee of the
+      controller. The employee of the Mainmatter GmbH will arrange the restriction of the processing.
     </p>
     <h4>
       f) Right to data portability
@@ -399,7 +400,7 @@
     </p>
     <p>
       In order to assert the right to data portability, the data subject may at any time contact any employee of the
-      simplabs GmbH.
+      Mainmatter GmbH.
     </p>
     <h4>
       g) Right to object
@@ -410,25 +411,25 @@
       point (e) or (f) of Article 6(1) of the GDPR. This also applies to profiling based on these provisions.
     </p>
     <p>
-      The simplabs GmbH shall no longer process the personal data in the event of the objection, unless we can
+      The Mainmatter GmbH shall no longer process the personal data in the event of the objection, unless we can
       demonstrate compelling legitimate grounds for the processing which override the interests, rights and freedoms of
       the data subject, or for the establishment, exercise or defence of legal claims.
     </p>
     <p>
-      If the simplabs GmbH processes personal data for direct marketing purposes, the data subject shall have the right
-      to object at any time to processing of personal data concerning him or her for such marketing. This applies to
-      profiling to the extent that it is related to such direct marketing. If the data subject objects to the simplabs
-      GmbH to the processing for direct marketing purposes, the simplabs GmbH will no longer process the personal data
-      for these purposes.
+      If the Mainmatter GmbH processes personal data for direct marketing purposes, the data subject shall have the
+      right to object at any time to processing of personal data concerning him or her for such marketing. This applies
+      to profiling to the extent that it is related to such direct marketing. If the data subject objects to the
+      simplabs GmbH to the processing for direct marketing purposes, the Mainmatter GmbH will no longer process the
+      personal data for these purposes.
     </p>
     <p>
       In addition, the data subject has the right, on grounds relating to his or her particular situation, to object to
-      processing of personal data concerning him or her by the simplabs GmbH for scientific or historical research
+      processing of personal data concerning him or her by the Mainmatter GmbH for scientific or historical research
       purposes, or for statistical purposes pursuant to Article 89(1) of the GDPR, unless the processing is necessary
       for the performance of a task carried out for reasons of public interest.
     </p>
     <p>
-      In order to exercise the right to object, the data subject may contact any employee of the simplabs GmbH. In
+      In order to exercise the right to object, the data subject may contact any employee of the Mainmatter GmbH. In
       addition, the data subject is free in the context of the use of information society services, and notwithstanding
       Directive 2002/58/EC, to use his or her right to object by automated means using technical specifications.
     </p>
@@ -446,14 +447,14 @@
     </p>
     <p>
       If the decision (1) is necessary for entering into, or the performance of, a contract between the data subject and
-      a data controller, or (2) it is based on the data subject's explicit consent, the simplabs GmbH shall implement
+      a data controller, or (2) it is based on the data subject's explicit consent, the Mainmatter GmbH shall implement
       suitable measures to safeguard the data subject's rights and freedoms and legitimate interests, at least the right
       to obtain human intervention on the part of the controller, to express his or her point of view and contest the
       decision.
     </p>
     <p>
       If the data subject wishes to exercise the rights concerning automated individual decision-making, he or she may,
-      at any time, contact any employee of the simplabs GmbH.
+      at any time, contact any employee of the Mainmatter GmbH.
     </p>
     <h4>
       i) Right to withdraw data protection consent
@@ -464,7 +465,7 @@
     </p>
     <p>
       If the data subject wishes to exercise the right to withdraw the consent, he or she may, at any time, contact any
-      employee of the simplabs GmbH.
+      employee of the Mainmatter GmbH.
     </p>
     <h3>
       8. Data protection for applications and the application procedures


### PR DESCRIPTION
This changes all mentions of "simplabs GmbH" to "Mainmatter GmbH" since the legal entity has been renamed. This is **not** the rebranding yet, just changing the name of the legal entity for now.