### PR TITLE
Update featured case studies on landing page

### DIFF
--- a/src/index.njk
+++ b/src/index.njk
@@ -27,7 +27,7 @@ title: null
 {% set logoCompanies = ['Qonto', 'Trainline', 'Cardstack', 'Timify', 'Experteer', 'Robin Hood', 'Dim3' ] %}
 {{ logoList(logoCompanies) }}
 {% set clients = ['qonto', 'trainline', 'timify', 'ddwrt'] %}
-{{ featuredCaseStudies(clients, 'Browse our  work') }}
+{{ featuredCaseStudies(clients, 'Browse our work') }}
 {% set 'content' = {
   "title": "Why mainmatter",
   "subtitle": "We are a team of developers, inventors, designers, strategists, artists and storytellers. We work remotely form 9 countries in Europe and we believe in recruiting top talents from any location.",

--- a/src/index.njk
+++ b/src/index.njk
@@ -26,7 +26,7 @@ title: null
 {{ featuredServices(services['services-list'], content) }}
 {% set logoCompanies = ['Qonto', 'Trainline', 'Cardstack', 'Timify', 'Experteer', 'Robin Hood', 'Dim3' ] %}
 {{ logoList(logoCompanies) }}
-{% set clients = ['qonto', 'trainline', 'timify', 'ddwrt'] %}
+{% set clients = ['qonto', 'experteer', 'trainline', 'mvb'] %}
 {{ featuredCaseStudies(clients, 'Browse our work') }}
 {% set 'content' = {
   "title": "Why mainmatter",


### PR DESCRIPTION
This updates the featured case studies on the main landing page:

* replaces Timify and dd-wrt with Experteer and MVB
* removes a double space 👀 

<img width="1147" alt="Bildschirm­foto 2022-11-03 um 18 14 52" src="https://user-images.githubusercontent.com/1510/199789723-e05eded4-6524-46b6-84b9-db03a65a72c2.png">

see #1914 