### PR TITLE
chore(deps): bump percy to 1.27.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@11ty/eleventy-plugin-rss": "1.2.0",
     "@11ty/eleventy-plugin-syntaxhighlight": "5.0.0",
     "@lhci/cli": "^0.12.0",
-    "@percy/cli": "^1.10.2",
+    "@percy/cli": "^1.27.4",
     "@quasibit/eleventy-plugin-sitemap": "^2.1.5",
     "@tbranyen/jsdom": "13.0.0",
     "broken-link-checker": "^0.7.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -299,105 +299,106 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@percy/cli-app@1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@percy/cli-app/-/cli-app-1.10.2.tgz#b37e2b2f74f17b54a92b3932f032e43655922ec3"
-  integrity sha512-1Ysyqsupfr8/PjcFqoNRVEdCsk8ssRMoxUQFb88r6fkfaR+1UQGq1feKQcc2EAeZtizu4HZvkFmTsNKIaccmVQ==
+"@percy/cli-app@1.27.4":
+  version "1.27.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-app/-/cli-app-1.27.4.tgz#2b8364443bfd2ac59c7b4e98ccab6000828443ae"
+  integrity sha512-av/s6K2QmQgq4SCQQ+3lmteNHeQtIpMeBjMfSgxs9zeBoPVOMx5hXrdsi6l7ChvOLXyYfzl/TbEuwrSDXiA8mw==
   dependencies:
-    "@percy/cli-command" "1.10.2"
-    "@percy/cli-exec" "1.10.2"
+    "@percy/cli-command" "1.27.4"
+    "@percy/cli-exec" "1.27.4"
 
-"@percy/cli-build@1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.10.2.tgz#81f709db5e869d53d417c2623b468101ff11acf8"
-  integrity sha512-k/obA7JLl6rl8WNrz1U687/igYjwbAxGVjTK8Ipxmy0D1GG0JU+QI+kAx+1HflUTLMqLrecXDxbgAIPEXHbi3A==
+"@percy/cli-build@1.27.4":
+  version "1.27.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.27.4.tgz#b5983129f41a461614594f62386dd2c5bd89e215"
+  integrity sha512-tzCAcV0sAw608Gr/Q6NtPvVkA8dnIehMzvEXNIN3WP9DkprOgu7MYuexN0fZXf4vSroDWYXT87pHYP8YrrnDag==
   dependencies:
-    "@percy/cli-command" "1.10.2"
+    "@percy/cli-command" "1.27.4"
 
-"@percy/cli-command@1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.10.2.tgz#3b68a6a95b09809b022ef600d60b23044d91d750"
-  integrity sha512-5V8zEPbtn7FXI9i6RIeUrTHawbdD0Fipby1W/fw/qBN6yiXgeSEwCQ5l2YUHZdkfrDOaXZEzjWDBcWV89M+QAQ==
+"@percy/cli-command@1.27.4":
+  version "1.27.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.27.4.tgz#c3537260909957b165b81766e6d1771dc2496942"
+  integrity sha512-YDKeeOr1MvksDOnc2ZKQ/XuERGrWwzuT/vWZ9it8L+0SyPj28UbklDu0e9zBgPsSDfxJlIvsWXRuHNGHsweKXg==
   dependencies:
-    "@percy/config" "1.10.2"
-    "@percy/core" "1.10.2"
-    "@percy/logger" "1.10.2"
+    "@percy/config" "1.27.4"
+    "@percy/core" "1.27.4"
+    "@percy/logger" "1.27.4"
 
-"@percy/cli-config@1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.10.2.tgz#0c729f6a592129eab5090ad735d04eddc197975e"
-  integrity sha512-bxAU/KIHItWmUDoNwwMj2wNY0HfizUa/Vp8/ahikTTuxsREXZ7WQK+ExZEgKo6r7/Cw5AN6N5Bs2A1qwcbZv2w==
+"@percy/cli-config@1.27.4":
+  version "1.27.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.27.4.tgz#c48f21040bed2a28f15888c01974ecb2226ca446"
+  integrity sha512-wFtQwPw4LEqpcZ6ac6WtejyGrvrrzzLdyvXNvsCPQLE47qXnXVXJ+E99k9KGcjavtUuPxrbWtX996Fz9Fb5hoQ==
   dependencies:
-    "@percy/cli-command" "1.10.2"
+    "@percy/cli-command" "1.27.4"
 
