### PR TITLE
Standardize media query breakpoints with scss

### DIFF
--- a/src/assets/css/base/_global.scss
+++ b/src/assets/css/base/_global.scss
@@ -1,45 +1,126 @@
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-	margin: 0;
-	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-	vertical-align: baseline;
+html,
+body,
+div,
+span,
+applet,
+object,
+iframe,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p,
+blockquote,
+pre,
+a,
+abbr,
+acronym,
+address,
+big,
+cite,
+code,
+del,
+dfn,
+em,
+img,
+ins,
+kbd,
+q,
+s,
+samp,
+small,
+strike,
+strong,
+sub,
+sup,
+tt,
+var,
+b,
+u,
+i,
+center,
+dl,
+dt,
+dd,
+ol,
+ul,
+li,
+fieldset,
+form,
+label,
+legend,
+table,
+caption,
+tbody,
+tfoot,
+thead,
+tr,
+th,
+td,
+article,
+aside,
+canvas,
+details,
+embed,
+figure,
+figcaption,
+footer,
+header,
+hgroup,
+menu,
+nav,
+output,
+ruby,
+section,
+summary,
+time,
+mark,
+audio,
+video {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  font-size: 100%;
+  font: inherit;
+  vertical-align: baseline;
 }
 /* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-	display: block;
+article,
+aside,
+details,
+figcaption,
+figure,
+footer,
+header,
+hgroup,
+menu,
+nav,
+section {
+  display: block;
 }
 body {
-	line-height: 1;
+  line-height: 1;
 }
-ol, ul {
-	list-style: none;
+ol,
+ul {
+  list-style: none;
 }
-blockquote, q {
-	quotes: none;
+blockquote,
+q {
+  quotes: none;
 }
-blockquote:before, blockquote:after,
-q:before, q:after {
-	content: '';
-	content: none;
+blockquote:before,
+blockquote:after,
+q:before,
+q:after {
+  content: "";
+  content: none;
 }
 table {
-	border-collapse: collapse;
-	border-spacing: 0;
+  border-collapse: collapse;
+  border-spacing: 0;
 }
 
 *,
@@ -95,7 +176,8 @@ a {
   text-decoration: none;
   font-weight: 700;
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     text-decoration: underline;
     text-decoration-thickness: 0.125rem;
     text-underline-offset: 0.25rem;
@@ -116,8 +198,7 @@ button {
   }
 }
 
-
-@media (min-width: 72em) {
+@media (min-width: $breakpoint-l) {
   body {
     line-height: 2;
     font-size: 1.125rem;

--- a/src/assets/css/base/_utility.scss
+++ b/src/assets/css/base/_utility.scss
@@ -51,14 +51,14 @@
   &t-10 {
     margin-top: 5rem;
 
-    @media (min-width: 48rem) {
+    @media (min-width: $breakpoint-s) {
       margin-top: 10rem;
     }
   }
   &t-15 {
     margin-top: 5rem;
 
-    @media (min-width: 48rem) {
+    @media (min-width: $breakpoint-s) {
       margin-top: 15rem;
     }
   }
@@ -86,14 +86,14 @@
   &b-10 {
     margin-bottom: 5rem;
 
-    @media (min-width: 48rem) {
+    @media (min-width: $breakpoint-s) {
       margin-bottom: 10rem;
     }
   }
   &b-15 {
     margin-bottom: 5rem;
 
-    @media (min-width: 48rem) {
+    @media (min-width: $breakpoint-s) {
       margin-bottom: 15rem;
     }
   }
@@ -121,14 +121,14 @@
   &y-10 {
     margin: 5rem auto;
 
-    @media (min-width: 48rem) {
+    @media (min-width: $breakpoint-s) {
       margin: 10rem auto;
     }
   }
   &y-15 {
     margin: 5rem auto;
 
-    @media (min-width: 48rem) {
+    @media (min-width: $breakpoint-s) {
       margin: 15rem auto;
     }
   }

--- a/src/assets/css/base/_variables.scss
+++ b/src/assets/css/base/_variables.scss
@@ -8,7 +8,7 @@
   --color-light-gray: #cfcece;
   --color-offwhite: #eeeeee;
   --color-white: #ffffff;
-  --color-red: #E04E39;
+  --color-red: #e04e39;
 
   --color-simplabs-blue: #007df6;
 
@@ -21,3 +21,8 @@
 
   --font-base: "Core Sans A", sans-serif;
 }
+
+$breakpoint-s: 48em;
+$breakpoint-m: 62em;
+$breakpoint-l: 72em;
+$breakpoint-xl: 80em;

--- a/src/assets/css/components/_author-header.scss
+++ b/src/assets/css/components/_author-header.scss
@@ -27,15 +27,14 @@
   a {
     color: var(--color-white);
 
-    &:hover, &:focus {
+    &:hover,
+    &:focus {
       color: var(--color-aqua);
     }
   }
-
-
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .author-header__wrapper {
     display: flex;
   }

--- a/src/assets/css/components/_author.scss
+++ b/src/assets/css/components/_author.scss
@@ -78,7 +78,7 @@
   color: var(--color-aqua);
 }
 
-@media (min-width: 62em) {
+@media (min-width: $breakpoint-m) {
   .author {
     align-items: center;
   }

--- a/src/assets/css/components/_blog-cta.scss
+++ b/src/assets/css/components/_blog-cta.scss
@@ -4,7 +4,7 @@
   margin-bottom: 3.25rem;
   padding: 3.25rem 1rem;
 
-  @media (min-width: 48em) {
+  @media (min-width: $breakpoint-s) {
     & {
       margin-bottom: 6.25rem;
       padding: 3.5rem 5rem;
@@ -14,7 +14,7 @@
   p + & {
     margin-top: 3.25rem;
 
-    @media (min-width: 48em) {
+    @media (min-width: $breakpoint-s) {
       & {
         margin-top: 6.25rem;
       }

--- a/src/assets/css/components/_case-cards.scss
+++ b/src/assets/css/components/_case-cards.scss
@@ -5,13 +5,13 @@
   margin-top: 2.5rem;
 }
 
-@media (min-width: 48rem) {
+@media (min-width: $breakpoint-s) {
   .case-cards__grid {
     grid-template-columns: 1fr 1fr;
   }
 }
 
-@media (min-width: 72rem) {
+@media (min-width: $breakpoint-l) {
   .case-cards__grid {
     grid-template-columns: 1fr 1fr 1fr;
   }
@@ -31,7 +31,8 @@
   overflow: hidden;
   cursor: pointer;
 
-  a:hover, &:focus {
+  a:hover,
+  &:focus {
     text-decoration: underline;
   }
 
@@ -67,7 +68,8 @@
 }
 
 @media (hover: hover) {
-  .case-cards__grid-element:hover, .case-cards__grid-element:focus {
+  .case-cards__grid-element:hover,
+  .case-cards__grid-element:focus {
     color: var(--color-white);
     cursor: pointer;
 
@@ -170,7 +172,8 @@
   position: relative;
   z-index: 100;
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     cursor: pointer;
     color: var(--color-white);
   }

--- a/src/assets/css/components/_case-study-card.scss
+++ b/src/assets/css/components/_case-study-card.scss
@@ -34,23 +34,23 @@
   visibility: visible;
 }
 
-.case-study-card__link  {
-  &:hover, &:focus {
-      &~.case-study-card__description .case-study-card__client {
-        color: var(--color-aqua);
-      }
+.case-study-card__link {
+  &:hover,
+  &:focus {
+    & ~ .case-study-card__description .case-study-card__client {
+      color: var(--color-aqua);
     }
+  }
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .case-study-card {
     grid-column: span 1 / span 1;
     margin-top: 0;
   }
 
-    .case-study-card__cta {
-      display: none;
-      visibility: hidden;
-    }
+  .case-study-card__cta {
+    display: none;
+    visibility: hidden;
+  }
 }
-

--- a/src/assets/css/components/_case-study.scss
+++ b/src/assets/css/components/_case-study.scss
@@ -13,7 +13,6 @@
 }
 
 .case-study__text {
-
   margin: 0 auto;
   overflow-wrap: break-word;
   word-wrap: break-word;
@@ -32,7 +31,7 @@
   margin-top: 3.5rem;
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .case-study__section {
     margin: 5rem 0 0;
   }

--- a/src/assets/css/components/_client-card.scss
+++ b/src/assets/css/components/_client-card.scss
@@ -25,25 +25,25 @@
 .client-card__link {
   flex-shrink: 0;
 
-      .icon-arrow {
-        transform: translateX(0px) rotate(-90deg);
-        transition: transform 0.5s ease;
-        height: 1.5rem;
-        width: 1.5rem;
-        color: var(--color-purple);
-        margin-left: 0.75rem;
-      }
+  .icon-arrow {
+    transform: translateX(0px) rotate(-90deg);
+    transition: transform 0.5s ease;
+    height: 1.5rem;
+    width: 1.5rem;
+    color: var(--color-purple);
+    margin-left: 0.75rem;
+  }
 
-      &:hover, &:focus {
-        .icon-arrow {
-          transform: translateX(0.5rem) rotate(-90deg);
-          transition: transform 0.5s ease;
-        }
-      }
+  &:hover,
+  &:focus {
+    .icon-arrow {
+      transform: translateX(0.5rem) rotate(-90deg);
+      transition: transform 0.5s ease;
     }
+  }
+}
 
-
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .client-card {
     margin: 0;
   }

--- a/src/assets/css/components/_collection-header.scss
+++ b/src/assets/css/components/_collection-header.scss
@@ -18,7 +18,7 @@
   font-weight: 500;
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .collection-header {
     padding: 10rem 0;
   }

--- a/src/assets/css/components/_color-hero.scss
+++ b/src/assets/css/components/_color-hero.scss
@@ -97,8 +97,7 @@
   margin-top: 2rem;
 }
 
-
-@media (min-width: 64em) {
+@media (min-width: $breakpoint-m) {
   .color-hero__container {
     display: flex;
     position: relative;
@@ -108,7 +107,4 @@
   .color-hero {
     min-height: 100vh;
   }
-
 }
-
-

--- a/src/assets/css/components/_contact-form.scss
+++ b/src/assets/css/components/_contact-form.scss
@@ -80,9 +80,11 @@ $states: "loading", "success", "error";
   top: 0;
   left: 0;
   opacity: 0;
-  font-size: .875rem;
+  font-size: 0.875rem;
   transform: translateY(-0.5rem);
-  transition: opacity 0.3s ease, transform 0.3s ease;
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease;
 }
 
 .contact-form__label-required {
@@ -172,11 +174,11 @@ $states: "loading", "success", "error";
   text-align: center;
   z-index: 1;
   pointer-events: none;
-  transition: background-color 0.3s ease, opacity 0.3s ease;
+  transition:
+    background-color 0.3s ease,
+    opacity 0.3s ease;
   overflow: hidden;
 }
-
-
 
 .contact-form__loading {
   display: none;
@@ -226,12 +228,13 @@ $states: "loading", "success", "error";
     transition: color 0.3s ease;
   }
 
-  &:hover svg, &:focus svg {
+  &:hover svg,
+  &:focus svg {
     color: var(--color-aqua);
   }
 }
 
-@media (min-width: 62em) {
+@media (min-width: $breakpoint-m) {
   .contact-form__main {
     padding: 9rem 0 5rem;
   }

--- a/src/assets/css/components/_contact-info.scss
+++ b/src/assets/css/components/_contact-info.scss
@@ -25,7 +25,7 @@
   gap: 1rem;
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .contact-info {
     padding: 6.25rem 0 1rem;
   }

--- a/src/assets/css/components/_cta-banner.scss
+++ b/src/assets/css/components/_cta-banner.scss
@@ -57,7 +57,7 @@
   padding: 4rem 0 3rem;
 }
 
-@media (min-width: 72rem) {
+@media (min-width: $breakpoint-l) {
   .cta-banner__wrapper {
     display: flex;
     position: relative;
@@ -89,7 +89,7 @@
 .cta__input {
   min-width: 100%;
 }
-@media (min-width: 48rem) {
+@media (min-width: $breakpoint-s) {
   .cta__input {
     min-width: 32rem;
   }

--- a/src/assets/css/components/_embroider-sponsors.scss
+++ b/src/assets/css/components/_embroider-sponsors.scss
@@ -22,7 +22,7 @@
     max-width: 160px;
   }
 
-  @media (min-width: 62em) {
+  @media (min-width: $breakpoint-m) {
     .embroider-sponsor__grid-element {
       max-width: unset;
       display: flex;

--- a/src/assets/css/components/_event-cards.scss
+++ b/src/assets/css/components/_event-cards.scss
@@ -57,7 +57,7 @@
   margin-top: 2rem;
 }
 
-@media (min-width: 64em) {
+@media (min-width: $breakpoint-m) {
   .event-cards {
     display: grid;
     grid-template-columns: 1fr;

--- a/src/assets/css/components/_expertise.scss
+++ b/src/assets/css/components/_expertise.scss
@@ -18,8 +18,8 @@
   width: 19rem;
 }
 
-@media (min-width: 72em) {
+@media (min-width: $breakpoint-l) {
   .expertise__logo {
-      max-width: 18rem;
-    }
+    max-width: 18rem;
+  }
 }

--- a/src/assets/css/components/_featured-case-studies.scss
+++ b/src/assets/css/components/_featured-case-studies.scss
@@ -16,7 +16,7 @@
   gap: 1.5rem;
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-m) {
   .featured-case-studies {
     padding: 5rem 0 11rem;
   }

--- a/src/assets/css/components/_featured-case-study.scss
+++ b/src/assets/css/components/_featured-case-study.scss
@@ -4,6 +4,7 @@
   flex-direction: column;
   align-self: flex-start;
   overflow: hidden;
+  grid-column: 1 / -1;
 
   & + & {
     margin-top: rem-calc(80);
@@ -14,7 +15,8 @@
     transition: transform 0.5s ease;
   }
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     .icon-arrow {
       transform: translateX(0.5rem) rotate(-90deg);
       transition: transform 0.5s ease;
@@ -37,11 +39,12 @@
 
     .featured-case-study--hover {
       transform: translateX(-100%);
-        background: var(--color-purple);
-        transition: transform 0.5s ease;
+      background: var(--color-purple);
+      transition: transform 0.5s ease;
     }
 
-    &:hover, &:focus {
+    &:hover,
+    &:focus {
       .featured-case-study--hover {
         transform: translateX(0px);
         background: var(--color-purple);
@@ -57,7 +60,6 @@
     --color-link-primary: var(--color-white);
     --color-link-primary-hover: var(--color-black);
     color: var(--color-white);
-
   }
 
   &--black {
@@ -79,7 +81,8 @@
       transition: transform 0.5s ease;
     }
 
-    &:hover, &:focus {
+    &:hover,
+    &:focus {
       .featured-case-study--hover {
         transform: translateX(0px);
         background: var(--color-black);
@@ -133,7 +136,6 @@
   object-fit: cover;
   object-position: center;
 }
-
 
 .featured-case-study--hover {
   position: absolute;
@@ -232,19 +234,12 @@
   }
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-m) {
   .featured-case-study {
-    grid-column: span 2 / span 2;
-
     & + & {
       margin-top: 0;
     }
   }
-
-  .featured-case-studies .featured-case-study {
-    grid-column: span 3 / span 3;
-  }
-
 
   .featured-case-study__content-wrapper {
     justify-content: center;
@@ -274,7 +269,6 @@
 
   .featured-case-study__tags {
     align-self: stretch;
-
   }
 
   .featured-case-study__client {
@@ -298,7 +292,7 @@
   }
 }
 
-@media (min-width: 72em) {
+@media (min-width: $breakpoint-l) {
   .featured-case-study__content-wrapper {
     padding: 1.25rem;
   }

--- a/src/assets/css/components/_featured-post.scss
+++ b/src/assets/css/components/_featured-post.scss
@@ -15,7 +15,6 @@
   flex-direction: column;
   align-items: start;
   gap: 1.25rem;
-
 }
 
 .featured-post__container {
@@ -62,7 +61,7 @@
   text-decoration: none;
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .featured-post {
     padding: 10rem 0;
   }
@@ -87,6 +86,5 @@
     span {
       margin-right: 1.5rem;
     }
-
   }
 }

--- a/src/assets/css/components/_featured-services.scss
+++ b/src/assets/css/components/_featured-services.scss
@@ -18,7 +18,8 @@
   }
 }
 
-.featured-services__link:hover, .featured-services__link:focus {
+.featured-services__link:hover,
+.featured-services__link:focus {
   text-decoration: none;
 }
 
@@ -46,7 +47,8 @@
     margin-right: 1.5rem;
   }
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     .featured-services__link-description {
       color: var(--color-purple);
     }
@@ -82,7 +84,7 @@ a.featured-services__link {
   max-width: 45rem;
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .featured-services {
     padding: 7rem 0;
   }

--- a/src/assets/css/components/_footer-menu.scss
+++ b/src/assets/css/components/_footer-menu.scss
@@ -31,7 +31,8 @@
   line-height: 1.4;
   text-decoration: none;
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     text-decoration: underline;
   }
 }
@@ -41,7 +42,7 @@
   color: var(--color-yellow);
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .footer-menu {
     display: block;
   }

--- a/src/assets/css/components/_footer.scss
+++ b/src/assets/css/components/_footer.scss
@@ -31,7 +31,8 @@
   justify-content: flex-start;
   gap: 1rem;
 
-  .social__link:hover, .social__link:focus {
+  .social__link:hover,
+  .social__link:focus {
     color: var(--color-aqua);
   }
 }
@@ -53,7 +54,7 @@
   text-transform: lowercase;
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .footer {
     padding: 4.5rem 0 1.75rem;
   }
@@ -82,7 +83,7 @@
   }
 }
 
-@media (min-width: 72em) {
+@media (min-width: $breakpoint-l) {
   .footer__container {
     flex-direction: row;
     justify-content: space-between;

--- a/src/assets/css/components/_image-aspect-ratio.scss
+++ b/src/assets/css/components/_image-aspect-ratio.scss
@@ -13,7 +13,7 @@
   object-position: center;
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .image-aspect-ratio__wrapper {
     aspect-ratio: var(--aspect-ratio-desktop);
   }

--- a/src/assets/css/components/_image-banner-with-text.scss
+++ b/src/assets/css/components/_image-banner-with-text.scss
@@ -18,7 +18,7 @@
   width: 100%;
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .image-banner-with-text__heading {
     margin-bottom: 3.25rem;
   }

--- a/src/assets/css/components/_image-stacked.scss
+++ b/src/assets/css/components/_image-stacked.scss
@@ -38,7 +38,7 @@
   display: block;
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .image-stacked__image-wrapper {
     width: 40rem;
 

--- a/src/assets/css/components/_logo-list.scss
+++ b/src/assets/css/components/_logo-list.scss
@@ -52,7 +52,8 @@
   display: block;
   text-align: center;
 
-  img, svg {
+  img,
+  svg {
     max-height: 5rem;
   }
 }
@@ -82,7 +83,7 @@
   }
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .logo-list__inner {
     width: calc(var(--marquee-logo-count) * 60%);
   }
@@ -104,13 +105,13 @@
   }
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .logo-list__inner {
     width: calc(var(--marquee-logo-count) * 50%);
   }
 }
 
-@media (min-width: 72em) {
+@media (min-width: $breakpoint-l) {
   .logo-list__inner {
     width: calc(var(--marquee-logo-count) * 35%);
   }
@@ -153,7 +154,7 @@
     visibility: hidden;
   }
 
-  @media (min-width: 80em) {
+  @media (min-width: $breakpoint-xl) {
     .logo-list__inner {
       width: 100%;
     }

--- a/src/assets/css/components/_nav-aside.scss
+++ b/src/assets/css/components/_nav-aside.scss
@@ -35,8 +35,7 @@
   gap: 1rem;
 }
 
-
-@media (min-width: 62em) {
+@media (min-width: $breakpoint-m) {
   .nav-aside {
     padding-bottom: 2rem;
   }
@@ -54,18 +53,18 @@
       height: 1.5rem;
     }
 
-    .social__item+.social__item {
+    .social__item + .social__item {
       margin-left: 0.75rem;
     }
   }
 }
 
-
 @media (hover: hover) {
   .nav-aside__cta {
     transition: background-color ease 0.3s;
 
-    &:hover, &:focus {
+    &:hover,
+    &:focus {
       background-color: var(--color-accent-hover);
     }
   }

--- a/src/assets/css/components/_nav.scss
+++ b/src/assets/css/components/_nav.scss
@@ -61,7 +61,8 @@
   display: inline-block;
   transition: color 0.3s ease;
 
-  &:hover, &:focus  {
+  &:hover,
+  &:focus {
     color: var(--color-aqua);
 
     .nav__link-text {
@@ -87,15 +88,14 @@
 .nav__link-text {
   text-decoration-color: rgba(var(--color-accent), 0);
   text-decoration-thickness: 0.125rem;
-      text-underline-offset: 0.55rem;
+  text-underline-offset: 0.55rem;
   transition: text-decoration-color 0.3s ease;
 
   &--active {
     text-decoration: underline;
     text-decoration-thickness: 0.125rem;
-      text-underline-offset: 0.55rem;
+    text-underline-offset: 0.55rem;
     text-decoration-color: rgba(var(--color-accent), 1);
-
   }
 }
 
@@ -155,8 +155,7 @@
   }
 }
 
-@media (min-width: 62em) {
-
+@media (min-width: $breakpoint-m) {
   .nav {
     width: 100%;
   }

--- a/src/assets/css/components/_next-events.scss
+++ b/src/assets/css/components/_next-events.scss
@@ -11,7 +11,7 @@
   gap: 1.5rem;
 }
 
-@media (min-width: 48rem) {
+@media (min-width: $breakpoint-s) {
   .next-events__list {
     display: grid;
     grid-template-columns: repeat(2, 1fr);
@@ -19,7 +19,7 @@
   }
 }
 
-@media (min-width: 72rem) {
+@media (min-width: $breakpoint-l) {
   .next-events__list {
     grid-template-columns: repeat(3, 1fr);
   }

--- a/src/assets/css/components/_open-source-list.scss
+++ b/src/assets/css/components/_open-source-list.scss
@@ -1,4 +1,3 @@
-
 .opensource-list__list {
   display: grid;
   grid-template-columns: 1fr;
@@ -12,9 +11,9 @@
   width: auto;
 }
 
-@media (min-width: 72rem) {
+@media (min-width: $breakpoint-l) {
   .opensource-list__list {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-}
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+  }
 }

--- a/src/assets/css/components/_policy.scss
+++ b/src/assets/css/components/_policy.scss
@@ -37,7 +37,7 @@
   font-style: normal;
 }
 
-@media (min-width: 72em) {
+@media (min-width: $breakpoint-l) {
   .policy {
     padding: 10rem 0;
 

--- a/src/assets/css/components/_post-banner.scss
+++ b/src/assets/css/components/_post-banner.scss
@@ -9,7 +9,7 @@
   --color-tag: var(--color-purple);
   --spacing: 1rem;
 
-  &+& {
+  & + & {
     margin-top: rem-calc(80);
   }
 }
@@ -118,12 +118,12 @@
   margin: 1.25rem 0 var(--spacing);
 }
 
-@media (min-width: 62em) {
+@media (min-width: $breakpoint-m) {
   .post-banner {
     grid-column: span 3 / span 3;
     --color-tag: var(--color-white);
 
-    &+& {
+    & + & {
       margin-top: 0;
     }
   }
@@ -172,7 +172,7 @@
   }
 }
 
-@media (min-width: 72em) {
+@media (min-width: $breakpoint-l) {
   .post-banner__title {
     font-size: 3.5rem;
     margin-bottom: 0.5rem;

--- a/src/assets/css/components/_post-cards.scss
+++ b/src/assets/css/components/_post-cards.scss
@@ -5,13 +5,13 @@
   margin-top: 2.5rem;
 }
 
-@media (min-width: 48rem) {
+@media (min-width: $breakpoint-s) {
   .post-cards__grid {
     grid-template-columns: 1fr 1fr;
   }
 }
 
-@media (min-width: 72rem) {
+@media (min-width: $breakpoint-l) {
   .post-cards__grid {
     grid-template-columns: 1fr 1fr 1fr;
   }
@@ -32,12 +32,14 @@
 
   cursor: pointer;
 
-  a:hover, &:focus  {
+  a:hover,
+  &:focus {
     text-decoration: underline;
   }
 }
 
-.post-cards__grid-element:hover, .post-cards__grid-element:focus {
+.post-cards__grid-element:hover,
+.post-cards__grid-element:focus {
   color: var(--color-white);
   cursor: pointer;
 
@@ -157,7 +159,8 @@
   position: relative;
   z-index: 100;
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     cursor: pointer;
   }
 }

--- a/src/assets/css/components/_post.scss
+++ b/src/assets/css/components/_post.scss
@@ -7,7 +7,6 @@
   }
 }
 
-
 .post__header {
   background-color: var(--color-purple);
   color: var(--color-white);
@@ -26,8 +25,6 @@
 .post__author-socials a {
   color: var(--color-white);
 }
-
-
 
 .post__author-name {
   font-weight: 500;
@@ -131,7 +128,7 @@
     font-weight: 700;
     margin-top: 3.25rem;
 
-    li+li {
+    li + li {
       margin-top: 1.5rem;
     }
   }
@@ -139,7 +136,6 @@
   li {
     padding: 0.25rem;
   }
-
 }
 
 .post__content {
@@ -152,7 +148,7 @@
   }
 
   li a {
-  color: var(--color-purple);
+    color: var(--color-purple);
   }
 }
 
@@ -172,7 +168,7 @@
   }
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .post {
     margin: 6.25rem auto 8rem;
   }
@@ -182,8 +178,7 @@
   }
 }
 
-
-@media (min-width: 62em) {
+@media (min-width: $breakpoint-m) {
   .post {
     img:not(.image--small):not(.image--full):not(.author__image),
     picture:not(.image--small):not(.image--full),

--- a/src/assets/css/components/_prev-next.scss
+++ b/src/assets/css/components/_prev-next.scss
@@ -13,7 +13,7 @@
   margin-top: 0.5rem;
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .prev-next__title {
     font-size: 1.5rem;
   }

--- a/src/assets/css/components/_quote.scss
+++ b/src/assets/css/components/_quote.scss
@@ -50,7 +50,7 @@
   margin: 0 0 2rem;
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .quote:not(.quote__workshop) {
     margin: 6.25rem auto;
     flex-wrap: nowrap;

--- a/src/assets/css/components/_quotes-list.scss
+++ b/src/assets/css/components/_quotes-list.scss
@@ -1,7 +1,7 @@
 .quotes-list {
   margin: 5rem 0 10rem;
 
-  @media (min-width: 48em) {
+  @media (min-width: $breakpoint-s) {
     & {
       margin: 6.25rem 0;
     }
@@ -11,7 +11,7 @@
     margin: 2rem 0 2.5rem;
     text-align: center;
 
-    @media (min-width: 48em) {
+    @media (min-width: $breakpoint-s) {
       margin: 3.25rem 0;
     }
   }
@@ -20,8 +20,8 @@
     list-style: none;
     margin: 0;
     padding: 0;
-    
-    @media (min-width: 48em) {
+
+    @media (min-width: $breakpoint-s) {
       & {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
@@ -39,7 +39,7 @@
         align-items: center;
         height: 5rem;
         margin-bottom: 0.75rem;
-      
+
         img {
           max-height: 100%;
           width: auto;
@@ -66,7 +66,7 @@
         }
       }
 
-      @media (min-width: 48em) {
+      @media (min-width: $breakpoint-s) {
         & {
           margin: 0;
         }
@@ -74,4 +74,3 @@
     }
   }
 }
-

--- a/src/assets/css/components/_recent-posts.scss
+++ b/src/assets/css/components/_recent-posts.scss
@@ -24,7 +24,7 @@
   gap: 1.5rem;
 }
 
-@media (min-width: 48rem) {
+@media (min-width: $breakpoint-s) {
   .recent-posts__cta {
     text-align: left;
   }
@@ -42,7 +42,7 @@
   }
 }
 
-@media (min-width: 72rem) {
+@media (min-width: $breakpoint-l) {
   .recent-posts__list {
     grid-template-columns: repeat(3, 1fr);
   }

--- a/src/assets/css/components/_rte.scss
+++ b/src/assets/css/components/_rte.scss
@@ -136,12 +136,12 @@
   }
 }
 
-@media (min-width: 48em) {
-  .rte  {
+@media (min-width: $breakpoint-s) {
+  .rte {
     blockquote:not(.quote__text) {
       margin: 4rem 0 3rem;
       padding-left: 3.75rem;
-  
+
       &::before {
         position: absolute;
         left: 0;
@@ -157,7 +157,7 @@
   }
 }
 
-@media (min-width: 72em) {
+@media (min-width: $breakpoint-l) {
   .rte {
     h2 {
       font-size: rem-calc(44);
@@ -168,7 +168,7 @@
     }
 
     blockquote:not(.quote__text) {
-      font-size: 1.5rem;        
+      font-size: 1.5rem;
     }
 
     author {

--- a/src/assets/css/components/_scroll-slides.scss
+++ b/src/assets/css/components/_scroll-slides.scss
@@ -1,4 +1,3 @@
-
 .scroll-slides__slide {
   height: 100vh;
   display: flex;
@@ -34,7 +33,7 @@
     color: var(--color-black);
     --color-link-primary: var(--color-black);
     --color-accent: var(--color-white);
-    --color-default:var(--color-black);
+    --color-default: var(--color-black);
     --color-link-primary-hover: var(--color-white);
   }
 }
@@ -178,9 +177,7 @@
   }
 }
 
-@media (min-width: 48em) and (min-height: 32rem) {
-
-
+@media (min-width: $breakpoint-s) and (min-height: 32rem) {
   .scroll-slides__container {
     gap: 2.5rem;
   }
@@ -194,7 +191,7 @@
   }
 
   .scroll-slides__tag {
-    margin: 0 0 .75rem;
+    margin: 0 0 0.75rem;
   }
 
   .scroll-slides__title {
@@ -216,14 +213,14 @@
   }
 }
 
-@media (min-width: 64em) and (min-height: 32rem) {
+@media (min-width: $breakpoint-m) and (min-height: 32rem) {
   .scroll-slides__title {
     font-size: 4rem;
     line-height: 1.2;
   }
 }
 
-@media (min-width: 78em) and (min-height: 32rem) {
+@media (min-width: $breakpoint-xl) and (min-height: 32rem) {
   .scroll-slides__pagination {
     position: absolute;
     left: -3.5rem;

--- a/src/assets/css/components/_secondary-feature.scss
+++ b/src/assets/css/components/_secondary-feature.scss
@@ -22,10 +22,9 @@
   width: 100%;
 }
 
-@media (min-width: 48rem) {
+@media (min-width: $breakpoint-s) {
   .ember-consultants {
     display: flex;
     flex-direction: column;
   }
 }
-

--- a/src/assets/css/components/_split-content.scss
+++ b/src/assets/css/components/_split-content.scss
@@ -7,7 +7,8 @@
   }
 }
 
-.split-content:not(.no-link):hover, .split-content:not(.no-link):focus {
+.split-content:not(.no-link):hover,
+.split-content:not(.no-link):focus {
   color: var(--color-purple);
 }
 
@@ -31,8 +32,7 @@
   clip-path: circle();
 }
 
-@media (min-width: 48em) {
-
+@media (min-width: $breakpoint-s) {
   .split-content__wrapper {
     display: flex;
     flex-direction: row;
@@ -51,12 +51,10 @@
 
   .split-content__wrapper {
     align-items: center;
-
   }
 
   .split-content__content {
     flex-wrap: nowrap;
-
   }
 
   .split-content__feature {

--- a/src/assets/css/components/_split-quote.scss
+++ b/src/assets/css/components/_split-quote.scss
@@ -70,7 +70,7 @@
   color: var(--color-quote-icon);
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .split-quote {
     flex-direction: row;
   }
@@ -95,7 +95,7 @@
   }
 }
 
-@media (min-width: 62em) {
+@media (min-width: $breakpoint-m) {
   .split-quote__quote {
     grid-template-columns: 3rem auto;
   }

--- a/src/assets/css/components/_startups.scss
+++ b/src/assets/css/components/_startups.scss
@@ -26,7 +26,7 @@
   gap: 1.5rem;
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .startups__featured_posts {
     display: grid;
     grid-template-columns: 1fr 1fr 1fr;

--- a/src/assets/css/components/_strategy-list.scss
+++ b/src/assets/css/components/_strategy-list.scss
@@ -10,11 +10,10 @@
   color: var(--color-purple);
 }
 
-@media (min-width: 72rem) {
+@media (min-width: $breakpoint-l) {
   .strategy-list__wrapper {
     flex-direction: row;
     align-items: center;
-
   }
 
   .strategy-list__number {

--- a/src/assets/css/components/_tag-filter.scss
+++ b/src/assets/css/components/_tag-filter.scss
@@ -36,7 +36,7 @@
   background-size: 0.75rem;
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .tag-filter {
     display: flex;
     flex-wrap: nowrap;

--- a/src/assets/css/components/_tags.scss
+++ b/src/assets/css/components/_tags.scss
@@ -15,6 +15,5 @@
   color: var(--color-tag);
 }
 
-@media (min-width: 48em) {
-
+@media (min-width: $breakpoint-s) {
 }

--- a/src/assets/css/components/_talk-banner.scss
+++ b/src/assets/css/components/_talk-banner.scss
@@ -96,7 +96,7 @@
   margin-bottom: 2rem;
 }
 
-@media (min-width: 64em) {
+@media (min-width: $breakpoint-m) {
   .talk-banner__image-overlay {
     position: relative;
     min-width: 100%;
@@ -120,11 +120,11 @@
   }
 
   .talk-banner__link {
-    &:hover, &:focus {
-
-      &~.talk-banner__image-overlay .cta-link__text,
-      &~.talk-banner__image-overlay .cta-link__arrow svg,
-      &~.cta-link {
+    &:hover,
+    &:focus {
+      & ~ .talk-banner__image-overlay .cta-link__text,
+      & ~ .talk-banner__image-overlay .cta-link__arrow svg,
+      & ~ .cta-link {
         color: var(--color-aqua);
       }
     }
@@ -141,7 +141,7 @@
   }
 }
 
-@media (min-width: 72em) {
+@media (min-width: $breakpoint-l) {
   .talk-banner__content-wrapper {
     padding: 1rem 1rem 4rem;
   }

--- a/src/assets/css/components/_talk-card.scss
+++ b/src/assets/css/components/_talk-card.scss
@@ -29,7 +29,7 @@
   margin: 0.5rem 0 0.5rem;
 }
 
-@media (min-width: 64em) {
+@media (min-width: $breakpoint-m) {
   .talk-card__image-overlay {
     aspect-ratio: 9/8;
   }

--- a/src/assets/css/components/_talks.scss
+++ b/src/assets/css/components/_talks.scss
@@ -16,8 +16,7 @@
   margin: 5rem 0 0;
 }
 
-@media (min-width: 72rem) {
-
+@media (min-width: $breakpoint-l) {
   .talks__list {
     margin: 0;
     display: grid;

--- a/src/assets/css/components/_tech-cards.scss
+++ b/src/assets/css/components/_tech-cards.scss
@@ -5,13 +5,13 @@
   margin-top: 2.5rem;
 }
 
-@media (min-width: 48rem) {
+@media (min-width: $breakpoint-s) {
   .tech-cards__grid {
     grid-template-columns: 1fr 1fr;
   }
 }
 
-@media (min-width: 72rem) {
+@media (min-width: $breakpoint-l) {
   .tech-cards__grid {
     grid-template-columns: 1fr 1fr 1fr;
   }
@@ -31,7 +31,8 @@
   cursor: pointer;
   overflow: hidden;
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     .tech-cards__link-arrow {
       .icon-arrow {
         transform: translateX(0.5rem) rotate(-90deg);
@@ -140,7 +141,6 @@
     transition: transform 0.5s ease;
     width: 24px;
     height: auto;
-
   }
 
   &--rotate {

--- a/src/assets/css/components/_text-with-list.scss
+++ b/src/assets/css/components/_text-with-list.scss
@@ -39,7 +39,7 @@
 
   &--unordered {
     .text-with-list__item::before {
-      content: '●';
+      content: "●";
       margin-right: 0.75rem;
       color: var(--color-accent);
     }
@@ -51,10 +51,9 @@
   align-items: center;
   counter-increment: item;
 
-  &+& {
+  & + & {
     margin-top: 2rem;
   }
-
 }
 
 .text-with-list__cta {
@@ -62,7 +61,7 @@
   margin-top: 3.5rem;
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .text-with-list {
     padding: 7.75rem 0;
   }

--- a/src/assets/css/components/_vite-upgrade-grid.scss
+++ b/src/assets/css/components/_vite-upgrade-grid.scss
@@ -1,17 +1,15 @@
 .vite-upgrade-grid {
-    display: grid;
-    grid-template-columns: 1fr;
-    grid-template-rows: 1fr 1fr;
-    align-items: center;
-    justify-content: center;
-    gap: 2em;
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: 1fr 1fr;
+  align-items: center;
+  justify-content: center;
+  gap: 2em;
 }
 
-@media (min-width: 48em) {
-    
-    .vite-upgrade-grid {
-        grid-template-columns: 1fr 1fr;
-        grid-template-rows: 1fr;
-}
-
+@media (min-width: $breakpoint-s) {
+  .vite-upgrade-grid {
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr;
+  }
 }

--- a/src/assets/css/components/_work.scss
+++ b/src/assets/css/components/_work.scss
@@ -20,7 +20,7 @@
   }
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .work__list {
     display: grid;
     grid-template-columns: 1fr 1fr;

--- a/src/assets/css/components/_workshop-authors-big.scss
+++ b/src/assets/css/components/_workshop-authors-big.scss
@@ -2,7 +2,6 @@
   margin: 5rem 0 10rem;
 }
 
-
 .author-big__wrapper {
   margin: 3rem 0;
   display: grid;
@@ -10,12 +9,10 @@
   justify-items: center;
   align-items: center;
 
-  @media (min-width: 64em) {
+  @media (min-width: $breakpoint-m) {
     grid-template-columns: 1fr 1fr;
-    
   }
 }
-
 
 .workshop-authors-big__image-wrapper {
   margin-right: 1.25rem;

--- a/src/assets/css/components/_workshop-topics.scss
+++ b/src/assets/css/components/_workshop-topics.scss
@@ -11,7 +11,7 @@
   counter-increment: item;
   display: flex;
 
-  &+& {
+  & + & {
     margin-top: 2rem;
   }
 
@@ -57,10 +57,9 @@
   margin-bottom: 1rem;
 }
 
-
-@media (min-width: 62em) {
-.workshop-topics__item {
-    &+& {
+@media (min-width: $breakpoint-m) {
+  .workshop-topics__item {
+    & + & {
       margin-top: 2.75rem;
     }
   }

--- a/src/assets/css/workshop-lp.scss
+++ b/src/assets/css/workshop-lp.scss
@@ -1,3 +1,4 @@
+@import "base/variables";
 @import "components/color-hero";
 @import "components/cta-banner";
 @import "base/utility";
@@ -10,7 +11,7 @@ nav {
   padding: 3rem 0;
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .text-with-list {
     padding: 7.75rem 0;
   }
@@ -67,7 +68,7 @@ nav {
   display: inline-flex;
 }
 
-@media (min-width: 48em) {
+@media (min-width: $breakpoint-s) {
   .lang-features {
     padding: 7rem 0;
   }
@@ -151,7 +152,8 @@ button {
     }
   }
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     .line {
       background-color: var(--color-white);
     }

--- a/src/components/case-card.njk
+++ b/src/components/case-card.njk
@@ -1,5 +1,5 @@
 {% macro caseCard(clientHandle) %}
-  <div class="case-cards__grid-element">
+  <li class="case-cards__grid-element">
     {% set caseStudy = clientHandle | findBySlug %}
     <div class="case-cards--hover"></div>
     {% if caseStudy.url %}
@@ -28,5 +28,5 @@
         <span class="case-cards__link-arrow">{% include 'svg/arrow.njk' %}</span>
       </div>
     </div>
-  </div>
+  </li>
 {% endmacro %}

--- a/src/components/featured-case-studies.njk
+++ b/src/components/featured-case-studies.njk
@@ -10,7 +10,7 @@ list: An array where each item is the slug for the case study.
   <section class="featured-case-studies">
     <div class="container container--xl">
       <h2 class="featured-case-studies__heading h5">{{ heading }}</h2>
-      <div class="featured-case-studies__list">
+      <ul class="featured-case-studies__list">
         {%- for caseStudyHandle in caseStudies -%}
           {% if loop.index === 1 %}
             {{ featuredCaseStudy(caseStudyHandle, 'purple') }}
@@ -18,7 +18,7 @@ list: An array where each item is the slug for the case study.
             {{ caseCard(caseStudyHandle) }}
           {% endif %}
         {% endfor %}
-      </div>
+      </ul>
     </div>
   </section>
 {%- endmacro -%}


### PR DESCRIPTION
Closes #2389
closes #2403

Standardizes the breakpoints across different levels. As of now, there is no way to use CSS custom properties in media queries, so I am using SCSS breakpoints. This solution isn't neccessarily ideal, but it should be possible to move off of in the future, either by minimizing the use of breakpoints by using more modern CSS techniques such as [responsive scaling of margins and text](https://utopia.fyi/) and the [minmax function ](https://developer.mozilla.org/en-US/docs/Web/CSS/minmax).

We should be mindful that because SCSS variables are only available in SCSS, tweaking the variables may need updating where we use breakpoints in HTML, such as for responsive images.