### PR TITLE
Fix sorting Elixir posts

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -47,6 +47,7 @@ module.exports = function (eleventyConfig) {
   eleventyConfig.addCollection("workshops", require("./collections/workshops"));
   eleventyConfig.addCollection("posts", require("./collections/posts"));
   eleventyConfig.addCollection("emberPosts", require("./collections/ember-posts"));
+  eleventyConfig.addCollection("elixirPosts", require("./collections/elixirPosts"));
   eleventyConfig.addCollection("authors", require("./collections/authors"));
   eleventyConfig.addCollection(
     "authorsPostsPaged",

--- a/collections/elixirPosts.js
+++ b/collections/elixirPosts.js
@@ -1,0 +1,8 @@
+const livePosts = require("./posts");
+
+module.exports = collection => {
+  const allPosts = livePosts(collection);
+  return allPosts.filter(
+    post => Array.isArray(post.data.tags) && post.data.tags.some(t => t.match(/^(elixir|phoenix)/))
+  );
+};

--- a/src/elixir-phoenix.njk
+++ b/src/elixir-phoenix.njk
@@ -55,6 +55,6 @@ are honored to be a Founding Sponsor of the Erlang Ecosystem Foundation.</p><p>E
 } %}
 {{ imageBannerWithText(content) }}
 
-{{ recentPosts("Latest from our blog on the topic", collections["elixir"]) }}
+{{ recentPosts("Latest from our blog on the topic", collections.elixirPosts) }}
 
 {% include 'content/hero-grow-with-us.njk' %}


### PR DESCRIPTION
This fixes sorting of the Elixir posts by explicitly defining the respective collection. I couldn't reproduce where the previously used collection even comes from – might be some kind of automatic thing that 11ty does based on Tags. This gives us a bit more freedom anyway.

closes #1882