### PR TITLE
Fix sorting ember posts

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -46,6 +46,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addCollection("videos", require("./collections/videos"));
   eleventyConfig.addCollection("workshops", require("./collections/workshops"));
   eleventyConfig.addCollection("posts", require("./collections/posts"));
+  eleventyConfig.addCollection("emberPosts", require("./collections/ember-posts"));
   eleventyConfig.addCollection("authors", require("./collections/authors"));
   eleventyConfig.addCollection(
     "authorsPostsPaged",

--- a/collections/ember-posts.js
+++ b/collections/ember-posts.js
@@ -1,0 +1,8 @@
+const livePosts = require("./posts");
+
+module.exports = collection => {
+  const allPosts = livePosts(collection);
+  return allPosts.filter(
+    post => Array.isArray(post.data.tags) && post.data.tags.some(t => t.match(/^ember\.?(js)?/))
+  );
+};

--- a/src/ember-consulting.njk
+++ b/src/ember-consulting.njk
@@ -125,7 +125,7 @@ permalink: /ember-consulting/
   </div>
 </section>
 
-{{ recentPosts("Latest from our blog on the topic", collections["ember"]) }}
+{{ recentPosts("Latest from our blog on the topic", collections.emberPosts) }}
 
 {% set 'content' = {
 "title": "Conferences and talks",


### PR DESCRIPTION
This fixes sorting of the Ember posts by explicitly defining the respective collection. I couldn't reproduce where the previously used collection even comes from – might be some kind of automatic thing that 11ty does based on Tags. This gives us a bit more freedom anyway.

closes #1881 