### PR TITLE
Add quote to Experteer case study

### DIFF
--- a/src/cases/experteer.md
+++ b/src/cases/experteer.md
@@ -47,3 +47,9 @@ hero:
     <p>In addition to implementing the application, we set up the infrastructure that would support its long-term evolution and maintenance. Our team established everything from the design system and component library to testing and deployment pipelines and preview systems for each pull request inside Experteer’s organization.</p>
   </div>
 </div>
+
+{% set 'content' = {
+  "text": "Mainmatter helped us tremendously to execute on our roadmap and move on with important strategic product features. On top of that, they pushed our engineering culture to a new level while we were transforming our legacy UI/UX to a state-of-the-art architecture.",
+  "source": "Thomas Nitsche, Director of Engineering, Experteer GmbH",
+  "loading": "lazy"
+} %} {{ quote(content) }}


### PR DESCRIPTION
This adds a quote by Thomas Nitsche to the Experteer case study:

<img width="1060" alt="Bildschirm­foto 2022-11-07 um 10 58 33" src="https://user-images.githubusercontent.com/1510/200281674-0ee8566f-13a7-4337-8c55-4778959831ec.png">

closes #1941 

## TODO

- [x] if we can use a photo, we should add it (update: we can't 😞 )