### PR TITLE
serve 404 for simplabs's sitemap

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,12 @@
 [build]
   environment = { NODE_VERSION = "16.17.0" }
 
+# serve 404 simplabs' sitemap
+  [[redirects]]
+    from = "https://simplabs.com/sitemap.xml"
+    to = "/404.html"
+    status = 404
+
 # redirect simplabs to Mainmatter
 [[redirects]]
   from = "https://simplabs.com/*"


### PR DESCRIPTION
Google says it's best to remove the sitemap of the old site when transferring to a new domain so this serve 404 for simplabs.com/sitemap.xml