### PR TITLE
run content parser scripts before minification

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -130,12 +130,13 @@ module.exports = function (eleventyConfig) {
    *
    * @link https://www.11ty.io/docs/config/#transforms
    */
+  // Parse the page HTML content and perform some manipulation
+  eleventyConfig.addTransform("contentParser", contentParser);
+
   if (process.env.ELEVENTY_ENV === "production") {
     // Minify HTML when building for production
     eleventyConfig.addTransform("htmlmin", htmlMinTransform);
   }
-  // Parse the page HTML content and perform some manipulation
-  eleventyConfig.addTransform("contentParser", contentParser);
 
   /**
    * Add Plugins


### PR DESCRIPTION
This runs the `contentParser.js` script that does a number of modifications on the HTML that 11ty generates before the minification step. While it makes sense to only minifiy at the very end, this also seems to fix the build problem that @beerinho encountered in #1952 for some reason…