### PR TITLE
Add CTA before content in all posts tagged with Rust

### DIFF
--- a/src/assets/css/app.scss
+++ b/src/assets/css/app.scss
@@ -65,6 +65,7 @@
 @import "components/startups";
 @import "components/scroll-slides";
 @import "components/quotes-list";
+@import "components/blog-cta";
 
 @import "animations/text-animation";
 

--- a/src/assets/css/components/_blog-cta.scss
+++ b/src/assets/css/components/_blog-cta.scss
@@ -1,0 +1,22 @@
+.blog-cta {
+  background-color: var(--color-purple);
+  color: var(--color-white);
+  margin-bottom: 3.25rem;
+  padding: 3.25rem 1rem;
+
+  @media (min-width: 48em) {
+    & {
+      margin-bottom: 6.25rem;
+      padding: 3.5rem 5rem;
+    }
+  }
+
+  a {
+    color: var(--color-aqua);
+  }
+
+  .contact-us {
+    display: block;
+    color: var(--color-white);
+  }
+}

--- a/src/components/global/rust-cta.njk
+++ b/src/components/global/rust-cta.njk
@@ -1,0 +1,10 @@
+{#
+A call-to-action meant to be displayed at the beginning of a blog post.
+#}
+<blockquote><p>
+    If you're looking to adopt Rust to develop web backends and need guidance along the way, 
+    <a href="/contact/" class="plausible-event-name=Rust+Contact">reach out</a>! 
+    We can help with <a href="/rust-consulting/" class="plausible-event-name=Rust+Consulting"> mentoring, training, team augmentation, 
+    and custom development</a>.
+    <author>Mainmatter team</author>
+</p></blockquote>

--- a/src/components/global/rust-cta.njk
+++ b/src/components/global/rust-cta.njk
@@ -1,10 +1,15 @@
+{% from "cta-link.njk" import ctaLink %}
+
 {#
 A call-to-action meant to be displayed at the beginning of a blog post.
 #}
-<blockquote><p>
+<div class="blog-cta">
+  <h4 class="h4">
     If you're looking to adopt Rust to develop web backends and need guidance along the way, 
-    <a href="/contact/" class="plausible-event-name=Rust+Contact">reach out</a>! 
-    We can help with <a href="/rust-consulting/" class="plausible-event-name=Rust+Consulting"> mentoring, training, team augmentation, 
-    and custom development</a>.
-    <author>Mainmatter team</author>
-</p></blockquote>
+    reach out!
+  </h4>
+  <p>
+    We can help with <a href="/rust-consulting/" class="plausible-event-name=Rust+Consulting">mentoring, training, team augmentation, and custom development</a>.</p>
+  </p>
+  {{ ctaLink("/contact/", "Contact us!", "contact-us plausible-event-name=Rust+Contact") }}
+</div>

--- a/src/components/layouts/post.njk
+++ b/src/components/layouts/post.njk
@@ -78,6 +78,13 @@ layout: base
         {% endfor %}
       {% endif %}
       {{ content | safe }}
+      {% if tags %}
+        {% for tag in tags %}
+          {% if tag === "rust" %}
+            {% include "global/rust-cta.njk" %}
+          {% endif %}
+        {% endfor %}
+      {% endif %}
     </div>
     <nav aria-label="Post Pagination" class="prev-next pagination">
       {% set previous = collections.posts | getPreviousCollectionItem(page) %}

--- a/src/components/layouts/post.njk
+++ b/src/components/layouts/post.njk
@@ -70,6 +70,19 @@ layout: base
   {% endif %}
   <div class="container container--lg post">
     <div class="post__content rte">
+      {% if tags %}
+        {% for tag in tags %}
+          {% if tag === "rust" %}
+            <blockquote><p>
+              If you're looking to adopt Rust to develop web backends and need guidance along the way, 
+              <a href="/contact/">reach out</a>! 
+              We can help with <a href="/rust-consulting/"> mentoring, training, team augmentation, 
+              and custom development</a>.
+              <author>Mainmatter team</author>
+            </p></blockquote>
+          {% endif %}
+        {% endfor %}
+      {% endif %}
       {{ content | safe }}
     </div>
     <nav aria-label="Post Pagination" class="prev-next pagination">

--- a/src/components/layouts/post.njk
+++ b/src/components/layouts/post.njk
@@ -75,8 +75,8 @@ layout: base
           {% if tag === "rust" %}
             <blockquote><p>
               If you're looking to adopt Rust to develop web backends and need guidance along the way, 
-              <a href="/contact/">reach out</a>! 
-              We can help with <a href="/rust-consulting/"> mentoring, training, team augmentation, 
+              <a href="/contact/" class="plausible-event-name=Rust+Contact">reach out</a>! 
+              We can help with <a href="/rust-consulting/" class="plausible-event-name=Rust+Consulting"> mentoring, training, team augmentation, 
               and custom development</a>.
               <author>Mainmatter team</author>
             </p></blockquote>

--- a/src/components/layouts/post.njk
+++ b/src/components/layouts/post.njk
@@ -73,13 +73,7 @@ layout: base
       {% if tags %}
         {% for tag in tags %}
           {% if tag === "rust" %}
-            <blockquote><p>
-              If you're looking to adopt Rust to develop web backends and need guidance along the way, 
-              <a href="/contact/" class="plausible-event-name=Rust+Contact">reach out</a>! 
-              We can help with <a href="/rust-consulting/" class="plausible-event-name=Rust+Consulting"> mentoring, training, team augmentation, 
-              and custom development</a>.
-              <author>Mainmatter team</author>
-            </p></blockquote>
+            {% include "global/rust-cta.njk" %}
           {% endif %}
         {% endfor %}
       {% endif %}

--- a/src/posts/2020-06-25-writing-rust-nifs-for-elixir-with-rustler.md
+++ b/src/posts/2020-06-25-writing-rust-nifs-for-elixir-with-rustler.md
@@ -1,7 +1,7 @@
 ---
 title: Writing Rust NIFs for Elixir With Rustler
 authorHandle: niklas_long
-tags: elixir
+tags: [elixir, rust]
 bio: "Backend Engineer, author of Breethe API"
 description:
   "Niklas Long describes the upcoming changes to Rustler and how it simplifies

--- a/src/posts/2023-02-01-using-rust-crates-in-elixir.md
+++ b/src/posts/2023-02-01-using-rust-crates-in-elixir.md
@@ -488,7 +488,3 @@ Further reading:
 - [https://github.com/andrewtimberlake/elixir-pdf](https://github.com/andrewtimberlake/elixir-pdf)
 - [https://discord.com/blog/using-rust-to-scale-elixir-for-11-million-concurrent-users](https://discord.com/blog/using-rust-to-scale-elixir-for-11-million-concurrent-users)
 - [https://discord.com/blog/why-discord-is-switching-from-go-to-rust](https://discord.com/blog/why-discord-is-switching-from-go-to-rust)
-
-Btw: if you'd like to get started using Rust but aren't sure how to get started,
-consider our
-[Rust workshop](/services/workshops/introduction-to-rust-for-web-developers/)!

--- a/src/posts/2023-06-28-present-and-future-of-rust-with-luca-palmieri.md
+++ b/src/posts/2023-06-28-present-and-future-of-rust-with-luca-palmieri.md
@@ -54,7 +54,3 @@ Check out the full interview below and don’t hesitate to contact us to learn h
 your company could benefit from adopting Rust.
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/Xb7NokhAVKI?rel=0" title="Embedded video of Luca's interview" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-If you're looking to adopt Rust to develop web backends and need guidance along
-the way, [get in touch](/contact/) We offer
-[team augmentation, mentoring, as well as development with Rust](/rust-consulting/).

--- a/src/posts/2023-08-01-pitching-rust-to-decision-makers-with-joel-marcey.md
+++ b/src/posts/2023-08-01-pitching-rust-to-decision-makers-with-joel-marcey.md
@@ -39,7 +39,3 @@ security, and significant operational cost reduction due to its efficiency, when
 pitching.
 
 <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/T951xRBcGD8" title="Embedded video of Joel's interview" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
-If you're looking to adopt Rust to develop web backends and need guidance along
-the way, [get in touch](/contact/) We offer
-[team augmentation, mentoring, as well as development with Rust](/rust-consulting/).


### PR DESCRIPTION
My e11y is _extremely_ basic, so I'm sure there's a better way to do this 😅 
The key idea: we have a consistent CTA in all posts tagged as Rust, with associated tracking in Plausible to measure conversion. 

~If we like the idea, I can then go through all existing Rusts posts to make sure that we don't have redundant CTAs.~ Done ✅ 