### PR TITLE
fix(this-week-in-os): change category of `renovatebot/renovate` to Renovate

### DIFF
--- a/config/this-week-in-open-source.config.json
+++ b/config/this-week-in-open-source.config.json
@@ -330,7 +330,7 @@
             ]
         },
         {
-            "name": "TypeScript",
+            "name": "Renovate",
             "repos": [
                 "renovatebot/renovate"
             ]


### PR DESCRIPTION
instead of `TypeScript`