### PR TITLE
add missing description for "The case for Rust on the Web" blog post

### DIFF
--- a/src/posts/2023-08-14-the-case-for-rust-on-the-web.md
+++ b/src/posts/2023-08-14-the-case-for-rust-on-the-web.md
@@ -3,7 +3,9 @@ title: "The Case for Rust on the Web"
 authorHandle: marcoow
 tags: [rust]
 bio: "Marco Otte-Witte"
-description: "TODO"
+description:
+  "Marco Otte-Witte explains why Mainmatter believes Rust has a bright future
+  for web backend development."
 og:
   image: /assets/images/posts/2023-08-14-the-case-for-rust-on-the-web/og-image.png
 tagline:


### PR DESCRIPTION
…this currently shows up as "TODO" in the metadata 🤦 