### PR TITLE
Add workshop info to Rust Nation calendar entry

### DIFF
--- a/src/calendar/2024-03-26-rust-nation.md
+++ b/src/calendar/2024-03-26-rust-nation.md
@@ -11,4 +11,5 @@ Rust Nation is the first UK conference dedicated to the Rust language. It will
 be held in London on March 26th to 28th. Mainmatter's Principal Engineering
 Consultant Luca Palmieri will discuss the current state of Rust's web ecosystem
 and the reasons for starting pavex, a new Rust framework for building APIs, in
-his talk.
+his talk. Luca will also host the expert workshop "Testing for Rust projects:
+going beyond the basics" on the first day of the conference.

--- a/src/calendar/2024-03-26-rust-nation.md
+++ b/src/calendar/2024-03-26-rust-nation.md
@@ -12,4 +12,4 @@ be held in London on March 26th to 28th. Mainmatter's Principal Engineering
 Consultant Luca Palmieri will discuss the current state of Rust's web ecosystem
 and the reasons for starting pavex, a new Rust framework for building APIs, in
 his talk. Luca will also host the expert workshop "Testing for Rust projects:
-going beyond the basics" on the first day of the conference.
+going beyond the basics".


### PR DESCRIPTION
Add info about Luca's workshop at Rust Nation.

<img width="653" alt="Screenshot 2024-01-10 at 16 15 58" src="https://github.com/mainmatter/mainmatter.com/assets/83696750/c0103f68-0c0d-4411-8c34-d611706a4855">