### PR TITLE
fix order of text/link in secondary features

### DIFF
--- a/src/assets/css/components/_secondary-feature.scss
+++ b/src/assets/css/components/_secondary-feature.scss
@@ -13,9 +13,6 @@
 
 .secondary-feature__link {
   color: currentColor;
-}
-
-.secondary-feature__text {
   margin: 1rem 0 2rem;
 }
 

--- a/src/components/secondary-feature.njk
+++ b/src/components/secondary-feature.njk
@@ -28,12 +28,12 @@ Example usage:
 {%- macro secondaryFeature(content, className) -%}
   <div class="secondary-feature{% if className %} {{ className }}{% endif %}" data-background-color="purple">
     <div class="secondary-feature__main">
-      {%- if content.linkUrl -%}
-        {{ ctaLink(content.linkUrl, content.linkText, 'secondary-feature__link') }}
-      {%- endif -%}
       {%- if content.text -%}
         <h2 class="secondary-feature__text h5 text--bold">{{ content.text | safe }}</h2>
       {%- endif %}
+      {%- if content.linkUrl -%}
+        {{ ctaLink(content.linkUrl, content.linkText, 'secondary-feature__link') }}
+      {%- endif -%}
     </div>
     <div class="secondary-feature__image-wrapper">
       {% if content.image -%}


### PR DESCRIPTION
| Before | After |
|--------|------|
| <img width="428" alt="Bildschirmfoto 2023-08-09 um 15 07 00" src="https://github.com/mainmatter/mainmatter.com/assets/1510/2da2153d-ba35-4977-818a-709291100d2a"> | <img width="436" alt="Bildschirmfoto 2023-08-09 um 15 08 07" src="https://github.com/mainmatter/mainmatter.com/assets/1510/6f1756ca-83ba-47d0-8e56-de312207d49a"> |