### PR TITLE
redirect old Svelte workshop landing page to regular workshop

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -156,12 +156,11 @@
   from = "/services/workshops/web-based-services-in-rust"
   to = "/services/workshops/build-production-ready-apis-in-rust/"
 
-# serve "Svelte & SvelteKit" landing page for svelte-sveltekit-workshop.mainmatter.com
+# redirect old "Svelte & SvelteKit" landing page to regular workshop
 [[redirects]]
   from = "https://svelte-sveltekit-workshop.mainmatter.com/"
-  to = "https://mainmatter.com/svelte-sveltekit-workshop/"
+  to = "https://mainmatter.com/services/workshops/svelte-and-sveltekit/"
   force = true
-  status = 200
 
 # serve "Telemetry for Rust applications" landing page for rust-telemetry-workshop.mainmatter.com
 [[redirects]]


### PR DESCRIPTION
…since the workshop is over now