### PR TITLE
move cta from post to layout

### DIFF
--- a/src/components/global/interface-inventory-workshop-cta.njk
+++ b/src/components/global/interface-inventory-workshop-cta.njk
@@ -6,7 +6,7 @@ A call-to-action meant to be displayed at the beginning of a blog post.
   set content = {
   "title": "Looking to move towards a design system?",
   "text": "We help teams create an interface inventory and start their journey towards a design system with our design system kickoff workshop.",
-  "linkUrl": "/services/workshops/design-system-kickoff-interface-inventory/",
+  "linkUrl": "/services/workshops/design-system-kickoff-interface-inventory",
   "linkText": "Book workshop!"
   }
 %}

--- a/src/components/service-cta.njk
+++ b/src/components/service-cta.njk
@@ -10,6 +10,12 @@
       {% if tag === "ember" %}
         {% include "global/ember-cta.njk" %}
       {% endif %}
+      {% if tag === "git" %}
+        {% include "global/git-workshop-cta.njk" %}
+      {% endif %}
+      {% if tag === "design" %}
+        {% include "global/interface-inventory-workshop-cta.njk" %}
+      {% endif %}
     {% endfor %}
   {% endif %}
 {%- endmacro -%}

--- a/src/posts/2021-05-26-keeping-a-clean-git-history.md
+++ b/src/posts/2021-05-26-keeping-a-clean-git-history.md
@@ -1,7 +1,7 @@
 ---
 title: "Git Good - The magic of keeping a clean Git history"
 authorHandle: real_ate
-tags: misc
+tags: [git, misc]
 bio: "Senior Software Engineer, Ember Learning Core Team member"
 description: |
   Chris Manson goes into detail about the benefits of a clean git history and
@@ -12,8 +12,6 @@ og:
 tagline: |
   <p>This post is designed to help you form a solid mental model while working with Git both professionally and in an open source project, and how to ensure you are following best practices to make the process easier for everyone.</p>
 ---
-
-{% include "global/git-workshop-cta.njk" %}
 
 This topic was inspired by some of my pairing sessions with my colleague
 [Tobias Bieniek](https://twitter.com/tobiasbieniek) and the concepts laid out in
@@ -343,4 +341,4 @@ merging, squashing, and rebasing.
 While everything in this post is completely optional, I hope that you can see
 the benefits and maybe adopt some of the ideas in your own workflow.
 
-{% include "global/git-workshop-cta.njk" %}
+

--- a/src/posts/2021-05-26-keeping-a-clean-git-history.md
+++ b/src/posts/2021-05-26-keeping-a-clean-git-history.md
@@ -340,5 +340,3 @@ merging, squashing, and rebasing.
 
 While everything in this post is completely optional, I hope that you can see
 the benefits and maybe adopt some of the ideas in your own workflow.
-
-

--- a/src/posts/2021-06-02-how-to-create-an-interface-inventory.md
+++ b/src/posts/2021-06-02-how-to-create-an-interface-inventory.md
@@ -226,4 +226,3 @@ and audit on your own, you are never alone. Consider joining the
 place to ask questions or get feedback regarding this process), or
 [hire a facilitator](/services/workshops/design-system-kickoff-interface-inventory/)
 to help make this project a success.
-

--- a/src/posts/2021-06-02-how-to-create-an-interface-inventory.md
+++ b/src/posts/2021-06-02-how-to-create-an-interface-inventory.md
@@ -1,7 +1,7 @@
 ---
 title: "How to create an interface inventory"
 authorHandle: msmarhigh
-tags: process
+tags: process design
 bio: "Director of Product Design"
 description: "Mar High on how to create an interface inventory"
 og:
@@ -9,8 +9,6 @@ og:
 tagline: |
   <p>Are you struggling with a messy interface? Is your digital product full of inconsistencies? Are your designers and developers having a hard time aligning on how to evolve your UI?</p> <p>If so, consider creating an interface inventory. It is a small but powerful step towards a homogenous, pattern-based digital design strategy.</p>
 ---
-
-{% include "global/interface-inventory-workshop-cta.njk" %}
 
 ## Interface inventories 101
 
@@ -229,4 +227,3 @@ place to ask questions or get feedback regarding this process), or
 [hire a facilitator](/services/workshops/design-system-kickoff-interface-inventory/)
 to help make this project a success.
 
-{% include "global/interface-inventory-workshop-cta.njk" %}

--- a/src/posts/2021-06-02-how-to-create-an-interface-inventory.md
+++ b/src/posts/2021-06-02-how-to-create-an-interface-inventory.md
@@ -1,7 +1,7 @@
 ---
 title: "How to create an interface inventory"
 authorHandle: msmarhigh
-tags: process design
+tags: [process, design]
 bio: "Director of Product Design"
 description: "Mar High on how to create an interface inventory"
 og:


### PR DESCRIPTION
Luca noticed that there's something broken with Chris' git blog post:

![Screenshot_2024-05-14-17-25-51-24_e4424258c8b8649f6e67d283a50a2cbc](https://github.com/mainmatter/mainmatter.com/assets/39055470/995b5736-da4f-4af5-92f8-eeb776c79e3f)

This seems to occur when a global cta is placed inside of the blog content file, so I added a condition for git and design to have those two topic specific ctas in the post layout instead of the post itself

