### PR TITLE
remove outline from focus state 

### DIFF
--- a/src/assets/css/base/_forms.scss
+++ b/src/assets/css/base/_forms.scss
@@ -6,3 +6,8 @@ textarea {
   border-bottom: rem-calc(1) solid currentColor;
   background-color: transparent;
 }
+
+input:focus-visible, textarea:focus-visible, select:focus-visible {
+  outline: none;
+  border-bottom: rem-calc(1) solid var(--color-link-primary-hover);
+}


### PR DESCRIPTION
I removed the outline, but made the onfocus color of the bottom border teal, so that there is still a visual cue for the focus state