### PR TITLE
Fix how we prevent pages from indexing

### DIFF
--- a/src/components/global/meta.njk
+++ b/src/components/global/meta.njk
@@ -14,10 +14,15 @@
 {%- endif -%}
 
 {%- if canonical -%}
-<link rel="canonical" href="{{ canonical }}" />
+  <link rel="canonical" href="{{ canonical }}" />
 {%- else -%}
-<link rel="canonical" href="{{ currentUrl }}" />
+  <link rel="canonical" href="{{ currentUrl }}" />
 {%- endif -%}
+
+{%- if noindex -%}
+  <meta name="robots" content="noindex">
+{%- endif -%}
+
 <meta property="og:site_name" content="{{ siteTitle }}" />
 <meta property="og:title" content="{{ pageTitle }}" />
 <meta property="og:type" content="website" />

--- a/src/imprint.njk
+++ b/src/imprint.njk
@@ -4,6 +4,7 @@ title: Imprint
 permalink: /imprint/
 sitemap:
   ignore: true
+noindex: true
 ---
 
 <div class="policy">

--- a/src/imprint.njk
+++ b/src/imprint.njk
@@ -2,6 +2,8 @@
 layout: base
 title: Imprint
 permalink: /imprint/
+sitemap:
+  ignore: true
 ---
 
 <div class="policy">

--- a/src/privacy.njk
+++ b/src/privacy.njk
@@ -2,6 +2,8 @@
 layout: base
 title: Privacy Policy
 permalink: /privacy/
+sitemap:
+  ignore: true
 ---
 
 <div class="policy">

--- a/src/privacy.njk
+++ b/src/privacy.njk
@@ -4,6 +4,7 @@ title: Privacy Policy
 permalink: /privacy/
 sitemap:
   ignore: true
+noindex: true
 ---
 
 <div class="policy">

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,8 +1,4 @@
 # http://www.robotstxt.org
 User-agent: *
 Disallow:
-Disallow: /imprint
-Disallow: /privacy
-Disallow: /imprint/
-Disallow: /privacy/
 Sitemap: https://mainmatter.com/sitemap.xml


### PR DESCRIPTION
We currently have the `/imprint` and `/privacy` pages in the sitemap and also ignore them from being indexed in `robots.txt`. Besides that being inconsistent, Google says to not use robots.txt for that anyway but add a noindex meta tag. So this:

* removes the `Disallow:` rules from `robots.txt`
* does not add the `/imprint` and `/privacy` pages to the sitemap anymore
* adds a `<meta name="robots" content="noindex">` tag for pages that should not be indexed