### PR TITLE
Optimize CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
   build:
     name: 'Build'
     runs-on: ubuntu-latest
+    needs: [lint]
     
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3
@@ -55,6 +56,7 @@ jobs:
   visual-regressions:
     name: 'Visual Regressions'
     runs-on: ubuntu-latest
+    needs: [lint]
   
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,31 @@ jobs:
       - name: lint
         run: yarn lint
 
+  build:
+    name: 'Build'
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3
+      - uses: volta-cli/action@25888009cd70dbe17a140f1c56d93f8c09f7bcef # v4
+        with:
+          registry-url: "https://registry.npmjs.org"
+    
+      - name: install dependencies
+        run: yarn install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    
+      - name: build
+        run: yarn build
+
+      - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3
+        with:
+          name: build
+          path: dist
+          if-no-files-found: error
+          retention-days: 1
+
   visual-regressions:
     name: 'Visual Regressions'
     runs-on: ubuntu-latest
@@ -54,6 +79,7 @@ jobs:
   performance:
     name: 'Performance'
     runs-on: ubuntu-latest
+    needs: [build]
 
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3
@@ -66,8 +92,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: build
-        run: yarn build
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
+        with:
+          name: build
 
       - name: lighthouse
         env:
@@ -77,6 +104,7 @@ jobs:
   crawl:
     name: 'Crawl Links'
     runs-on: ubuntu-latest
+    needs: [build]
     
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3
@@ -91,8 +119,12 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     
-      - name: build
-        run: yarn build
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
+        with:
+          name: build
+    
+      - name: dbg
+        run: tree .
     
       - name: crawl
         run: yarn crawl dist
@@ -100,6 +132,7 @@ jobs:
   gravity:
     name: 'Gravity'
     runs-on: ubuntu-latest
+    needs: [build]
     
     steps:
       - uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3
@@ -114,8 +147,9 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     
-      - name: build
-        run: yarn build
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
+        with:
+          name: build
     
       - name: Run Gravity
         run: npm run gravityci "dist/**/*"


### PR DESCRIPTION
We're doing a bunch of things more than once and run some steps even if a fundamental one (e.g. linting) fails which makes things slower than they need to be.

This runs linting before everything else (and does not run anything else if linting fails) and caches the build between build steps.