### PR TITLE
Update workshop.njk

### DIFF
--- a/src/components/layouts/workshop.njk
+++ b/src/components/layouts/workshop.njk
@@ -67,9 +67,7 @@ layout: "base"
               <p class="author__title large">{{ lead.title }}</p>
             </div>
           </div>
-          <div
-            class="author__details mt-3 author__details--full-width"
-          >
+          <div class="author__details mt-3 author__details--full-width">
             <p>{{ lead.bio | safe }}</p>
           </div>
         </div>

--- a/src/components/layouts/workshop.njk
+++ b/src/components/layouts/workshop.njk
@@ -68,7 +68,7 @@ layout: "base"
             </div>
           </div>
           <div
-            class="author__details mt-3 {% if lead.bio.length > 200 %}author__details--full-width{% endif %} "
+            class="author__details mt-3 author__details--full-width"
           >
             <p>{{ lead.bio | safe }}</p>
           </div>


### PR DESCRIPTION
Currently the width of an workshop author description is based on the amount of characters(?)

If there are different lengths of descriptions, this results in looking weird:

<img width="1131" alt="Screenshot 2024-05-10 at 17 55 43" src="https://github.com/mainmatter/mainmatter.com/assets/39055470/db3c75b7-7362-4df7-aed5-0e4de039a643">

This PR removes the if character amount condition