### PR TITLE
Limit size of client logo in hero section

### DIFF
--- a/src/assets/css/components/_color-hero.scss
+++ b/src/assets/css/components/_color-hero.scss
@@ -102,6 +102,11 @@
 
 .color-hero__client-logo {
   margin-bottom: 1rem;
+
+  img {
+    max-height: 6rem;
+    max-width: 14rem;
+  }
 }
 
 .color-hero__client-tags {


### PR DESCRIPTION
The client logos we show in the hero sections are currently allowed to grow to arbitrary size. This adds some CSS to limit that so we actively control the image size via CSS, not implicitly by the dimensions of the image itself.