### PR TITLE
Add new case studies to footer

### DIFF
--- a/src/_data/footerNavigation.json
+++ b/src/_data/footerNavigation.json
@@ -29,6 +29,18 @@
           "link": "/cases/trainline/"
         },
         {
+          "text": "Experteer",
+          "link": "/cases/experteer/"
+        },
+        {
+          "text": "MVB",
+          "link": "/cases/mvb/"
+        },
+        {
+          "text": "AIS",
+          "link": "/cases/ais/"
+        },
+        {
           "text": "Timify",
           "link": "/cases/timify/"
         },


### PR DESCRIPTION
This adds the Experteer, AIS, and MVB case studies to the footer:

<img width="1168" alt="Bildschirm­foto 2022-11-03 um 18 16 07" src="https://user-images.githubusercontent.com/1510/199790005-5e58357e-f02b-4891-b1ec-d77e4db839f9.png">

see #1914