### PR TITLE
Stabilize Percy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,7 @@ jobs:
         run: yarn install
 
       - name: build
-        # build and disable lazy loading of images which makes the Percy snapshots random otherwise
-        run: |
-          yarn build
-          find ./dist/**/*.html -type f -exec sed -i '' -e 's/loading=\"lazy\"//gI' {} \;
+        run: yarn percy:build
 
       - name: snapshots
         env:

--- a/.percy-disable-lazy-loading.js
+++ b/.percy-disable-lazy-loading.js
@@ -1,0 +1,5 @@
+module.exports = {
+  files: "dist/**/*.html",
+  from: /loading="lazy"/g,
+  to: "",
+};

--- a/.percy.js
+++ b/.percy.js
@@ -10,5 +10,15 @@ module.exports = {
       /blog\/tag\/.*\/page\/*/,
       /blog\/author\/.*\/page\/*/
     ]
-  }
+  },
+  snapshot: {
+    percyCSS: `*, :before, :after {
+       /*CSS transitions*/
+       transition-property: none !important;
+       /*CSS transforms*/
+       transform: none !important;
+       /*CSS animations*/
+       animation: none !important;
+    }`,
+  },
 };

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "sass": "sass src/assets/css/app.scss ./assets/css/app.css --style=compressed --watch",
     "serve": "eleventy  --quiet --serve --port=8080",
     "dev": "npm run watch",
+    "percy:build": "run-s build percy:disable-lazy-images",
+    "percy:disable-lazy-images": "replace-in-file --configFile=.percy-disable-lazy-loading.js",
     "percy": "percy snapshot",
     "crawl": "node scripts/crawl.js",
     "this-week": "./bin/this-week-in-open-source --config-path=config/this-week-in-open-source.config.json"
@@ -47,6 +49,7 @@
     "netlify-plugin-11ty": "^1.1.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.7.1",
+    "replace-in-file": "^6.3.5",
     "rollup": "^2.40.0",
     "rollup-plugin-commonjs": "^10.1.0",
     "rollup-plugin-node-resolve": "^5.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1215,7 +1215,7 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.0.2:
+chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1350,6 +1350,15 @@ cliui@^7.0.2:
   dependencies:
     string-width "^4.2.0"
     strip-ansi "^6.0.0"
+    wrap-ansi "^7.0.0"
+
+cliui@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-8.0.1.tgz#0c04b075db02cbfe60dc8e6cf2f5486b1a3608aa"
+  integrity sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.1"
     wrap-ansi "^7.0.0"
 
 clone-response@^1.0.2:
@@ -2719,7 +2728,7 @@ glob-parent@^6.0.1:
   dependencies:
     is-glob "^4.0.3"
 
-glob@^7.1.3:
+glob@^7.1.3, glob@^7.2.0:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -5041,6 +5050,15 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==
 
+replace-in-file@^6.3.5:
+  version "6.3.5"
+  resolved "https://registry.yarnpkg.com/replace-in-file/-/replace-in-file-6.3.5.tgz#ff956b0ab5bc96613207d603d197cd209400a654"
+  integrity sha512-arB9d3ENdKva2fxRnSjwBEXfK1npgyci7ZZuwysgAp7ORjHSyxz6oqIjTEv8R0Ydl4Ll7uOAZXL4vbkhGIizCg==
+  dependencies:
+    chalk "^4.1.2"
+    glob "^7.2.0"
+    yargs "^17.2.1"
+
 request-promise-core@1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.4.tgz#3eedd4223208d419867b78ce815167d10593a22f"
@@ -6612,6 +6630,19 @@ yargs@^15.4.1:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.2"
+
+yargs@^17.2.1:
+  version "17.6.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.6.0.tgz#e134900fc1f218bc230192bdec06a0a5f973e46c"
+  integrity sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.0.0"
 
 yargs@^17.3.1:
   version "17.5.1"


### PR DESCRIPTION
This stabilizes the Percy integration which was pretty flaky so far and thus caused quiet a bit of noise.

* disable all animations for Percy
* remove all `loading="lazy"` attributes from images which might cause images not to have loaded when Percy takes the snapshot (we had this before but it never worked – see e.g. https://github.com/mainmatter/mainmatter.com/actions/runs/3337295611/jobs/5523460437#step:5:223)

closes #1899