### PR TITLE
fix link color

### DIFF
--- a/src/assets/css/components/_cta-banner.scss
+++ b/src/assets/css/components/_cta-banner.scss
@@ -76,6 +76,10 @@
 .cta-banner__text,
 .cta-banner__link {
   margin-top: 2.5rem;
+
+  a {
+    color: var(--color-white);
+  }
 }
 
 .cta-banner__eyebrow {

--- a/src/assets/css/components/_event-cards.scss
+++ b/src/assets/css/components/_event-cards.scss
@@ -5,8 +5,6 @@
   margin-bottom: 5rem;
 }
 
-
-
 .event-card {
   position: relative;
   display: flex;
@@ -26,17 +24,22 @@
     --color-link-primary-hover: var(--color-purple);
   }
 
-  &+& {
+  & + & {
     margin-top: 2.5rem;
   }
 }
-
 
 .event-card__content-wrapper {
   padding: 2.5rem;
   display: flex;
   flex-direction: column;
   align-items: start;
+}
+
+.event-card__description {
+  a {
+    color: var(--color-white);
+  }
 }
 
 .event-card__image {
@@ -63,7 +66,7 @@
   }
 
   .event-card {
-    &+& {
+    & + & {
       margin-top: 0;
     }
   }
@@ -77,5 +80,4 @@
   .event-card__content-wrapper {
     padding: 5rem;
   }
-
 }


### PR DESCRIPTION
There are still some bugs regarding the link color on colored bg boxes:

<img width="1382" alt="Screenshot 2024-05-07 at 11 40 26" src="https://github.com/mainmatter/mainmatter.com/assets/39055470/44e83e14-5c7a-4912-9799-eecd4144a586">
<img width="1382" alt="Screenshot 2024-05-07 at 11 40 45" src="https://github.com/mainmatter/mainmatter.com/assets/39055470/8034929d-daad-419c-b0fb-8592739fdb55">

This fixes the issue for the ones in blog posts cta banners and on event cards