### PR TITLE
redirect Rust Telemetry workshop landing page to regular workshop

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -163,12 +163,11 @@
   force = true
   status = 200
 
-# serve "Telemetry for Rust applications" landing page for rust-telemetry-workshop.mainmatter.com
+# redirect "Telemetry for Rust applications" landing page to regular workshop
 [[redirects]]
   from = "https://rust-telemetry-workshop.mainmatter.com/"
-  to = "https://mainmatter.com/rust-application-telemetry-workshop/"
+  to = "https://mainmatter.com/services/workshops/telemetry-for-rust-apis/"
   force = true
-  status = 200
 
 # serve 404 for all paths that don't exist
 [[redirects]]


### PR DESCRIPTION
…since the workshop is over now