### PR TITLE
Tweak Calendly's wording to avoid reach outs from individuals/hobbyists

### DIFF
--- a/src/rust-consulting.njk
+++ b/src/rust-consulting.njk
@@ -69,7 +69,7 @@ permalink: /rust-consulting/
 
 {% set 'slide_1' = {
   "color": "purple",
-  "title": "Is Rust the right choice for me?",
+  "title": "Is Rust the right choice for us?",
   "text": "Every new technology brings its own risks - Rust is no exception. Luca Palmieri, the author of <a href=\"http://zero2prod.com\">Zero to Production in Rust</a> and our in-house Rust expert, is here to help your company. You walk him through your company's usecase and your requirements and he’ll do his best to suggest the best course of action. Sometimes Rust is not the answer, but if it is, he’ll make sure you are on the right track.",
   "linkUrl": "https://calendly.com/luca-palmieri/is-rust-the-right-choice-for-us",
   "linkText": "Book a free 1:1 call with Luca"

--- a/src/rust-consulting.njk
+++ b/src/rust-consulting.njk
@@ -70,7 +70,7 @@ permalink: /rust-consulting/
 {% set 'slide_1' = {
   "color": "purple",
   "title": "Is Rust the right choice for me?",
-  "text": "Every new technology brings its own risks - Rust is no exception. Luca Palmieri, the author of <a href=\"http://zero2prod.com\">Zero to Production in Rust</a> and our in-house Rust expert, is here to help you. You walk him through your usecase and your requirements and he’ll do his best to suggest the best course of action. Sometimes Rust is not the answer, but if it is, he’ll make sure you are on the right track.",
+  "text": "Every new technology brings its own risks - Rust is no exception. Luca Palmieri, the author of <a href=\"http://zero2prod.com\">Zero to Production in Rust</a> and our in-house Rust expert, is here to help your company. You walk him through your company's usecase and your requirements and he’ll do his best to suggest the best course of action. Sometimes Rust is not the answer, but if it is, he’ll make sure you are on the right track.",
   "linkUrl": "https://calendly.com/luca-palmieri/is-rust-the-right-choice-for-us",
   "linkText": "Book a free 1:1 call with Luca"
 } %}

--- a/src/rust-consulting.njk
+++ b/src/rust-consulting.njk
@@ -70,7 +70,7 @@ permalink: /rust-consulting/
 {% set 'slide_1' = {
   "color": "purple",
   "title": "Is Rust the right choice for us?",
-  "text": "Every new technology brings its own risks - Rust is no exception. Luca Palmieri, the author of <a href=\"http://zero2prod.com\">Zero to Production in Rust</a> and our in-house Rust expert, is here to help your company. You walk him through your company's usecase and your requirements and he’ll do his best to suggest the best course of action. Sometimes Rust is not the answer, but if it is, he’ll make sure you are on the right track.",
+  "text": "Every new technology brings its own risks - Rust is no exception. Luca Palmieri, the author of <a href=\"http://zero2prod.com\">Zero to Production in Rust</a> and our in-house Rust expert, is here to help your team. You walk him through your company's usecase and your requirements and he’ll do his best to suggest the best course of action. Sometimes Rust is not the answer, but if it is, he’ll make sure you are on the right track.",
   "linkUrl": "https://calendly.com/luca-palmieri/is-rust-the-right-choice-for-us",
   "linkText": "Book a free 1:1 call with Luca"
 } %}


### PR DESCRIPTION
We got three bookings so far and, from what I've seen, two of them are from hobbyists for their hobby projects which isn't the type of convos we want to be having.
Tweaking the wording slightly to nudge the right people to reach out.