### PR TITLE
Remove unnecessary frontmatter attributes

### DIFF
--- a/src/cases/ddwrt.md
+++ b/src/cases/ddwrt.md
@@ -1,10 +1,6 @@
 ---
 layout: case-study
 company: DDWRT
-companyDescription:
-  DD-WRT is a Linux-based firmware for wireless routers. Originally designed for
-  the Linksys WRT54G series, it now runs on a wide variety of models and is
-  installed on millions of devices worldwide.
 title: A modern UI for DD-WRT NXT based on Ember.js | Work
 displayTitle: "A modern user interface for <em>perennial</em> router firmware"
 description:

--- a/src/cases/expedition.md
+++ b/src/cases/expedition.md
@@ -1,9 +1,6 @@
 ---
 layout: case-study
 company: Expedition
-companyDescription:
-  Expedition is an online travel magazine for global citizens who want to
-  experience world’s best destinations through the eyes of a local.
 title: An architecture based on Elixir and Ember.js for Expedition | Work
 displayTitle: "A sturdy foundation for <em>advanced</em> system architecture"
 description:

--- a/src/cases/qonto.md
+++ b/src/cases/qonto.md
@@ -1,9 +1,6 @@
 ---
 layout: case-study
 company: Qonto
-companyDescription:
-  Qonto is a B2B Neobank that provides banking services and credit cards to more
-  than 75,000 freelancers and SMEs in Europe.
 title: Co-Engineering the Future of Banking for SMEs with Qonto | Work
 displayTitle: "A helping hand for a <em>visionary</em> fintech startup"
 description:

--- a/src/cases/timify.md
+++ b/src/cases/timify.md
@@ -1,9 +1,6 @@
 ---
 layout: case-study
 company: Timify
-companyDescription:
-  Timify is a cloud-based appointment scheduling system that serves over 50,000
-  businesses across a wide range of industries.
 displayTitle: "An engineering overhaul for a <em>validated</em> booking system"
 description:
   <p>Timify is an online appointment scheduling service that connects service

--- a/src/cases/trainline.md
+++ b/src/cases/trainline.md
@@ -1,9 +1,6 @@
 ---
 layout: case-study
 company: Trainline
-companyDescription:
-  Trainline is Europe's leading independent rail and coach platform. They serve
-  more than 125,000 rides every single day in and across 36 countries.
 title: Mobile train tickets with Ember.js for Trainline | Work
 displayTitle: "The full market potential for a <em>leading</em> travel platform"
 description:


### PR DESCRIPTION
We currently define `companyDescription` for some cases but never use that anywhere. This PR just removes that to avoid confusion.