-"@percy/cli-exec@1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.10.2.tgz#44e966936551ea87d4217a3db37812f5ef108c39"
-  integrity sha512-qrGu9Zm0+ElYeT6IU1AVd/pBujH8Mce6MmrQyFpbkIX8Nu3NIAETwiaR0GwjiHqVvMQU5qbJVtupz4SAAe3PIQ==
+"@percy/cli-exec@1.27.4":
+  version "1.27.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.27.4.tgz#8839d4e8b0f4b34b8d5885d41d15fd60beede44c"
+  integrity sha512-aSDLvzXXdwJso+p5iI4iTOa7AYzgFdRoqY9ij/R5aAL9juNkvG5QatB1bkUNbJabKFe16t7iigt4eJnlS0R13A==
   dependencies:
-    "@percy/cli-command" "1.10.2"
+    "@percy/cli-command" "1.27.4"
     cross-spawn "^7.0.3"
     which "^2.0.2"
 
-"@percy/cli-snapshot@1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.10.2.tgz#198df043f8758f71c1c8c311cc4767c6288ecc39"
-  integrity sha512-NxysEuQHmEo7W5knaYV0UJn+zPJBYUrXecQBfSTLl1o+N1M9OIUCiE7wkJvU2w+t9Nw+kVZvtZn0wHbCgLfQfw==
+"@percy/cli-snapshot@1.27.4":
+  version "1.27.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.27.4.tgz#1082e4594ef9eede4ec06aa4b7cfdff3dfc862ce"
+  integrity sha512-dDT2UpeP6X5NcMdj3AKLhHGmnobwzlXsHa52C+ne3kg3HSZgaXH9OsNY866Xe7onvcsZxvnRKDYHmWW6kC3cKQ==
   dependencies:
-    "@percy/cli-command" "1.10.2"
+    "@percy/cli-command" "1.27.4"
     yaml "^2.0.0"
 
-"@percy/cli-upload@1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.10.2.tgz#bfba933f62506de7f92dc6f3a80dc5ec918cdd57"
-  integrity sha512-dCYBGBoeLdOUIkuy2KkKk2H3T4QNXuuIbxjCEpbCbY4uX9HeTOfpVnqMFQj4XX7JI83WwmHdrZ6CwVwqOVO3sg==
+"@percy/cli-upload@1.27.4":
+  version "1.27.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.27.4.tgz#ec3e5280fc82a3789b6fb5cde69d210fee322fbf"
+  integrity sha512-+4mcEOUydFubyMWVzQjPV79sL1Jar95SR7Yr7Vp4FBoE0iq0CbaHoJtyOWDfwvHYYp4rRjVMxpY0ha3jnmF0mA==
   dependencies:
-    "@percy/cli-command" "1.10.2"
+    "@percy/cli-command" "1.27.4"
     fast-glob "^3.2.11"
     image-size "^1.0.0"
 
-"@percy/cli@^1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.10.2.tgz#2844b78c97146e125782112bdb1982fee618f352"
-  integrity sha512-jol4tLkafI01qgDNcuiMiIIwovCkABi8eeWsqrkpHCn4ovJkKgzWYxswBEQt1xmG5weRJGrvqwgZWFDzCjzIeg==
+"@percy/cli@^1.27.4":
+  version "1.27.4"
+  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.27.4.tgz#a5b6c2082f346a86d64245fda0212f610c18d7dd"
+  integrity sha512-eIM44ejCMFc/S2W7X0htV+lvvmf63x5CaBpsSoQ9LRc/W02zHVAwQYdFFUowZEK6G1EwJEPIUnDxuuEx9PLG5A==
   dependencies:
-    "@percy/cli-app" "1.10.2"
-    "@percy/cli-build" "1.10.2"
-    "@percy/cli-command" "1.10.2"
-    "@percy/cli-config" "1.10.2"
-    "@percy/cli-exec" "1.10.2"
-    "@percy/cli-snapshot" "1.10.2"
-    "@percy/cli-upload" "1.10.2"
-    "@percy/client" "1.10.2"
-    "@percy/logger" "1.10.2"
+    "@percy/cli-app" "1.27.4"
+    "@percy/cli-build" "1.27.4"
+    "@percy/cli-command" "1.27.4"
+    "@percy/cli-config" "1.27.4"
+    "@percy/cli-exec" "1.27.4"
+    "@percy/cli-snapshot" "1.27.4"
+    "@percy/cli-upload" "1.27.4"
+    "@percy/client" "1.27.4"
+    "@percy/logger" "1.27.4"
 
