### PR TITLE
Add workshop teasers to blog posts

### DIFF
--- a/src/assets/css/components/_blog-cta.scss
+++ b/src/assets/css/components/_blog-cta.scss
@@ -33,4 +33,8 @@
   h4 {
     margin-top: 0;
   }
+
+  .blog-cta_content {
+    margin-bottom: 1rem;
+  }
 }

--- a/src/components/global/git-workshop-cta.njk
+++ b/src/components/global/git-workshop-cta.njk
@@ -1,0 +1,14 @@
+{% from "cta-link.njk" import ctaLink %}
+
+{#
+A call-to-action meant to be displayed at the beginning of a blog post.
+#}
+<div class="blog-cta" data-background-color="purple">
+  <h4 class="h4">
+    Struggling with Git?
+  </h4>
+  <p>
+    We help teams master Git and end the struggle with our 1 day Git workshop.
+  </p>
+  {{ ctaLink("/services/workshops/effective-git/", "Book Workshop", "contact-us plausible-event-name=Git+Post+Workshop") }}
+</div>

--- a/src/components/global/git-workshop-cta.njk
+++ b/src/components/global/git-workshop-cta.njk
@@ -7,7 +7,7 @@ A call-to-action meant to be displayed at the beginning of a blog post.
   <h4 class="h4">
     Struggling with Git?
   </h4>
-  <p>
+  <p class="blog-cta_content">
     We help teams master Git and end the struggle with our 1 day Git workshop.
   </p>
   {{ ctaLink("/services/workshops/effective-git/", "Book Workshop", "contact-us plausible-event-name=Git+Post+Workshop") }}

--- a/src/components/global/interface-inventory-workshop-cta.njk
+++ b/src/components/global/interface-inventory-workshop-cta.njk
@@ -1,0 +1,14 @@
+{% from "cta-link.njk" import ctaLink %}
+
+{#
+A call-to-action meant to be displayed at the beginning of a blog post.
+#}
+<div class="blog-cta" data-background-color="purple">
+  <h4 class="h4">
+    Looking to move towards a design system?
+  </h4>
+  <p>
+    We help teams create an interface inventory and start their journey towards a design system with our design system kickoff workshop.
+  </p>
+  {{ ctaLink("/services/workshops/design-system-kickoff-interface-inventory/", "Book Workshop", "contact-us plausible-event-name=Interface+Inventory+Post+Workshop") }}
+</div>

--- a/src/components/global/interface-inventory-workshop-cta.njk
+++ b/src/components/global/interface-inventory-workshop-cta.njk
@@ -7,7 +7,7 @@ A call-to-action meant to be displayed at the beginning of a blog post.
   <h4 class="h4">
     Looking to move towards a design system?
   </h4>
-  <p>
+  <p class="blog-cta_content">
     We help teams create an interface inventory and start their journey towards a design system with our design system kickoff workshop.
   </p>
   {{ ctaLink("/services/workshops/design-system-kickoff-interface-inventory/", "Book Workshop", "contact-us plausible-event-name=Interface+Inventory+Post+Workshop") }}

--- a/src/posts/2021-05-26-keeping-a-clean-git-history.md
+++ b/src/posts/2021-05-26-keeping-a-clean-git-history.md
@@ -13,6 +13,8 @@ tagline: |
   <p>This post is designed to help you form a solid mental model while working with Git both professionally and in an open source project, and how to ensure you are following best practices to make the process easier for everyone.</p>
 ---
 
+{% include "global/git-workshop-cta.njk" %}
+
 This topic was inspired by some of my pairing sessions with my colleague
 [Tobias Bieniek](https://twitter.com/tobiasbieniek) and the concepts laid out in
 this post have become invaluable to me while working with open source
@@ -341,5 +343,4 @@ merging, squashing, and rebasing.
 While everything in this post is completely optional, I hope that you can see
 the benefits and maybe adopt some of the ideas in your own workflow.
 
-If you need help with any of these topics or if you have questions we encourage
-you to [contact us](https://mainmatter.com/contact/)!
+{% include "global/git-workshop-cta.njk" %}

--- a/src/posts/2021-06-02-how-to-create-an-interface-inventory.md
+++ b/src/posts/2021-06-02-how-to-create-an-interface-inventory.md
@@ -10,6 +10,8 @@ tagline: |
   <p>Are you struggling with a messy interface? Is your digital product full of inconsistencies? Are your designers and developers having a hard time aligning on how to evolve your UI?</p> <p>If so, consider creating an interface inventory. It is a small but powerful step towards a homogenous, pattern-based digital design strategy.</p>
 ---
 
+{% include "global/interface-inventory-workshop-cta.njk" %}
+
 ## Interface inventories 101
 
 An interface inventory is a categorized collection of every piece of design that
@@ -226,3 +228,5 @@ and audit on your own, you are never alone. Consider joining the
 place to ask questions or get feedback regarding this process), or
 [hire a facilitator](/services/workshops/design-system-kickoff-interface-inventory/)
 to help make this project a success.
+
+{% include "global/interface-inventory-workshop-cta.njk" %}


### PR DESCRIPTION
This adds teasers to related workshops to 2 relatively successful blog posts about git and design systems.

![Bildschirmfoto 2024-01-10 um 10 20 57](https://github.com/mainmatter/mainmatter.com/assets/1510/148ec28a-6e28-47fc-909f-d0f2d3507749)
![Bildschirmfoto 2024-01-10 um 10 21 15](https://github.com/mainmatter/mainmatter.com/assets/1510/3f516d63-bd68-43db-ae4b-ce8831b85d70)
