### PR TITLE
fix text on Svelte landing page

### DIFF
--- a/src/svelte-consulting.njk
+++ b/src/svelte-consulting.njk
@@ -27,7 +27,7 @@ og:
       <h1 class="color-hero__title color-hero__title--full ">Svelte is the future of frontend development</h1>
       <div class="color-hero__text color-hero__text--large">
         <p>Svelte combines a leading developer experience with performance and maintainability. With SvelteKit and its progressive enhancement capabilities, it's a fit for a wide range of use cases.</p>
-        <p>Mainmatter is here to empower your team to fully realize those benefits in your web and backend projects.</p>
+        <p>Mainmatter is here to empower your team to fully realize Svelte's benefits in your projects.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
This was copied over from the Rust landing page and mentions "backend projects" which obviously doesn't make sense for Svelte…