### PR TITLE
Fix canonical URL handling

### DIFF
--- a/src/components/global/meta.njk
+++ b/src/components/global/meta.njk
@@ -1,7 +1,6 @@
 {%- set pageTitle = config.name -%}
 {%- set pageDesc = config.description -%}
 {%- set siteTitle = config.name -%}
-{%- set currentUrl = config.url + page.url -%}
 
 {%- if renderData.title -%}
   {%- set pageTitle = renderData.title + ' - ' + config.name -%}
@@ -16,7 +15,7 @@
 {%- if canonical -%}
   <link rel="canonical" href="{{ canonical }}" />
 {%- else -%}
-  <link rel="canonical" href="{{ currentUrl }}" />
+  <link rel="canonical" href="https://mainmatter.com{{ page.url }}" />
 {%- endif -%}
 
 {%- if noindex -%}

--- a/src/components/layouts/base.njk
+++ b/src/components/layouts/base.njk
@@ -14,7 +14,6 @@ og:
     {%- endif -%}
 
     <title>{{ pageTitle }}</title>
-    <link rel="canonical" href="https://mainmatter.com{{ page.url }}" />
     {% include "global/fonts.njk" %}
     <link rel="stylesheet" href="/assets/css/app.css" />
     <script src="/assets/js/app.js" defer></script>


### PR DESCRIPTION
This

* removes the duplicate canonical URL tag
* uses https://mainmatter.com/… as the prefix for canonical URLs by default (we'd never want to set the tag with the domain of a Netlify preview system for example)