### PR TITLE
exclude source maps from Gravity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         run: pnpm build
 
       - name: Run Gravity
-        run: npm run gravityci "dist/**/*"
+        run: npm run gravityci "dist/**/!(*.js.map)"
         env:
           GRAVITY_TOKEN: ${{ secrets.GRAVITY_TOKEN }}
           GRAVITY_HOST: ${{ vars.GRAVITY_HOST }}


### PR DESCRIPTION
…since we don't really care how big those are