### PR TITLE
Add error tracking via Sentry

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "last 1 Edge versions"
   ],
   "dependencies": {
+    "@sentry/browser": "^7.16.0",
     "lax.js": "^2.0.3"
   },
   "engines": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -7,6 +7,7 @@ export default {
   output: {
     file: "assets/js/app.js",
     format: "cjs",
+    sourcemap: true,
   },
   plugins: [nodeResolve({ browser: true }), commonjs(), terser()],
 };

--- a/src/assets/js/app.js
+++ b/src/assets/js/app.js
@@ -1,9 +1,16 @@
+import * as Sentry from "@sentry/browser";
 import "wicg-inert";
 import { Animations } from "./animations";
 import { Nav } from "./nav";
 import { ContactForm } from "./contact-form";
 import { LogoList } from "./logo-list";
 import bindSelectDropdowns from "./select";
+
+if (window.location.host === "mainmatter.com") {
+  Sentry.init({
+    dsn: "https://43f7627909d94dc4a769340ad730f1a2@o68744.ingest.sentry.io/4504039028817920"
+  });
+}
 
 const navElement = document.getElementById("nav");
 new Nav(navElement);

--- a/src/privacy.njk
+++ b/src/privacy.njk
@@ -488,7 +488,6 @@ noindex: true
       burden of proof in a procedure under the General Equal Treatment Act (AGG).
     </p>
     <h2>
-    <h2>
       9. Data protection provisions about the application and use of Plausible Analytics
     </h2>
     <p>
@@ -504,9 +503,24 @@ noindex: true
     </p>
     <p>
        For Plausible's policies and practices around analysis and storage of user data, refer to <a href="https://plausible.io/data-policy">https://plausible.io/data-policy</a>.
-     </p>
+    </p>
     <h2>
-      10. Data protection provisions about the application and use of Twitter
+      10. Data protection provisions about the application and use of Sentry
+    </h2>
+    <p>
+      On this website, the controller has integrated the component of Sentry.
+      Sentry is a web error tracking service. Error tracking is the collection, gathering, and analysis of data
+      about any errors occuring for visitors to websites. An error tracking service collects, inter alia, data about the user's browser and operating system, which events occored on the website, and what errors occured on the website. Error tracking is mainly used for the optimization of a website and in order to
+      ensure a smooth experience for all users.
+    </p>
+    <p>
+      The operator of the Sentry component is Functional Software Inc., 45 Fremont Street 8th Floor, San Francisco, CA 94105, United States.
+    </p>
+    <p>
+      For Sentry's policies and practices around analysis and storage of user data, refer to <a href="https://sentry.io/legal">https://sentry.io/legal</a>.
+    </p>
+    <h2>
+      11. Data protection provisions about the application and use of Twitter
     </h2>
     <p>
       On this website, the controller has integrated components of Twitter. Twitter is a multilingual,
@@ -549,7 +563,7 @@ noindex: true
       The applicable data protection provisions of Twitter may be accessed under https://twitter.com/privacy?lang=en.
     </p>
     <h2>
-      11. Legal basis for the processing
+      12. Legal basis for the processing
     </h2>
     <p>
       Art. 6(1) lit. a GDPR serves as the legal basis for processing operations for which we obtain consent for a
@@ -572,14 +586,14 @@ noindex: true
       the data subject is a client of the controller (Recital 47 Sentence 2 GDPR).
     </p>
     <h2>
-      12. The legitimate interests pursued by the controller or by a third party
+      13. The legitimate interests pursued by the controller or by a third party
     </h2>
     <p>
       Where the processing of personal data is based on Article 6(1) lit. f GDPR our legitimate interest is to carry out
       our business in favor of the well-being of all our employees and the shareholders.
     </p>
     <h2>
-      13. Period for which the personal data will be stored
+      14. Period for which the personal data will be stored
     </h2>
     <p>
       The criteria used to determine the period of storage of personal data is the respective statutory retention
@@ -587,7 +601,7 @@ noindex: true
       necessary for the fulfillment of the contract or the initiation of a contract.
     </p>
     <h2>
-      14. Provision of personal data as statutory or contractual requirement; Requirement necessary to enter into a
+      15. Provision of personal data as statutory or contractual requirement; Requirement necessary to enter into a
       contract; Obligation of the data subject to provide the personal data; possible consequences of failure to provide
       such data
     </h2>
@@ -603,7 +617,7 @@ noindex: true
       provide the personal data and the consequences of non-provision of the personal data.
     </p>
     <h2>
-      15. Existence of automated decision-making
+      16. Existence of automated decision-making
     </h2>
     <p>
       As a responsible company, we do not use automatic decision-making or profiling.

--- a/yarn.lock
+++ b/yarn.lock
@@ -408,6 +408,38 @@
     array-flat-polyfill "^1.0.1"
     sitemap "^6.3.2"
 
+"@sentry/browser@^7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.16.0.tgz#afd2bac91857d2359272a0d9d2b1ee5ca7d69828"
+  integrity sha512-tJ063zvoF8Raw7mzQEXupOFPSN6v36WIbsDVGeFdToPCwViaBuATaxvWCrudGzsnBkMyItmTLJkzn9SEIXUOiw==
+  dependencies:
+    "@sentry/core" "7.16.0"
+    "@sentry/types" "7.16.0"
+    "@sentry/utils" "7.16.0"
+    tslib "^1.9.3"
+
+"@sentry/core@7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.16.0.tgz#60f9b54ef2ec524176b329e1d15be39c36da5953"
+  integrity sha512-vq6H1b/IPTvzDD9coQ3wIudvSjkAYuUlXb1dv69dRlq4v3st9dcKBps1Zf0lQ1i4TVlDLoe1iGMmNFglMF1Q5w==
+  dependencies:
+    "@sentry/types" "7.16.0"
+    "@sentry/utils" "7.16.0"
+    tslib "^1.9.3"
+
+"@sentry/types@7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.16.0.tgz#79c06ada153a84feb949fa49b1c9d15f91decd79"
+  integrity sha512-i6D+OK6d0l/k+VQvRp/Pt21WkDEgVBUIZq+sOkEZJczbcfexVdXKeXXoYTD2vYuFq8Yy28fzlsZaKI+NoH94yQ==
+
+"@sentry/utils@7.16.0":
+  version "7.16.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.16.0.tgz#b832520c661d4435808969ee04814ff8e20497b1"
+  integrity sha512-3Zh1txg7IRp4kZAdG27YF7K6lD1IZyuAo9KjoPg1Xzqa4DOZyASJuEkbf+rK2a9T4HrtVHHXJUsNbKg8WM3VHg==
+  dependencies:
+    "@sentry/types" "7.16.0"
+    tslib "^1.9.3"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -6034,7 +6066,7 @@ tree-kill@^1.2.1:
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
   integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
 
-tslib@^1.9.0:
+tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
This adds Sentry:

* enables sourcemaps for more meaningful logs on Sentry
* tracks any uncaught errors with Sentry
* explicitly logs failed contact form deliveries to Sentry
* adds Sentry to our privacy policy

closes #1902 