### PR TITLE
Explicitly sort collections

### DIFF
--- a/collections/appearances.js
+++ b/collections/appearances.js
@@ -1,5 +1,8 @@
 const pathConfig = require("../src/_data/paths.json");
+const sortByDate = require("../utils/sortByDate");
 
 module.exports = collection => {
-  return [...collection.getFilteredByGlob(`./${pathConfig.src}/appearances/*.md`)];
+  return [...collection.getFilteredByGlob(`./${pathConfig.src}/appearances/*.md`)].sort(
+    sortByDate("desc")
+  );
 };

--- a/collections/authorsPostsPaged.js
+++ b/collections/authorsPostsPaged.js
@@ -1,4 +1,5 @@
 const config = require("../src/_data/config");
+const sortByDate = require("../utils/sortByDate");
 
 module.exports = collection => {
   const authorList = require("./authors")(collection);
@@ -8,9 +9,11 @@ module.exports = collection => {
   const pagedPosts = [];
 
   authorList.forEach(author => {
-    const sortedPosts = postList.filter(post => {
-      return post.data.authorHandle === author.data.page.fileSlug;
-    });
+    const sortedPosts = postList
+      .filter(post => {
+        return post.data.authorHandle === author.data.page.fileSlug;
+      })
+      .sort(sortByDate("desc"));
 
     const numberOfPages = Math.ceil(sortedPosts.length / maxPostsPerPage);
 

--- a/collections/calendar.js
+++ b/collections/calendar.js
@@ -1,4 +1,5 @@
 const pathConfig = require("../src/_data/paths.json");
+const sortByDate = require("../utils/sortByDate");
 const now = new Date();
 
 module.exports = collection => {
@@ -6,5 +7,5 @@ module.exports = collection => {
     ...collection
       .getFilteredByGlob(`./${pathConfig.src}/calendar/*.md`)
       .filter(event => event.date >= now),
-  ];
+  ].sort(sortByDate("asc"));
 };

--- a/collections/posts.js
+++ b/collections/posts.js
@@ -1,4 +1,5 @@
 const pathConfig = require("../src/_data/paths.json");
+const sortByDate = require("../utils/sortByDate");
 const now = new Date();
 const livePosts = post => post.date <= now && !post.data.draft;
 
@@ -7,5 +8,5 @@ module.exports = collection => {
     ...collection
       .getFilteredByGlob(`./${pathConfig.src}/${pathConfig.blogdir}/**/*`)
       .filter(livePosts),
-  ].reverse();
+  ].sort(sortByDate("desc"));
 };

--- a/collections/tagsPostsPaged.js
+++ b/collections/tagsPostsPaged.js
@@ -1,4 +1,5 @@
 const config = require("../src/_data/config");
+const sortByDate = require("../utils/sortByDate");
 
 module.exports = collection => {
   const tagList = require("./tags")(collection);
@@ -7,7 +8,7 @@ module.exports = collection => {
   const pagedPosts = [];
 
   Object.keys(tagList).forEach(tagName => {
-    const sortedPosts = [...collection.getFilteredByTag(tagName)].reverse();
+    const sortedPosts = [...collection.getFilteredByTag(tagName)].sort(sortByDate("desc"));
     const numberOfPages = Math.ceil(sortedPosts.length / maxPostsPerPage);
 
     for (let pageNum = 1; pageNum <= numberOfPages; pageNum++) {

--- a/collections/videos.js
+++ b/collections/videos.js
@@ -1,5 +1,8 @@
 const pathConfig = require("../src/_data/paths.json");
+const sortByDate = require("../utils/sortByDate");
 
 module.exports = collection => {
-  return [...collection.getFilteredByGlob(`./${pathConfig.src}/videos/*.md`)].reverse();
+  return [...collection.getFilteredByGlob(`./${pathConfig.src}/videos/*.md`)].sort(
+    sortByDate("desc")
+  );
 };

--- a/src/events.njk
+++ b/src/events.njk
@@ -46,7 +46,7 @@ description: Find out about upcoming events, conferences and meetups we will be 
   </div>
   <div class="talks__container">
     <ol class="talks__list">
-      {% for appearance in collections.appearances | reverse %}
+      {% for appearance in collections.appearances %}
         {% if loop.index === 1 %}
           <li class="talks__item talks__item--full-width">
             {{ talkBanner(appearance, "black") }}

--- a/src/talks.njk
+++ b/src/talks.njk
@@ -26,7 +26,7 @@ eleventyNavigation:
   </div>
   <div class="talks__container">
     <ol class="talks__list">
-      {% for appearance in collections.appearances | reverse %}
+      {% for appearance in collections.appearances %}
         {% if loop.index === 1 %}
           <li class="talks__item talks__item--full-width">
             {{ talkBanner(appearance, "black") }}

--- a/utils/sortByDate.js
+++ b/utils/sortByDate.js
@@ -1,0 +1,9 @@
+module.exports = function sortByDate(order) {
+  return function (a, b) {
+    if (order === "desc") {
+      return b.date - a.date;
+    } else {
+      return a.date - b.date;
+    }
+  };
+};


### PR DESCRIPTION
This replaces the sorting-by-descending-date that's currently done with the `reverse` method with explicit usage of the `sort` method. Both methods mutate the array which means that when the code is called multiple times `reverse` will change the order each time it's invoked while `sort` will remain stable.