### PR TITLE
Fix text on product development page

### DIFF
--- a/src/services/digital-products-and-design.njk
+++ b/src/services/digital-products-and-design.njk
@@ -38,7 +38,7 @@ title: Digital Products & Design | Our Services
 {% set content = {
   "title": "Product design",
   "subtitle": "Experiences that users love",
-  "text": "When a compley digital product delights you with its ease of use, that’s by design. Your users have a problem, and it’s up to us to solve it through smart design coupled with outspoken visual appeal. Your product should be remarkable from every angle.",
+  "text": "When a complex digital product delights you with its ease of use, that’s by design. Your users have a problem, and it’s up to us to solve it through smart design coupled with outspoken visual appeal. Your product should be remarkable from every angle.",
   "listType": "unordered",
   "list": ["Multi-stakeholder design research", "Wireframing & Rapid prototyping", "Develop a consistent design system", "Ideation across the entire user journey"]
 } %}

--- a/src/services/digital-products-and-design.njk
+++ b/src/services/digital-products-and-design.njk
@@ -20,7 +20,7 @@ title: Digital Products & Design | Our Services
   "title": "Our process",
   "subtitle": "Rapid exploration, research and validation",
   "text": "How can you be sure that you understand the needs of your users? We stress-test all assumptions to gather evidence en route to validated product concepts. Strategic clarity enables us to rapidly iterate on ideas that work.",
-  "list": ["Market validation", "Idea extraction & strategy workshop", "Validate essential assumptions", "Groom the product roadmap", "Define product principles", "Separate MVP and follow-on improvements"],
+  "list": ["Market Research", "Product Strategy Workshop", "Validate essential assumptions", "Define product principles", "Separate MVP and follow-on improvements"],
   "linkUrl": "/playbook/",
   "linkText": "Download our playbook"
 } %}
@@ -40,7 +40,7 @@ title: Digital Products & Design | Our Services
   "subtitle": "Experiences that users love",
   "text": "When a complex digital product delights you with its ease of use, that’s by design. Your users have a problem, and it’s up to us to solve it through smart design coupled with outspoken visual appeal. Your product should be remarkable from every angle.",
   "listType": "unordered",
-  "list": ["Multi-stakeholder design research", "Wireframing & Rapid prototyping", "Develop a consistent design system", "Ideation across the entire user journey"]
+  "list": ["Multi-stakeholder design research", "Shaping & Wireframing", "Develop a consistent design system", "Ideation across the entire user journey"]
 } %}
 {{ textWithList(content, "purple") }}
 


### PR DESCRIPTION
I realized we were saying some things that were just wrong on the page for digital product development – this fixes that:

<img width="1437" alt="Bildschirm­foto 2022-11-30 um 08 22 04" src="https://user-images.githubusercontent.com/1510/204732763-21220547-daee-4155-b273-fa147b4b1124.png">
