### PR TITLE
 TWIOS 2023-11-12

### DIFF
--- a/config/this-week-in-open-source.config.json
+++ b/config/this-week-in-open-source.config.json
@@ -409,7 +409,9 @@
         "emberobserver/client",
         "emberjs/ember-test-helpers",
         "lan0/ember-power-time-picker",
-        "mixonic/ember-cli-deprecation-workflow"
+        "mixonic/ember-cli-deprecation-workflow",
+        "adopted-ember-addons/ember-cp-validations",
+        "ember-cli/ember-fetch"
       ]
     }
   ],
@@ -488,5 +490,5 @@
   ],
   "exclude_closed_not_merged": true,
   "output_path": "src/twios/",
-  "last_date": ""
+  "last_date": "2023-11-05..2023-11-12"
 }

--- a/config/this-week-in-open-source.config.json
+++ b/config/this-week-in-open-source.config.json
@@ -488,5 +488,5 @@
   ],
   "exclude_closed_not_merged": true,
   "output_path": "src/twios/",
-  "last_date": "2023-10-29..2023-11-05"
+  "last_date": ""
 }

--- a/src/twios/2023-11-12.md
+++ b/src/twios/2023-11-12.md
@@ -1,0 +1,131 @@
+## Rust
+
+- [marcoow/rust_rest] [#28](https://github.com/marcoow/rust_rest/pull/28) Reuse
+  code in db bin ([@marcoow])
+- [marcoow/rust_rest] [#27](https://github.com/marcoow/rust_rest/pull/27) use
+  reset task on ci ([@marcoow])
+
+## Embroider
+
+- [embroider-build/embroider]
+  [#1658](https://github.com/embroider-build/embroider/pull/1658) change
+  release-plan to get publish-stable to run ([@mansona])
+- [embroider-build/embroider]
+  [#1657](https://github.com/embroider-build/embroider/pull/1657) fix the
+  release-stable CI job ([@mansona])
+- [embroider-build/embroider]
+  [#1656](https://github.com/embroider-build/embroider/pull/1656) prepare
+  release ([@mansona])
+- [embroider-build/embroider]
+  [#1655](https://github.com/embroider-build/embroider/pull/1655) fix node
+  version for @embroider/util ([@mansona])
+- [embroider-build/embroider]
+  [#1654](https://github.com/embroider-build/embroider/pull/1654) don't run CI
+  for all branches starting with v ([@mansona])
+- [embroider-build/embroider]
+  [#1653](https://github.com/embroider-build/embroider/pull/1653) Refactor
+  embroider-implicit-modules export pojo ([@mansona])
+
+## JavaScript
+
+- [ember-learn/algolia-index-update-scripts]
+  [#21](https://github.com/ember-learn/algolia-index-update-scripts/pull/21)
+  Setup linting and CI ([@mansona])
+- [ember-learn/algolia-index-update-scripts]
+  [#19](https://github.com/ember-learn/algolia-index-update-scripts/pull/19) add
+  script for deleting tags ([@mansona])
+- [ember-learn/ember-jsonapi-docs]
+  [#136](https://github.com/ember-learn/ember-jsonapi-docs/pull/136) Enable
+  ember-cli project generation ([@mansona])
+- [ember-learn/ember-jsonapi-docs]
+  [#134](https://github.com/ember-learn/ember-jsonapi-docs/pull/134) move from
+  minimist to commander ([@mansona])
+- [storybookjs/storybook]
+  [#24795](https://github.com/storybookjs/storybook/pull/24795) feat: tighter
+  integration with sveltekit ([@paoloricciuti])
+
+## Ember
+
+- [ember-learn/ember-api-docs]
+  [#897](https://github.com/ember-learn/ember-api-docs/pull/897) Enable
+  ember-cli as a real project ([@mansona])
+- [ember-learn/ember-api-docs-data]
+  [#23](https://github.com/ember-learn/ember-api-docs-data/pull/23) Add
+  ember-cli ([@mansona])
+- [lan0/ember-power-time-picker]
+  [#14](https://github.com/lan0/ember-power-time-picker/pull/14) Upgrade
+  vertical collection ([@Mikek2252])
+- [lan0/ember-power-time-picker]
+  [#13](https://github.com/lan0/ember-power-time-picker/pull/13) Upgrade power
+  select ([@Mikek2252])
+- [nickschot/ember-mobile-menu]
+  [#779](https://github.com/nickschot/ember-mobile-menu/pull/779) Replace SCSS
+  with plain CSS approach ([@nickschot])
+- [nickschot/ember-mobile-menu]
+  [#778](https://github.com/nickschot/ember-mobile-menu/pull/778) Convert to v2
+  addon ([@nickschot])
+
+## Unknown
+
+- [adopted-ember-addons/ember-cp-validations]
+  [#749](https://github.com/adopted-ember-addons/ember-cp-validations/pull/749)
+  update @embroider/test-setup to fix CI ([@mansona])
+- [adopted-ember-addons/ember-cp-validations]
+  [#748](https://github.com/adopted-ember-addons/ember-cp-validations/pull/748)
+  fix peer-dependencies ([@mansona])
+- [adopted-ember-addons/ember-cp-validations]
+  [#747](https://github.com/adopted-ember-addons/ember-cp-validations/pull/747)
+  Add compatibility to readme ([@mansona])
+- [adopted-ember-addons/ember-cp-validations]
+  [#746](https://github.com/adopted-ember-addons/ember-cp-validations/pull/746)
+  Remove obsolete config changelog.js and release.js ([@mansona])
+- [adopted-ember-addons/ember-cp-validations]
+  [#745](https://github.com/adopted-ember-addons/ember-cp-validations/pull/745)
+  Don’t use isArray on ember data objects ([@mansona])
+- [adopted-ember-addons/ember-cp-validations]
+  [#744](https://github.com/adopted-ember-addons/ember-cp-validations/pull/744)
+  Remove Ember. from doc strings ([@mansona])
+- [adopted-ember-addons/ember-cp-validations]
+  [#743](https://github.com/adopted-ember-addons/ember-cp-validations/pull/743)
+  bump default ember-data version ([@mansona])
+- [adopted-ember-addons/ember-cp-validations]
+  [#742](https://github.com/adopted-ember-addons/ember-cp-validations/pull/742)
+  update to v4.12 with ember-cli-update ([@mansona])
+- [ember-cli/ember-fetch]
+  [#743](https://github.com/ember-cli/ember-fetch/pull/743) update to v3.28 with
+  ember-cli-update ([@mansona])
+- [ember-cli/ember-fetch]
+  [#742](https://github.com/ember-cli/ember-fetch/pull/742) drop support for
+  node < 16 ([@mansona])
+- [mainmatter/svelte-workshop]
+  [#5](https://github.com/mainmatter/svelte-workshop/pull/5) Reveal: Convert
+  Basics ([@pichfl])
+- [mainmatter/svelte-workshop]
+  [#4](https://github.com/mainmatter/svelte-workshop/pull/4) Reveal: Convert
+  0-Introduction ([@pichfl])
+- [mainmatter/svelte-workshop]
+  [#3](https://github.com/mainmatter/svelte-workshop/pull/3) Refactor: Add
+  Reveal.js ([@pichfl])
+
+[@mikek2252]: https://github.com/Mikek2252
+[@mansona]: https://github.com/mansona
+[@marcoow]: https://github.com/marcoow
+[@nickschot]: https://github.com/nickschot
+[@paoloricciuti]: https://github.com/paoloricciuti
+[@pichfl]: https://github.com/pichfl
+[adopted-ember-addons/ember-cp-validations]:
+  https://github.com/adopted-ember-addons/ember-cp-validations
+[ember-cli/ember-fetch]: https://github.com/ember-cli/ember-fetch
+[ember-learn/algolia-index-update-scripts]:
+  https://github.com/ember-learn/algolia-index-update-scripts
+[ember-learn/ember-api-docs-data]:
+  https://github.com/ember-learn/ember-api-docs-data
+[ember-learn/ember-api-docs]: https://github.com/ember-learn/ember-api-docs
+[ember-learn/ember-jsonapi-docs]:
+  https://github.com/ember-learn/ember-jsonapi-docs
+[embroider-build/embroider]: https://github.com/embroider-build/embroider
+[lan0/ember-power-time-picker]: https://github.com/lan0/ember-power-time-picker
+[mainmatter/svelte-workshop]: https://github.com/mainmatter/svelte-workshop
+[marcoow/rust_rest]: https://github.com/marcoow/rust_rest
+[nickschot/ember-mobile-menu]: https://github.com/nickschot/ember-mobile-menu
+[storybookjs/storybook]: https://github.com/storybookjs/storybook

--- a/src/twios/2023-11-12.md
+++ b/src/twios/2023-11-12.md
@@ -46,27 +46,6 @@
 
 ## Ember
 
-- [ember-learn/ember-api-docs]
-  [#897](https://github.com/ember-learn/ember-api-docs/pull/897) Enable
-  ember-cli as a real project ([@mansona])
-- [ember-learn/ember-api-docs-data]
-  [#23](https://github.com/ember-learn/ember-api-docs-data/pull/23) Add
-  ember-cli ([@mansona])
-- [lan0/ember-power-time-picker]
-  [#14](https://github.com/lan0/ember-power-time-picker/pull/14) Upgrade
-  vertical collection ([@Mikek2252])
-- [lan0/ember-power-time-picker]
-  [#13](https://github.com/lan0/ember-power-time-picker/pull/13) Upgrade power
-  select ([@Mikek2252])
-- [nickschot/ember-mobile-menu]
-  [#779](https://github.com/nickschot/ember-mobile-menu/pull/779) Replace SCSS
-  with plain CSS approach ([@nickschot])
-- [nickschot/ember-mobile-menu]
-  [#778](https://github.com/nickschot/ember-mobile-menu/pull/778) Convert to v2
-  addon ([@nickschot])
-
-## Unknown
-
 - [adopted-ember-addons/ember-cp-validations]
   [#749](https://github.com/adopted-ember-addons/ember-cp-validations/pull/749)
   update @embroider/test-setup to fix CI ([@mansona])
@@ -97,6 +76,27 @@
 - [ember-cli/ember-fetch]
   [#742](https://github.com/ember-cli/ember-fetch/pull/742) drop support for
   node < 16 ([@mansona])
+- [ember-learn/ember-api-docs]
+  [#897](https://github.com/ember-learn/ember-api-docs/pull/897) Enable
+  ember-cli as a real project ([@mansona])
+- [ember-learn/ember-api-docs-data]
+  [#23](https://github.com/ember-learn/ember-api-docs-data/pull/23) Add
+  ember-cli ([@mansona])
+- [lan0/ember-power-time-picker]
+  [#14](https://github.com/lan0/ember-power-time-picker/pull/14) Upgrade
+  vertical collection ([@Mikek2252])
+- [lan0/ember-power-time-picker]
+  [#13](https://github.com/lan0/ember-power-time-picker/pull/13) Upgrade power
+  select ([@Mikek2252])
+- [nickschot/ember-mobile-menu]
+  [#779](https://github.com/nickschot/ember-mobile-menu/pull/779) Replace SCSS
+  with plain CSS approach ([@nickschot])
+- [nickschot/ember-mobile-menu]
+  [#778](https://github.com/nickschot/ember-mobile-menu/pull/778) Convert to v2
+  addon ([@nickschot])
+
+## Unknown
+
 - [mainmatter/svelte-workshop]
   [#5](https://github.com/mainmatter/svelte-workshop/pull/5) Reveal: Convert
   Basics ([@pichfl])


### PR DESCRIPTION
Using this-week-in-open-source v0.5.1


- TWIOS_PATH src/twios/
- TWIOS_DATE 2023-11-05..2023-11-12
- TWIOS_UNLABELLED
  - [adopted-ember-addons/ember-cp-validations] Ember @mansona
  - [ember-cli/ember-fetch] Ember @mansona
  - [mainmatter/svelte-workshop] UNKNOWN @pichfl

Change repo category to `EXCLUDED` in order to permantently ignore it from TWIOS from now on.