### PR TITLE
Fix size of intro paragraph in blog posts

### DIFF
--- a/src/components/layouts/post.njk
+++ b/src/components/layouts/post.njk
@@ -53,7 +53,7 @@ layout: base
         </div>
       </div>
 
-      <div class="post__tagline text--sm">
+      <div class="post__tagline">
         {{ tagline | safe }}
       </div>
     </div>


### PR DESCRIPTION
This fixes the size of the intro paragraph of blog posts so it's the same size as the rest of the post's text:

<img width="1025" alt="Bildschirm­foto 2022-11-11 um 17 02 45" src="https://user-images.githubusercontent.com/1510/201381166-d9863a33-896d-492d-9eff-51dd9bba0f8f.png">

closes #1893