### PR TITLE
fix text of workshop CTA

### DIFF
--- a/src/components/content/hero-book-workshop.njk
+++ b/src/components/content/hero-book-workshop.njk
@@ -1,7 +1,7 @@
 {% from "color-hero.njk" import colorHero %}
 {% set 'content' = {
   "title": "Book this workshop",
-  "text": "Our mentors are looking forward to work with your team and unlock new capabilities.",
+  "text": "Our mentors look forward to working with your team and unlocking new capabilities.",
   "linkUrl": "/contact/",
   "linkText": "Get in touch",
   "image": "/assets/images/photos/mainmatter-team-collaboration.jpg",


### PR DESCRIPTION
<img width="1118" alt="Bildschirm­foto 2022-11-11 um 16 57 00" src="https://user-images.githubusercontent.com/1510/201380162-b463bd39-5988-4c89-be24-2f9131598415.png">

closes #1943 