### PR TITLE
feat: add newsletter-signup id for signup form

### DIFF
--- a/src/components/cta-banner.njk
+++ b/src/components/cta-banner.njk
@@ -22,7 +22,12 @@
           <div class="cta-banner__text">{{ content.text | safe }}</div>
         {% endif %}
         {% if content.newsletterSignup %}
-          <form action="{{ content.newsletterSignupAction }}" method="post" target="_blank">
+          <form
+            id="newsletter-signup"
+            action="{{ content.newsletterSignupAction }}"
+            method="post"
+            target="_blank"
+          >
             <div class="contact-form__field cta__input mb-2 mt-2">
               <input
                 class="contact-form__input"


### PR DESCRIPTION
- Adds an `id=newsletter-signup` attribute to the `cta-banner` form.

![image](https://github.com/mainmatter/mainmatter.com/assets/15948633/e80055e3-6474-4cb4-abef-70e483822a1f)
