### PR TITLE
Shorter CTA for Rust

### DIFF
--- a/src/components/global/rust-cta.njk
+++ b/src/components/global/rust-cta.njk
@@ -5,8 +5,7 @@ A call-to-action meant to be displayed at the beginning of a blog post.
 #}
 <div class="blog-cta" data-background-color="purple">
   <h4 class="h4">
-    If you're looking to adopt Rust to develop web backends and need guidance along the way, 
-    reach out!
+    If need expert support for a Rust project, reach out!
   </h4>
   <p>
     We can help with <a href="/rust-consulting/" class="plausible-event-name=Rust+Consulting">mentoring, training, team augmentation, and custom development</a>.</p>

--- a/src/components/global/rust-cta.njk
+++ b/src/components/global/rust-cta.njk
@@ -10,5 +10,5 @@ A call-to-action meant to be displayed at the beginning of a blog post.
   <p>
     We can help with <a href="/rust-consulting/" class="plausible-event-name=Rust+Consulting">mentoring, training, team augmentation, and custom development</a>.</p>
   </p>
-  {{ ctaLink("https://calendly.com/luca-palmieri/is-rust-the-right-choice-for-us", "Contact us!", "contact-us plausible-event-name=Rust+Contact") }}
+  {{ ctaLink("https://calendly.com/luca-palmieri/is-rust-the-right-choice-for-us", "Talk to us!", "contact-us plausible-event-name=Rust+Contact") }}
 </div>

--- a/src/components/global/rust-cta.njk
+++ b/src/components/global/rust-cta.njk
@@ -5,10 +5,10 @@ A call-to-action meant to be displayed at the beginning of a blog post.
 #}
 <div class="blog-cta" data-background-color="purple">
   <h4 class="h4">
-    If need expert support for a Rust project, reach out!
+    Are you on a Rust journey?
   </h4>
   <p>
     We can help with <a href="/rust-consulting/" class="plausible-event-name=Rust+Consulting">mentoring, training, team augmentation, and custom development</a>.</p>
   </p>
-  {{ ctaLink("/contact/", "Contact us!", "contact-us plausible-event-name=Rust+Contact") }}
+  {{ ctaLink("https://calendly.com/luca-palmieri/is-rust-the-right-choice-for-us", "Contact us!", "contact-us plausible-event-name=Rust+Contact") }}
 </div>


### PR DESCRIPTION
It feels like our Rust CTA is too verbose at the moment.
I reworded it to reduce the amount of screen real estate dedicated to the CTA: 

<img width="405" alt="image" src="https://github.com/mainmatter/mainmatter.com/assets/20745048/df919f87-e0b1-4a85-b609-a19156dba9b3">

I've also changed the "contact us" to go straight to the Calendly link: lower friction than having to fill a form and we're not getting too many inbounds at the moment. If it gets spammy, we can adapt.