### PR TITLE
fix(this-week): job failed to edit category

### DIFF
--- a/src/twios/2024-05-26.md
+++ b/src/twios/2024-05-26.md
@@ -76,9 +76,6 @@
 - [embroider-build/github-changelog]
   [#23](https://github.com/embroider-build/github-changelog/pull/23) only
   process commits on the current branch ([@mansona])
-
-## Unknown
-
 - [embroider-build/app-blueprint]
   [#15](https://github.com/embroider-build/app-blueprint/pull/15) schedule CI to
   run once a day ([@mansona])


### PR DESCRIPTION
There's still "Unknown" category because the job failed.
edit job failed here: https://github.com/mainmatter/mainmatter.com/pull/2421 