### PR TITLE
Fix animated GIFs

### DIFF
--- a/utils/transforms/contentParser.js
+++ b/utils/transforms/contentParser.js
@@ -135,7 +135,7 @@ module.exports = function (value, outputPath) {
 
         let formats = ["webp", imageData.fileType];
         if (imageData.fileType === "gif") {
-          formats = ["webp"];
+          formats = ["gif"];
         }
 
         let url = "./static" + imageData.src;


### PR DESCRIPTION
Anim GIFs are currently broken on the entire site, such as inside @BobrImperator 's [post](https://mainmatter.com/blog/2021/12/08/validations-in-ember-apps/). This might not be the actual fix, because AFAIK WebP images can be animated, too, but for some reason I could't make it work. Maybe someone with more experience with Eleventy configs can?

Another issue: even if I managed to output anim GIFs _locally_, it refused to work when deployed to Netlify. Guessing it's a caching issue? Nevertheless, this is something to be aware of, so at the very least the solution should be found on a local setup first, before wasting time with Netlify (which I did).

cc @marcoow 