-"@percy/client@1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.10.2.tgz#4108eb5f06fd115e512ad597ffeba1b0984158a4"
-  integrity sha512-Zvp37zN4rrtgB3XMUSdmk1bDvyoNfJfF61TWoHWe6H4qMHsed81vA11DKVX5OZf6f/e+pSdXae9Wi7VBVx7v1Q==
+"@percy/client@1.27.4":
+  version "1.27.4"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.27.4.tgz#a6901e93e56245170e23b24bdf906fdfdb066956"
+  integrity sha512-1F8ulTJhfk4/Lgj1Cn0blaRd8vTRJDxahAGseTbfrnZ2PHsftPZ65/5nCHPtpdD/2CE8N5COBQscGTMQQO+hBA==
   dependencies:
-    "@percy/env" "1.10.2"
-    "@percy/logger" "1.10.2"
+    "@percy/env" "1.27.4"
+    "@percy/logger" "1.27.4"
 
-"@percy/config@1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.10.2.tgz#b0427b20ca11413d450145248de6b5a397113b57"
-  integrity sha512-9uPbmP64/9WwrGX4isMr4SqKrE1RQGiv0tRwWY2+iLJOgzuTBpXRH1W69ZaKPvf5B4WXicjQcs4qReIAy5WNcA==
+"@percy/config@1.27.4":
+  version "1.27.4"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.27.4.tgz#83bde546be17c801305e63b0cf84ed04fe748fba"
+  integrity sha512-mlgiOdzdSfUSx9FskVIjmbT/iHbTif0Ow5evZQJTT1W0xgHOBWDCZyhINdsqulSBw+K1PNhHsu1J0h2ijxF4uA==
   dependencies:
-    "@percy/logger" "1.10.2"
+    "@percy/logger" "1.27.4"
     ajv "^8.6.2"
-    cosmiconfig "^7.0.0"
+    cosmiconfig "^8.0.0"
     yaml "^2.0.0"
 
-"@percy/core@1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.10.2.tgz#bd990f440ac3e20d2b150bb1eafc39a3abd8f298"
-  integrity sha512-ytxaaXhx1OHiV+LK9dD/pGLu3LfITBSPwtelcLpxiw7YlSy4gilGKnk3Vn2p04VCKebKVhnJOT+3IKyJ52NFqw==
+"@percy/core@1.27.4":
+  version "1.27.4"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.27.4.tgz#673ea19be0b9e435e3ec2419505e9d9adbab5d6e"
+  integrity sha512-WdsA4zlPgXl9xj+a5WW2wA20iU6VTDmRq5sgsYNSuPzZfQB2I5Cecgvb55p86dhlUTbPJrC76daQKzDTGe0hfA==
   dependencies:
-    "@percy/client" "1.10.2"
-    "@percy/config" "1.10.2"
-    "@percy/dom" "1.10.2"
-    "@percy/logger" "1.10.2"
+    "@percy/client" "1.27.4"
+    "@percy/config" "1.27.4"
+    "@percy/dom" "1.27.4"
+    "@percy/logger" "1.27.4"
+    "@percy/webdriver-utils" "1.27.4"
     content-disposition "^0.5.4"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
@@ -408,20 +409,35 @@
     rimraf "^3.0.2"
     ws "^8.0.0"
 
-"@percy/dom@1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.10.2.tgz#3d589018165201f97396599c2ad86592c71fe87f"
-  integrity sha512-BDCVfQlomn/pIbNbIMWc+EbSm2kCD3as0xSaWb+1BeSjf+pQZ700u6ZSBI2wJ1RXlXYy+gv0+B5VJQUtJo2riQ==
+"@percy/dom@1.27.4":
+  version "1.27.4"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.27.4.tgz#199597ca6107c16ca452a640e9d1bfe2f65f6820"
+  integrity sha512-pwPDx3e9y7uRobVlEya8xu3BB3GeXbC74kQ6pPM/wFYDwi/Dg8DJywCsj5Nko/7QuhXP02rYgatkbREOIRxDnA==
 
-"@percy/env@1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.10.2.tgz#8fad97979a81d057b5d5ca7eb74b3beef0a58914"
-  integrity sha512-TKIjcR6CtPYf8JMtQX48vIY4dcxLErR+uJ+ylMPPqSm2C7BUswdkbHTYvK1vFlB1dBIY3wU8xt0khHQq01RPnw==
+"@percy/env@1.27.4":
+  version "1.27.4"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.27.4.tgz#8c308c470dae5fb970d858703e1f49aff266e791"
+  integrity sha512-Xl2VUpljOrlCvAp/+KfmN9NUcTGpRdXPa1U9zSIyBnV/oAksp3/CK5EPpKZX/f8xUUkTp78UPaG99sEMA8VvXQ==
+  dependencies:
+    "@percy/logger" "1.27.4"
 
