### PR TITLE
Sort blog tags in select box

### DIFF
--- a/src/components/global/tag-filter.njk
+++ b/src/components/global/tag-filter.njk
@@ -4,7 +4,7 @@
     <label class="tag-filter__label h5" for="tag-select">Filter by:</label>
     <select class="tag-filter__select" name="tag-filter" id="tag-select" data-select>
       <option value="/blog/" {% if paged.tag == false %} selected{% endif %}>All tags</option>
-      {% set allTags = collections.tags | getCollectionKeys() %}
+      {% set allTags = collections.tags | getCollectionKeys() | sort() %}
       {% for tag in allTags %}
         {% set targetUrl = "/blog/tag/" + tag + "/" %}
         {% set isCurrentPage = targetUrl == page.url %}


### PR DESCRIPTION
This sorts the tags in the select box on the blog landing page alphabetically:

| Before | After |
|--------|------|
| ![Bildschirmfoto 2024-01-12 um 10 07 03](https://github.com/mainmatter/mainmatter.com/assets/1510/92aa1727-493e-4902-830a-6b1f61c97163) | ![Bildschirmfoto 2024-01-12 um 10 07 17](https://github.com/mainmatter/mainmatter.com/assets/1510/0e70c191-c2fb-4bc4-9ac6-b1628a16e5d7) |
