### PR TITLE
Use dedicated footer and CTA on workshop pages

### DIFF
--- a/src/components/content/hero-book-workshop.njk
+++ b/src/components/content/hero-book-workshop.njk
@@ -1,0 +1,11 @@
+{% from "color-hero.njk" import colorHero %}
+{% set 'content' = {
+  "title": "Book this workshop",
+  "text": "Our mentors are looking forward to work with your team and unlock new capabilities.",
+  "linkUrl": "/contact/",
+  "linkText": "Get in touch",
+  "image": "/assets/images/photos/mainmatter-team-collaboration.jpg",
+  "alt": "Three smiling team members looking at a laptop",
+  "loading": "lazy"
+} %}
+{{ colorHero('center', 'small', 'purple', content, true) }}

--- a/src/components/layouts/workshop.njk
+++ b/src/components/layouts/workshop.njk
@@ -91,4 +91,4 @@ layout: 'base'
     </div>
   </div>
 </article>
-{% include 'content/hero-grow-with-us.njk' %}{%- endblock -%}
+{% include 'content/hero-book-workshop.njk' %}{%- endblock -%}


### PR DESCRIPTION
This changes the workshop pages so they use a more relevant footer/CTA.

closes #1927 