### PR TITLE
fix blog meta description

### DIFF
--- a/src/author.njk
+++ b/src/author.njk
@@ -2,7 +2,7 @@
 layout: base
 renderData:
   title: All posts by {{ paged.author.data.name }}
-description: 'The latest insights on product strategy, design and development. Read in-depth articles on the web technologies we master: Ember.js, Elixir/Phoenix, and JavaScript.'
+description: "Frontend and JavaScript, Svelte and Ember, Rust and WASM, Elixir and Phoenix, Product and Design: Stay on top of what's happening."
 pagination:
   data: collections.authorsPostsPaged
   size: 1

--- a/src/blog.njk
+++ b/src/blog.njk
@@ -1,7 +1,7 @@
 ---js
 {
   title: "Engineering, Design & Product Blog",
-  description: "Frontend and JavaScript, Rust and WASM, Elixir and Phoenix, Product and Design: Stay on top of what's happening.",
+  description: "Frontend and JavaScript, Svelte and Ember, Rust and WASM, Elixir and Phoenix, Product and Design: Stay on top of what's happening.",
   permalink: "/blog/{% if pagination.pageNumber > 0 %}/page/{{ pagination.pageNumber + 1 }}/{% endif %}",
   layout: "base.njk",
   pagination: {

--- a/src/tag.njk
+++ b/src/tag.njk
@@ -1,7 +1,7 @@
 ---
 renderData:
   title: Tagged with “{{ paged.tag }}”
-description: 'The latest insights on product strategy, design and development. Read in-depth articles on the web technologies we master: Ember.js, Elixir/Phoenix, and JavaScript.'
+description: "Frontend and JavaScript, Svelte and Ember, Rust and WASM, Elixir and Phoenix, Product and Design: Stay on top of what's happening."
 layout: base
 pagination:
   data: collections.tagsPostsPaged


### PR DESCRIPTION
This fixes the meta description of all of our blog pages to be the same and to include the keyowrds Ember and Svelte.