### PR TITLE
Add CTAs to more blog posts

### DIFF
--- a/src/assets/css/components/_blog-cta.scss
+++ b/src/assets/css/components/_blog-cta.scss
@@ -19,4 +19,8 @@
     display: block;
     color: var(--color-white);
   }
+
+  h4 {
+    margin-top: 0;
+  }
 }

--- a/src/components/global/ember-cta.njk
+++ b/src/components/global/ember-cta.njk
@@ -1,0 +1,15 @@
+{% from "cta-link.njk" import ctaLink %}
+
+{#
+A call-to-action meant to be displayed at the beginning of a blog post.
+#}
+<div class="blog-cta">
+  <h4 class="h4">
+    If you're facing challenges with Ember.js and need a helping hand, 
+    reach out!
+  </h4>
+  <p>
+    We can help with <a href="/ember-consulting/" class="plausible-event-name=Ember+Consulting">mentoring, training, team augmentation, and custom development</a>.</p>
+  </p>
+  {{ ctaLink("/contact/", "Contact us!", "contact-us plausible-event-name=Ember+Contact") }}
+</div>

--- a/src/components/global/svelte-cta.njk
+++ b/src/components/global/svelte-cta.njk
@@ -1,0 +1,15 @@
+{% from "cta-link.njk" import ctaLink %}
+
+{#
+A call-to-action meant to be displayed at the beginning of a blog post.
+#}
+<div class="blog-cta">
+  <h4 class="h4">
+    If you're looking to adopt Svelte and SvelteKit and need guidance along the way, 
+    reach out!
+  </h4>
+  <p>
+    We can help with <a href="/svelte-consulting/" class="plausible-event-name=Svelte+Consulting">mentoring, training, team augmentation, and custom development</a>.</p>
+  </p>
+  {{ ctaLink("/contact/", "Contact us!", "contact-us plausible-event-name=Svelte+Contact") }}
+</div>

--- a/src/components/layouts/post.njk
+++ b/src/components/layouts/post.njk
@@ -5,6 +5,7 @@ layout: base
 {% from "image-aspect-ratio.njk" import imageAspectRatio %}
 {% from "author-socials.njk" import authorSocials %}
 {% from "color-hero.njk" import colorHero %}
+{% from "service-cta.njk" import serviceCta %}
 
 {%- block content -%}
 <article>
@@ -70,21 +71,9 @@ layout: base
   {% endif %}
   <div class="container container--lg post">
     <div class="post__content rte">
-      {% if tags %}
-        {% for tag in tags %}
-          {% if tag === "rust" %}
-            {% include "global/rust-cta.njk" %}
-          {% endif %}
-        {% endfor %}
-      {% endif %}
+      {{ serviceCta(tags) }}
       {{ content | safe }}
-      {% if tags %}
-        {% for tag in tags %}
-          {% if tag === "rust" %}
-            {% include "global/rust-cta.njk" %}
-          {% endif %}
-        {% endfor %}
-      {% endif %}
+      {{ serviceCta(tags) }}
     </div>
     <nav aria-label="Post Pagination" class="prev-next pagination">
       {% set previous = collections.posts | getPreviousCollectionItem(page) %}

--- a/src/components/service-cta.njk
+++ b/src/components/service-cta.njk
@@ -1,0 +1,9 @@
+{%- macro serviceCta(tags) -%}
+  {% if tags %}
+    {% for tag in tags %}
+      {% if tag === "rust" %}
+        {% include "global/rust-cta.njk" %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+{%- endmacro -%}

--- a/src/components/service-cta.njk
+++ b/src/components/service-cta.njk
@@ -7,6 +7,9 @@
       {% if tag === "svelte" %}
         {% include "global/svelte-cta.njk" %}
       {% endif %}
+      {% if tag === "ember" %}
+        {% include "global/ember-cta.njk" %}
+      {% endif %}
     {% endfor %}
   {% endif %}
 {%- endmacro -%}

--- a/src/components/service-cta.njk
+++ b/src/components/service-cta.njk
@@ -4,6 +4,9 @@
       {% if tag === "rust" %}
         {% include "global/rust-cta.njk" %}
       {% endif %}
+      {% if tag === "svelte" %}
+        {% include "global/svelte-cta.njk" %}
+      {% endif %}
     {% endfor %}
   {% endif %}
 {%- endmacro -%}


### PR DESCRIPTION
This adds CTAs like the ones we're showing for Rust blog posts to posts that are about Ember and Svelte as well, e.g.

![Bildschirmfoto 2023-11-08 um 15 22 53](https://github.com/mainmatter/mainmatter.com/assets/1510/a64eb7a0-b9b4-424c-96f7-1aea2dabfd49)
