### PR TITLE
Fix dynamic front matter

### DIFF
--- a/src/author.njk
+++ b/src/author.njk
@@ -1,6 +1,7 @@
 ---
 layout: base
-title: "All posts by {{ paged.author.data.name }}"
+eleventyComputed:
+  title: "All posts by {{ paged.author.data.name }}"
 description: "Frontend and JavaScript, Svelte and Ember, Rust and WASM, Elixir and Phoenix, Product and Design: Stay on top of what's happening."
 pagination:
   data: collections.authorsPostsPaged

--- a/src/author.njk
+++ b/src/author.njk
@@ -1,7 +1,6 @@
 ---
 layout: base
-renderData:
-  title: All posts by {{ paged.author.data.name }}
+title: "All posts by {{ paged.author.data.name }}"
 description: "Frontend and JavaScript, Svelte and Ember, Rust and WASM, Elixir and Phoenix, Product and Design: Stay on top of what's happening."
 pagination:
   data: collections.authorsPostsPaged

--- a/src/components/global/meta.njk
+++ b/src/components/global/meta.njk
@@ -2,9 +2,7 @@
 {%- set pageDesc = config.description -%}
 {%- set siteTitle = config.name -%}
 
-{%- if renderData.title -%}
-  {%- set pageTitle = renderData.title + ' - ' + config.name -%}
-{%- elif title -%}
+{%- if title -%}
   {%- set pageTitle = title + ' - ' + config.name -%}
 {%- endif -%}
 

--- a/src/components/layouts/base.njk
+++ b/src/components/layouts/base.njk
@@ -7,9 +7,7 @@ og:
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     {%- set pageTitle = config.name -%}
-    {%- if renderData.title -%}
-      {%- set pageTitle = renderData.title + ' | ' + config.name -%}
-    {%- elif title -%}
+    {%- if title -%}
       {%- set pageTitle = title + ' | ' + config.name -%}
     {%- endif -%}
 

--- a/src/tag.njk
+++ b/src/tag.njk
@@ -1,5 +1,6 @@
 ---
-title: "Tagged with “{{ paged.tag }}”"
+eleventyComputed:
+  title: "Tagged with “{{ paged.tag }}”"
 description: "Frontend and JavaScript, Svelte and Ember, Rust and WASM, Elixir and Phoenix, Product and Design: Stay on top of what's happening."
 layout: base
 pagination:

--- a/src/tag.njk
+++ b/src/tag.njk
@@ -1,6 +1,5 @@
 ---
-renderData:
-  title: Tagged with “{{ paged.tag }}”
+title: "Tagged with “{{ paged.tag }}”"
 description: "Frontend and JavaScript, Svelte and Ember, Rust and WASM, Elixir and Phoenix, Product and Design: Stay on top of what's happening."
 layout: base
 pagination:


### PR DESCRIPTION
This fixes dynamic frontmatter data by using [`eleventyComputed`](https://www.11ty.dev/docs/data-computed/):

| Before | After |
|--------|------|
| <img width="563" alt="Bildschirmfoto 2023-07-17 um 12 50 52" src="https://github.com/mainmatter/mainmatter.com/assets/1510/6d26322f-1f70-439c-9690-0200ee91e99b"> | <img width="624" alt="Bildschirmfoto 2023-07-17 um 12 49 26" src="https://github.com/mainmatter/mainmatter.com/assets/1510/ee44541f-5dd3-422c-b789-0df3357274ff"> |

closes #2709