### PR TITLE
add Plausible Analytics to privacy policy

### DIFF
--- a/src/privacy.njk
+++ b/src/privacy.njk
@@ -551,7 +551,24 @@ noindex: true
       execute the reinstallation or reactivation of the browser add-ons.
     </p>
     <h2>
-      10. Data protection provisions about the application and use of Twitter
+      10. Data protection provisions about the application and use of Plausible Analytics
+    </h2>
+    <p>
+      On this website, the controller has integrated the component of Plausible Analytics.
+      Plausible Analytics is a web analytics service. Web analytics is the collection, gathering, and analysis of data
+      about the behavior of visitors to websites. A web analysis service collects, inter alia, data about the website
+      from which a person has come (the so-called referrer), which sub-pages were visited, or how often and for what
+      duration a sub-page was viewed. Web analytics are mainly used for the optimization of a website and in order to
+      carry out a cost-benefit analysis of Internet advertising.
+    </p>
+    <p>
+      The operator of the Plausible Analytics component is Plausible Insights OÜ, Västriku tn 2, 50403, Tartu, Estonia.
+    </p>
+    <p>
+       For Plausible's policies and practices around analysis and storage of user data, refer to <a href="https://plausible.io/data-policy">https://plausible.io/data-policy</a>.
+     </p>
+    <h2>
+      11. Data protection provisions about the application and use of Twitter
     </h2>
     <p>
       On this website, the controller has integrated components of Twitter. Twitter is a multilingual,
@@ -594,7 +611,7 @@ noindex: true
       The applicable data protection provisions of Twitter may be accessed under https://twitter.com/privacy?lang=en.
     </p>
     <h2>
-      11. Legal basis for the processing
+      12. Legal basis for the processing
     </h2>
     <p>
       Art. 6(1) lit. a GDPR serves as the legal basis for processing operations for which we obtain consent for a
@@ -617,14 +634,14 @@ noindex: true
       the data subject is a client of the controller (Recital 47 Sentence 2 GDPR).
     </p>
     <h2>
-      12. The legitimate interests pursued by the controller or by a third party
+      13. The legitimate interests pursued by the controller or by a third party
     </h2>
     <p>
       Where the processing of personal data is based on Article 6(1) lit. f GDPR our legitimate interest is to carry out
       our business in favor of the well-being of all our employees and the shareholders.
     </p>
     <h2>
-      13. Period for which the personal data will be stored
+      14. Period for which the personal data will be stored
     </h2>
     <p>
       The criteria used to determine the period of storage of personal data is the respective statutory retention
@@ -632,7 +649,7 @@ noindex: true
       necessary for the fulfillment of the contract or the initiation of a contract.
     </p>
     <h2>
-      14. Provision of personal data as statutory or contractual requirement; Requirement necessary to enter into a
+      15. Provision of personal data as statutory or contractual requirement; Requirement necessary to enter into a
       contract; Obligation of the data subject to provide the personal data; possible consequences of failure to provide
       such data
     </h2>
@@ -648,7 +665,7 @@ noindex: true
       provide the personal data and the consequences of non-provision of the personal data.
     </p>
     <h2>
-      15. Existence of automated decision-making
+      16. Existence of automated decision-making
     </h2>
     <p>
       As a responsible company, we do not use automatic decision-making or profiling.


### PR DESCRIPTION
This adds a section about our use of plausible.io to the privacy policy.

close #1907 