-"@percy/logger@1.10.2":
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.10.2.tgz#06474daa41ccb15332eedbbc86c18aac81d9e761"
-  integrity sha512-Sg67QklLHM7oTv80RH2PovV4Ps0mjiRrLYzxbsAvDopn73alPvy5uWHtJAHnJc3EYCiBde43L1jOSsGCsOv0Tg==
+"@percy/logger@1.27.4":
+  version "1.27.4"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.27.4.tgz#8d493299e219d971a92052b5998177697191dd05"
+  integrity sha512-AwXqYaDkHaq1TPkP+ByB8rjvH9ddvkAH9tFd2kmq8AeFFXZ0amAPSbm6u090OUtdHWjRmKQK9JjSouBxEh0aRw==
+
+"@percy/sdk-utils@1.27.4":
+  version "1.27.4"
+  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.27.4.tgz#7396d743aa6916ae7fad639b0fa86f206a9b2aca"
+  integrity sha512-vhPcdtmJlvTYJ5VOqiVzo02ujdtBFNw1/Bj+2ybiZgn7PkCDPFcITfXoWWPea319EIibGC4ZHjWHctRBgtW/tQ==
+
+"@percy/webdriver-utils@1.27.4":
+  version "1.27.4"
+  resolved "https://registry.yarnpkg.com/@percy/webdriver-utils/-/webdriver-utils-1.27.4.tgz#35ce3054bcd0a0f21262ab885ee33a51d0df6f0e"
+  integrity sha512-pZOOYns8Fikh2qlbxO16DxFEnCrnFIoLpE7iz4M9jXxOfk16VZF1PWknMChSr5NqG2I9k2OMjizUE2j8zvtl2Q==
+  dependencies:
+    "@percy/config" "1.27.4"
+    "@percy/sdk-utils" "1.27.4"
 
 "@puppeteer/browsers@0.5.0":
   version "0.5.0"
@@ -606,11 +622,6 @@
   version "14.18.29"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.29.tgz#a0c58d67a42f8953c13d32f0acda47ed26dfce40"
   integrity sha512-LhF+9fbIX4iPzhsRLpK5H7iPdvW8L4IwGciXQIOEcuF62+9nw/VQVsOViAOOGxY3OlOKGLFv0sWwJXdwQeTn6A==
-
-"@types/parse-json@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
-  integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
 "@types/resolve@0.0.8":
   version "0.0.8"
@@ -1494,16 +1505,15 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
-cosmiconfig@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-7.0.1.tgz#714d756522cace867867ccb4474c5d01bbae5d6d"
-  integrity sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==
+cosmiconfig@^8.0.0:
+  version "8.3.6"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-8.3.6.tgz#060a2b871d66dba6c8538ea1118ba1ac16f5fae3"
+  integrity sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==
   dependencies:
-    "@types/parse-json" "^4.0.0"
-    import-fresh "^3.2.1"
-    parse-json "^5.0.0"
+    import-fresh "^3.3.0"
+    js-yaml "^4.1.0"
+    parse-json "^5.2.0"
     path-type "^4.0.0"
-    yaml "^1.10.0"
 
 cross-env@7.0.3:
   version "7.0.3"
@@ -2738,7 +2748,7 @@ immutable@^4.0.0:
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.1.0.tgz#f795787f0db780183307b9eb2091fcac1f6fafef"
   integrity sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==
 
-import-fresh@^3.0.0, import-fresh@^3.2.1:
+import-fresh@^3.0.0, import-fresh@^3.2.1, import-fresh@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
   integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
@@ -3977,7 +3987,7 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
-parse-json@^5.0.0:
+parse-json@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.2.0.tgz#c76fc66dee54231c962b22bcc8a72cf2f99753cd"
   integrity sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
@@ -5757,11 +5767,6 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
-
-yaml@^1.10.0:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
-  integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
 yaml@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
This was an attempt to fix Visual Regression tests check for over an hour.
Percy is not broken however, it was stuck due to exceeded quotas.

Somehow the percy upgrade doesn't yield an error anymore though. 

> [percy] Error: This project has exceeded the assigned screenshot limits. Administrators can update limits at:
> https://percy.io/organizations/simplabs-com/mainmatter.com/settings

***

This is a copy of PR https://github.com/mainmatter/mainmatter.com/pull/2192 that was closed by accident and could not be reopened. Originally created by @BobrImperator.