### PR TITLE
fix link to SvelteLab on Svelte consulting page

### DIFF
--- a/src/svelte-consulting.njk
+++ b/src/svelte-consulting.njk
@@ -53,7 +53,7 @@ og:
     <h3 class="split-content__subheading h2">Succeeding with Svelte</h3>
     <div class="split-content__content">
       <div class="split-content__text">
-        <p>Getting started with Svelte and SvelteKit is straightforward but an experienced partner can help ensure you're set up for success from the beginning. Paolo Ricciuti, Svelte ambassador, co-author of <a href=\"https://www.sveltelab.dev\">SvelteLab</a>, and our in-house Svelte expert, is here to help your team.</p>
+        <p>Getting started with Svelte and SvelteKit is straightforward but an experienced partner can help ensure you're set up for success from the beginning. Paolo Ricciuti, Svelte ambassador, co-author of <a href="https://www.sveltelab.dev">SvelteLab</a>, and our in-house Svelte expert, is here to help your team.</p>
         {{ ctaLink('https://calendar.google.com/calendar/u/0/appointments/schedules/AcZssZ26xh3Rs58rD4ZNFuzlzbTxFxubT5_9qSqc_NU4Pmqdot1YTIiylxcyL2kJrfEHn8tpgJqoHi8O', 'Book a 1:1 call with Paolo', 'split-content__link plausible-event-name=Svelte+1on1+Call') }}
       </div>
       <div class="split-content__feature">


### PR DESCRIPTION
The link was escaped in the source and thus didn't work

***

PR #2203 was closed by accident and could not be reopened. Originally created by @marcoow.