### PR TITLE
add keyword "workshop" to workshop landing pages

### DIFF
--- a/src/workshops/advanced-testing-in-rust.md
+++ b/src/workshops/advanced-testing-in-rust.md
@@ -1,6 +1,6 @@
 ---
 title: "Testing in Rust: going beyond the basics"
-format: 1 day, on-site or remote
+format: "Workshop: 1 day, on-site or remote"
 description: |
   <p>No application is an island: you need to interact with third-party APIs, databases and who knows what else. 
   Testing those interactions is tricky, to say the least! 

--- a/src/workshops/an-introduction-to-testing-in-rust.md
+++ b/src/workshops/an-introduction-to-testing-in-rust.md
@@ -1,6 +1,6 @@
 ---
 title: "Testing in Rust: an introduction"
-format: 4 hours, on-site or remote
+format: "Workshop: 4 hours, on-site or remote"
 description: |
   <p>Rust's type system is great, but it's not enough on its own to ensure correctness: 
   a solid testing strategy is a requirement for any serious Rust application.</p>

--- a/src/workshops/design-system-kickoff-interface-inventory.md
+++ b/src/workshops/design-system-kickoff-interface-inventory.md
@@ -1,6 +1,6 @@
 ---
 title: Design system kickoff (interface inventory)
-format: 2-3 days on-site or remote
+format: "Workshop: 2-3 days on-site or remote"
 description:
   Create an interface inventory of your digital product, and align with your
   team on how to prioritize refactoring using a design systems methodology.

--- a/src/workshops/digital-product-strategy.md
+++ b/src/workshops/digital-product-strategy.md
@@ -1,6 +1,6 @@
 ---
 title: Digital product strategy workshop
-format: 2–3 days remote
+format: "Workshop: 2–3 days on-site or remote"
 description:
   In this workshop we will collaborate to formulate a clear product vision,
   establishing a blueprint for your digital product's development process. This

--- a/src/workshops/effective-git.md
+++ b/src/workshops/effective-git.md
@@ -1,6 +1,6 @@
 ---
 title: Effective Git
-format: Remote
+format: "Workshop: 1 day, on-site or remote"
 description:
   <p>Git is at the center of modern pull request-based development workflows.
   Mastering it makes teams more productive and developers' jobs more

--- a/src/workshops/hands-on-ember.md
+++ b/src/workshops/hands-on-ember.md
@@ -1,6 +1,6 @@
 ---
 title: Hands-on Ember.js
-format: 2-3 days remote
+format: "Workshop: 2-3 days on-site or remote"
 description: <p>We go through a series of stages that each build on one another.
   Each topic is introduced via an in-depth presentation as well as a small,
   focussed demo application that illustrates the respective concept in practice.

--- a/src/workshops/introduction-to-rust-for-web-developers.md
+++ b/src/workshops/introduction-to-rust-for-web-developers.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction to Rust for Web Developers
-format: 2-3 days on-site or remote
+format: "Workshop: 2-3 days, on-site or remote"
 description: <p>According to the Stack Overflow survey, Rust is one of the most
   beloved programming languages. In recent years, it has also gained popularity.
   There has never been a better time to become familiar with Rust! Learning a

--- a/src/workshops/svelte-and-sveltekit.md
+++ b/src/workshops/svelte-and-sveltekit.md
@@ -1,6 +1,6 @@
 ---
 title: Svelte & SvelteKit
-format: 2-3 days remote or on-site
+format: "Workshop: 2-3 days, remote or on-site"
 description: <p>Svelte is great choice for building fast and light-weight web
   applications. Its unique approach of generating reactive code at compile time
   instead of relying on a runtime, moves work out of the browser and results in

--- a/src/workshops/telemetry-for-rust-apis.md
+++ b/src/workshops/telemetry-for-rust-apis.md
@@ -1,6 +1,6 @@
 ---
 title: "You can't fix what you can't see: telemetry for Rust APIs"
-format: 1 day on-site or remote
+format: "Workshop: 1 day, on-site or remote"
 description:
   <p>Your Rust application has finally been deployed to production! Nice! But is
   it working? This workshop will introduce you to a comprehensive toolkit to

--- a/src/workshops/web-based-services-in-rust.md
+++ b/src/workshops/web-based-services-in-rust.md
@@ -1,6 +1,6 @@
 ---
 title: Web-based Services in Rust
-format: 2-3 days on-site or remote
+format: "Workshop: 2-3 days, on-site or remote"
 description: <p>Rust is an excellent programming language for developing web
   applications and web services due to its concurrency approach, tool
   flexibility, library availability, and rich ecosystem. As a result, you can


### PR DESCRIPTION
We didn't actually say "workshop" in the headers of the workshop pages…