### PR TITLE
Standardize icon animations

### DIFF
--- a/src/assets/css/app.scss
+++ b/src/assets/css/app.scss
@@ -9,6 +9,7 @@
 @import "base/forms";
 @import "base/prism-theme";
 
+@import "components/icon-arrow";
 @import "components/nav";
 @import "components/nav-submenu";
 @import "components/mobile-menu";

--- a/src/assets/css/base/_buttons-links.scss
+++ b/src/assets/css/base/_buttons-links.scss
@@ -16,22 +16,11 @@ p a {
   transition: color ease 0.5s;
   overflow: hidden;
   transform: translate3d(0, 0, 0);
+  --icon-arrow-margin: 0 0 0 0.5rem;
 
-  .icon-arrow {
-    flex-shrink: 0;
-    transform: translateX(0px) rotate(-90deg);
-    height: 1rem;
-    width: 1rem;
-    color: var(--color-white);
-    margin-left: 0.5rem;
-    transition: transform 0.5s ease;
-  }
 
   &:hover, &:focus {
-   .icon-arrow {
-      transform: translateX(0.5rem) rotate(-90deg);
-      transition: transform 0.5s ease;
-    }
+    --icon-arrow-transform: translate3d(0.5rem, 0, 0);
   }
 
   &--purple {
@@ -45,10 +34,6 @@ p a {
   &--white {
     background-color: var(--color-white);
     color: var(--color-link-primary);
-
-    .icon-arrow {
-      color: var(--color-link-primary);
-    }
   }
 }
 
@@ -60,85 +45,22 @@ p a {
   display: flex;
   align-items: center;
   text-decoration: none;
+  --icon-arrow-size: 1.5rem;
+  --icon-arrow-margin: 0 1.5rem 0 0;
+  --icon-arrow-color: var(--color-purple);
 
   &-text {
     text-decoration: none;
   }
 
-  .icon-arrow {
-    flex-shrink: 0;
-    transform: translateX(0px) rotate(-90deg);
-    height: 1.5rem;
-    width: 1.5rem;
-    color: var(--color-purple);
-    margin-right: 1.5rem;
-    transition: transform 0.5s ease;
-  }
-
-  &.previous {
-    .icon-arrow {
-      transform: translateX(0px) rotate(90deg);
-      margin-right: 1.5rem;
-      margin-left: 0;
-      transition: transform 0.5s ease;
-    }
-
-    &:hover .icon-arrow, &:focus .icon-arrow {
-      transform: translateX(-0.5rem) rotate(90deg);
-    }
-  }
-}
-
-.btn-secondary:hover, .btn-secondary:focus {
-  text-decoration: none;
-
-  .icon-arrow {
-    transform: translateX(0.5rem) rotate(-90deg);
-    transition: transform 0.5s ease;
-  }
-
-  .btn-secondary-text {
-    text-decoration: none;
-  }
-}
-
-.next {
-  .icon-arrow {
-    transform: rotate(-90deg);
-    margin-right: 0;
-    margin-left: 1.5rem;
-  }
-}
-
-.videos {
-  .icon-arrow {
-    transform: rotate(-90deg);
-    margin-right: 0;
-    margin-left: 1.5rem;
-  }
-}
-
-.message {
-  cursor: pointer;
-
-  .icon-arrow {
-    transform: rotate(-90deg);
-    margin-right: 0;
-    margin-left: 1.5rem;
-    color: var(--color-white);
-  }
-
   &:hover, &:focus {
-    color: var(--color-aqua);
+    --icon-arrow-transform: translate3d(0.5rem,0,0);
+    text-decoration: none;
+    color: var(--color-purple);
   }
-}
 
-a.btn-secondary {
-  &:hover,
-  &:focus {
-    .btn-secondary__text {
-      color: var(--color-purple);
-    }
+  &--reversed {
+    --icon-arrow-margin: 0 0 0 1.5rem;
   }
 }
 

--- a/src/assets/css/base/_variables.scss
+++ b/src/assets/css/base/_variables.scss
@@ -20,6 +20,12 @@
   --color-link-background: var(--color-yellow);
 
   --font-base: "Core Sans A", sans-serif;
+
+  // Arrow icons
+  --icon-arrow-rotate: -90deg;
+  --icon-arrow-transform: translate3d(0, 0, 0);
+  --icon-arrow-size: 1rem;
+  --icon-arrow-margin: 0 0 0 1rem;
 }
 
 $breakpoint-s: 48em;

--- a/src/assets/css/components/_case-cards.scss
+++ b/src/assets/css/components/_case-cards.scss
@@ -70,6 +70,7 @@
 @media (hover: hover) {
   .case-cards__grid-element:hover,
   .case-cards__grid-element:focus {
+    --icon-arrow-transform: translate3d(0.5rem, 0, 0);
     color: var(--color-white);
     cursor: pointer;
 
@@ -80,21 +81,7 @@
     .solution {
       transform: translate(0px);
     }
-
-    .icon-arrow {
-      transform: translateX(0.5rem) rotate(-90deg);
-      transition: transform 0.5s ease;
-    }
   }
-}
-
-.case-cards_link {
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
-  text-decoration: none;
 }
 
 .case-cards__content {
@@ -120,6 +107,7 @@
   text-decoration: none;
   background-repeat: no-repeat;
   z-index: 50;
+  outline-offset: -0.5rem;
 }
 
 .case-cards__link-wrapper {
@@ -144,37 +132,16 @@
 }
 
 .case-cards__link-arrow {
+  --icon-arrow-size: 1.5rem;
   position: relative;
   margin-left: 0.25rem;
   z-index: 1;
   display: flex;
   justify-content: center;
-
-  .icon-arrow {
-    transform: translateX(0px) rotate(-90deg);
-    transition: transform 0.5s ease;
-    width: 24px;
-    height: auto;
-  }
-
-  &--rotate {
-    margin-left: 0;
-    margin-right: 0.5rem;
-
-    .icon-arrow {
-      transform: rotate(90deg);
-    }
-  }
 }
 
 .case-cards__link-label a {
   text-decoration: none;
   position: relative;
   z-index: 100;
-
-  &:hover,
-  &:focus {
-    cursor: pointer;
-    color: var(--color-white);
-  }
 }

--- a/src/assets/css/components/_client-card.scss
+++ b/src/assets/css/components/_client-card.scss
@@ -18,32 +18,19 @@
 }
 
 .client-card__link {
+  --icon-arrow-size: 1.5rem;
+  --icon-arrow-margin: 0 0 0 0.75rem;
   display: flex;
   align-items: center;
-}
-
-.client-card__link {
   flex-shrink: 0;
-
-  .icon-arrow {
-    transform: translateX(0px) rotate(-90deg);
-    transition: transform 0.5s ease;
-    height: 1.5rem;
-    width: 1.5rem;
-    color: var(--color-purple);
-    margin-left: 0.75rem;
-  }
 
   &:hover,
   &:focus {
-    .icon-arrow {
-      transform: translateX(0.5rem) rotate(-90deg);
-      transition: transform 0.5s ease;
-    }
+    --icon-arrow-transform: translate3d(0.5rem, 0, 0);
   }
 }
 
-@media (min-width: $breakpoint-s) {
+@media (min-width: 48em) {
   .client-card {
     margin: 0;
   }

--- a/src/assets/css/components/_featured-case-study.scss
+++ b/src/assets/css/components/_featured-case-study.scss
@@ -10,17 +10,9 @@
     margin-top: rem-calc(80);
   }
 
-  .icon-arrow {
-    transform: translateX(0px) rotate(-90deg);
-    transition: transform 0.5s ease;
-  }
-
   &:hover,
   &:focus {
-    .icon-arrow {
-      transform: translateX(0.5rem) rotate(-90deg);
-      transition: transform 0.5s ease;
-    }
+    --icon-arrow-transform: translate3d(0.5rem, 0, 0);
   }
 
   &--purple {
@@ -239,6 +231,10 @@
     & + & {
       margin-top: 0;
     }
+  }
+
+  .featured-case-studies .featured-case-study {
+    grid-column: span 3 / span 3;
   }
 
   .featured-case-study__content-wrapper {

--- a/src/assets/css/components/_featured-services.scss
+++ b/src/assets/css/components/_featured-services.scss
@@ -24,6 +24,9 @@
 }
 
 .featured-services__link {
+  --icon-arrow-color: var(--color-purple);
+  --icon-arrow-size: 1.5rem;
+  --icon-arrow-margin: 0 1.5rem 0 0;
   display: flex;
   align-items: start;
   flex-direction: column;
@@ -38,24 +41,12 @@
     font-size: 1rem;
   }
 
-  .icon-arrow {
-    transform: translateX(0px) rotate(-90deg);
-    transition: transform 0.5s ease;
-    height: 1.5rem;
-    width: 1.5rem;
-    color: var(--color-purple);
-    margin-right: 1.5rem;
-  }
-
   &:hover,
   &:focus {
+    --icon-arrow-transform: translate3d(0.5rem, 0, 0);
+
     .featured-services__link-description {
       color: var(--color-purple);
-    }
-
-    .icon-arrow {
-      transform: translateX(0.5rem) rotate(-90deg);
-      transition: transform 0.5s ease;
     }
   }
 }
@@ -66,7 +57,7 @@
   align-items: center;
 }
 
-a.featured-services__link {
+.featured-services__link {
   &:hover,
   &:focus {
     .featured-services__link-text {

--- a/src/assets/css/components/_icon-arrow.scss
+++ b/src/assets/css/components/_icon-arrow.scss
@@ -1,0 +1,10 @@
+.icon-arrow {
+  flex-shrink: 0;
+  height: var(--icon-arrow-size);
+  width: var(--icon-arrow-size);
+  margin: var(--icon-arrow-margin);
+  transform: var(--icon-arrow-transform) rotate(var(--icon-arrow-rotate));
+  transition: transform 0.5s ease;
+  will-change: transform;
+  color: var(--icon-arrow-color, inherit);
+}

--- a/src/assets/css/components/_nav-submenu.scss
+++ b/src/assets/css/components/_nav-submenu.scss
@@ -17,6 +17,7 @@
 }
 
 .nav-submenu__toggle {
+  --icon-arrow-margin: 0 0 0 0.5rem;
   display: flex;
   align-items: center;
   border: 0;
@@ -29,15 +30,8 @@
     display: none;
   }
 
-  svg {
-    margin-left: 0.5rem;
-    transform: rotate(0);
-  }
-
   body[data-js-enabled="false"] .nav-submenu[open] & {
-    svg {
-      transform: rotate(180deg);
-    }
+    --icon-arrow-rotate: 0deg;
   }
 }
 
@@ -72,6 +66,9 @@
 }
 
 .nav-submenu__link {
+  --icon-arrow-size: 0.75rem;
+  --icon-arrow-margin: 0 1rem 0 0;
+
   display: flex;
   flex-direction: column;
   text-decoration: none;
@@ -79,22 +76,10 @@
   outline-offset: -0.125rem;
   transition: color 0.3s ease;
 
-  .icon-arrow {
-    width: 0.75rem;
-    height: 0.75rem;
-    transform: translateX(0px) rotate(-90deg);
-    margin-right: 1rem;
-    transition: transform 0.5s ease;
-  }
-
   &:hover, &:focus  {
+    --icon-arrow-transform: translate3d(0.5rem, 0, 0);
     color: var(--color-accent);
     text-decoration: none;
-
-    .icon-arrow {
-      transform: translateX(0.5rem) rotate(-90deg);
-      transition: transform 0.5s ease;
-    }
   }
 }
 
@@ -137,35 +122,16 @@ body[data-js-enabled="true"] {
   }
 
   .nav-submenu__toggle {
-    svg {
-      transform: translateX(0px) rotate(-90deg);
-      height: 1rem;
-      width: 1rem;
-    }
-
     &:hover, &:focus  {
-      .icon-arrow {
-        transform: translateX(0.5rem) rotate(-90deg);
-        transition: transform 0.5s ease;
-      }
+      --icon-arrow-transform: translate3d(0.5rem, 0, 0);
     }
   }
 
   .nav-submenu__link {
+    --icon-arrow-size: 2rem;
     font-size: 2rem;
     display: flex;
     align-items: start;
     padding: 0.5rem 0;
-
-    .icon-arrow {
-      width: 2rem;
-      height: 2rem;
-    }
-  }
-
-  .nav-submenu[open] .nav-submenu__toggle svg & {
-    svg {
-      transform: rotate(-90deg);
-    }
   }
 }

--- a/src/assets/css/components/_nav.scss
+++ b/src/assets/css/components/_nav.scss
@@ -62,7 +62,7 @@
   transition: color 0.3s ease;
 
   &:hover,
-  &:focus {
+  &:focus-within {
     color: var(--color-aqua);
 
     .nav__link-text {

--- a/src/assets/css/components/_next-events-cards.scss
+++ b/src/assets/css/components/_next-events-cards.scss
@@ -10,7 +10,6 @@
   align-items: start;
   text-decoration: none;
   overflow: hidden;
-
   cursor: pointer;
 
   a:hover, &:focus  {
@@ -18,16 +17,8 @@
   }
 }
 
-.next-events-cards__grid-element:hover, .next-events-cards__grid-element:focus {
-  color: var(--color-white);
-  cursor: pointer;
-
-  .next-events-cards__link-arrow {
-    .icon-arrow {
-      transform: translateX(0.5rem) rotate(-90deg);
-      transition: transform 0.5s ease;
-    }
-  }
+.next-events-cards__grid-element:hover, .next-events-cards__grid-element:focus-within {
+  --icon-arrow-transform: translate3d(0.5rem, 0, 0);
 }
 
 .next-events-cards__date-wrapper {
@@ -64,14 +55,6 @@
   align-self: end;
 }
 
-.next-events-cards--hover {
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 100%;
-  width: 100%;
-}
-
 .next-events-cards__link {
   position: absolute;
   top: 0;
@@ -84,26 +67,10 @@
 }
 
 .next-events-cards__link-arrow {
+  --icon-arrow-size: 1.5rem;
   position: relative;
   margin-left: 0.25rem;
   z-index: 1;
   display: flex;
   justify-content: center;
-
-  .icon-arrow {
-    transform: translateX(0px) rotate(-90deg);
-    transition: color 0.3s ease;
-    width: 24px;
-    height: auto;
-    transition: transform 0.5s ease;
-  }
-
-  &--rotate {
-    margin-left: 0;
-    margin-right: 0.5rem;
-
-    .icon-arrow {
-      transform: rotate(90deg);
-    }
-  }
 }

--- a/src/assets/css/components/_pagination.scss
+++ b/src/assets/css/components/_pagination.scss
@@ -14,11 +14,7 @@
     margin-top: 3rem;
   }
 
-  & .next:only-child {
-    margin-left: auto;
-  }
-
-  & .next-wrapper:only-child {
+  & > [class$="reversed"]:only-child {
     margin-left: auto;
   }
 }
@@ -31,41 +27,16 @@
   flex-grow: 2;
 }
 
+
 .previous-wrapper {
+  --icon-arrow-rotate: 90deg;
   display: flex;
   flex-direction: column;
   align-items: start;
   text-align: left;
   flex-grow: 2;
-}
 
-
-.pagination__link {
-  padding: 0.75rem 1rem;
-
-  &[aria-current="page"] {
-    font-weight: 600;
-    color: var(--color-purple);
-    text-decoration: none;
+  a:hover, a:focus {
+    --icon-arrow-transform: translate3d(-0.5rem, 0, 0);
   }
-}
-
-.pagination__previous,
-.pagination__next {
-  text-decoration: none;
-
-  &:hover, &:focus  {
-    text-decoration: none;
-  }
-}
-
-.pagination__previous {
-  grid-column: 1 / 2;
-  text-align: left;
-}
-
-.pagination__next {
-  grid-column: 2 / 3;
-  justify-self: end;
-  text-align: right;
 }

--- a/src/assets/css/components/_post-cards.scss
+++ b/src/assets/css/components/_post-cards.scss
@@ -29,25 +29,15 @@
   align-items: start;
   text-decoration: none;
   overflow: hidden;
-
   cursor: pointer;
 
-  a:hover,
+  &:hover,
   &:focus {
-    text-decoration: underline;
+    --icon-arrow-transform: translate3d(0.5rem, 0, 0);
   }
-}
 
-.post-cards__grid-element:hover,
-.post-cards__grid-element:focus {
-  color: var(--color-white);
-  cursor: pointer;
-
-  .post-cards__link-arrow {
-    .icon-arrow {
-      transform: translateX(0.5rem) rotate(-90deg);
-      transition: transform 0.5s ease;
-    }
+  a:hover {
+    text-decoration: underline;
   }
 }
 
@@ -126,41 +116,19 @@
   text-decoration: none;
   background-repeat: no-repeat;
   z-index: 50;
+  outline-offset: -0.25rem;
 }
 
 .post-cards__link-arrow {
+  --icon-arrow-size: 1.5rem;
   position: relative;
   margin-left: 0.25rem;
   z-index: 1;
   display: flex;
-  justify-content: center;
-
-  .icon-arrow {
-    transform: translateX(0px) rotate(-90deg);
-    transition: color 0.3s ease;
-    width: 24px;
-    height: auto;
-    transition: transform 0.5s ease;
-  }
-
-  &--rotate {
-    margin-left: 0;
-    margin-right: 0.5rem;
-
-    .icon-arrow {
-      transform: rotate(90deg);
-    }
-  }
 }
 
 .post-cards__link-label a,
 .post-cards__author-name a {
-  text-decoration: none;
   position: relative;
   z-index: 100;
-
-  &:hover,
-  &:focus {
-    cursor: pointer;
-  }
 }

--- a/src/assets/css/components/_talks.scss
+++ b/src/assets/css/components/_talks.scss
@@ -28,17 +28,3 @@
     text-align: right;
   }
 }
-
-.talks_pagination {
-  display: flex;
-  align-items: end;
-  margin-top: 5rem;
-
-  & .videos:only-child {
-    margin-left: auto;
-  }
-
-  & .videos:only-child {
-    margin-left: auto;
-  }
-}

--- a/src/assets/css/workshop-lp.scss
+++ b/src/assets/css/workshop-lp.scss
@@ -129,6 +129,7 @@ button {
     height: 1em;
     background-color: var(--color-link-primary);
   }
+
   span {
     color: var(--color-link-primary);
     text-decoration: none;
@@ -136,53 +137,9 @@ button {
     cursor: pointer;
   }
 
-  .icon-arrow {
-    flex-shrink: 0;
-    transform: translateX(0px) rotate(-90deg);
-    height: 1rem;
-    width: 1rem;
-    color: var(--color-white);
-    margin-left: 0.5rem;
-    transition: transform 0.5s ease;
-  }
-
-  &.btn-primary--white {
-    svg {
-      color: var(--color-purple);
-    }
-  }
-
   &:hover,
   &:focus {
-    .line {
-      background-color: var(--color-white);
-    }
-
-    span {
-      color: var(--color-white);
-      text-decoration: none;
-      font-weight: 700;
-    }
-
-    .icon-arrow {
-      transform: translateX(0.5rem) rotate(-90deg);
-      transition: transform 0.5s ease;
-      color: var(--color-white);
-    }
-
-    &.btn-primary--white {
-      .line {
-        background-color: var(--color-purple);
-      }
-
-      span {
-        color: var(--color-purple);
-      }
-
-      svg {
-        color: var(--color-purple);
-      }
-    }
+    --icon-arrow-transform: translate3d(0.5rem, 0, 0);
   }
 }
 

--- a/src/blog.njk
+++ b/src/blog.njk
@@ -45,7 +45,9 @@ eleventyNavigation:
   {% else %}
     {% set nextLabel = 'Next' %}
   {% endif %}
-  {{ navPagination(pagination.href.previous, pagination.href.next, nextLabel) }}
+  {% if pagination.href.previous %}{% set previous %}{{ pagination.href.previous }}#posts{% endset %}{% endif %}
+  {% set next %}{{ pagination.href.next }}#posts{% endset %}
+  {{ navPagination(previous, next, 'Previous', nextLabel) }}
 </div>
 {%
   set 'content' = {

--- a/src/blog.njk
+++ b/src/blog.njk
@@ -46,7 +46,7 @@ eleventyNavigation:
     {% set nextLabel = 'Next' %}
   {% endif %}
   {% if pagination.href.previous %}{% set previous %}{{ pagination.href.previous }}#posts{% endset %}{% endif %}
-  {% set next %}{{ pagination.href.next }}#posts{% endset %}
+  {% if pagination.href.next %}{% set next %}{{ pagination.href.next }}#posts{% endset %}{% endif %}
   {{ navPagination(previous, next, 'Previous', nextLabel) }}
 </div>
 {%

--- a/src/components/btn-secondary.njk
+++ b/src/components/btn-secondary.njk
@@ -1,6 +1,14 @@
-{%- macro btnSecondary(link, class) -%}
-  <a href="{{ link.url }}" class="btn-secondary h4 {{ class }}">
-    {% include 'svg/arrow.njk' %}
+{%- macro btnSecondary(link, class, flip = false) -%}
+  <a
+    href="{{ link.url }}"
+    class="btn-secondary h4 {{ class }} {% if flip %}btn-secondary--reversed{% endif %}"
+  >
+    {% if flip == false %}
+      {% include 'svg/arrow.njk' %}
+    {% endif %}
     <span class="btn-secondary__text">{{ link.label }}</span>
+    {% if flip == true %}
+      {% include 'svg/arrow.njk' %}
+    {% endif %}
   </a>
 {% endmacro %}

--- a/src/components/layouts/post.njk
+++ b/src/components/layouts/post.njk
@@ -86,7 +86,10 @@ layout: base
         {% endif %}
         {% if next %}
           <div class="next-wrapper">
-            <a href="{{ next.url }}" class="btn-secondary h4 pagination-item next">
+            <a
+              href="{{ next.url }}"
+              class="btn-secondary h4 pagination-item btn-secondary--reversed"
+            >
               <span class="btn-secondary__text">Next post</span>
               {% include 'svg/arrow.njk' %}
             </a>

--- a/src/components/nav-pagination.njk
+++ b/src/components/nav-pagination.njk
@@ -3,33 +3,34 @@ Previous / next pagination for within listing pages
 Configuration Options:
 previous: page object of the next page, or null.
 next: see above
-nextLabel: string for Next button label only on first page
+nextLabel: string for Previous button label
+nextLabel: string for Next button label
 #}
+{% from "btn-secondary.njk" import btnSecondary %}
 
-{%- macro navPagination(previous, next, nextLabel) -%}
+{%- macro navPagination(previous, next, previousLabel = "Previous", nextLabel = "Next") -%}
   {% if previous or next %}
-
-    {% if nextLabel %}
-      {% set next_label = nextLabel %}
-    {% else %}
-      {% set next_label = 'Next' %}
-    {% endif %}
-
     <nav class="pagination" aria-label="Pagination">
       {% if previous %}
         <div class="previous-wrapper">
-          <a href="{{ previous }}#posts" class="btn-secondary h4 pagination-item previous">
-            {% include 'svg/arrow.njk' %}
-            <span class="btn-secondary__text">Previous</span>
-          </a>
+          {%
+            set link = {
+            "label": previousLabel,
+            "url": previous
+            }
+          %}
+          {{ btnSecondary(link, '') }}
         </div>
       {% endif %}
       {% if next %}
         <div class="next-wrapper">
-          <a href="{{ next }}#posts" class="btn-secondary h4 pagination-item next">
-            <span class="btn-secondary__text">{{ next_label }}</span>
-            {% include 'svg/arrow.njk' %}
-          </a>
+          {%
+            set link = {
+            "label": nextLabel,
+            "url": next
+            }
+          %}
+          {{ btnSecondary(link, '', true) }}
         </div>
       {% endif %}
     </nav>

--- a/src/components/post-card.njk
+++ b/src/components/post-card.njk
@@ -8,7 +8,6 @@ post: A post object
 #}
 {%- macro postCard(post) -%}
   <div class="post-cards__grid-element">
-    <div class="post-cards--hover"></div>
     <a href="{{ post.url }}" class="post-cards__link"></a>
     <div class="post-cards__date-wrapper">
       <p class="small">{{ post.date | monthDayYear }}</p>

--- a/src/components/recent-posts.njk
+++ b/src/components/recent-posts.njk
@@ -1,6 +1,7 @@
 {% from "cta-link.njk" import ctaLink %}
 {% from "post-banner.njk" import postBanner %}
 {% from "post-card.njk" import postCard %}
+{% from "btn-secondary.njk" import btnSecondary %}
 
 {%- macro recentPosts(title, collection) -%}
   <section class="recent-posts">
@@ -15,12 +16,15 @@
           {% endif %}
         {%- endfor -%}
       </ol>
-      <nav class="pagination" aria-label="Pagination">
-        <a href="/blog/" class="btn-secondary h4 pagination-item next mt-2">
-          <span class="btn-secondary__text">Explore more articles</span>
-          {% include 'svg/arrow.njk' %}
-        </a>
-      </nav>
+      <div class="pagination">
+        {%-
+          set link = {
+          "label": "Explore more articles",
+          "url": "/blog/"
+          }
+        -%}
+        {{- btnSecondary(link, 'mt-2', true) -}}
+      </div>
     </div>
   </section>
 {%- endmacro -%}

--- a/src/events.njk
+++ b/src/events.njk
@@ -10,6 +10,7 @@ description: Find out about upcoming events, conferences and meetups we will be 
 {% from "talk-card.njk" import talkCard %}
 {% from "cta-link.njk" import ctaLink %}
 {% from "btn-primary.njk" import btnPrimary %}
+{% from "btn-secondary.njk" import btnSecondary %}
 {% from "cta-banner.njk" import ctaBanner %}
 {%
   set 'content' = {
@@ -61,11 +62,14 @@ description: Find out about upcoming events, conferences and meetups we will be 
       {% endfor %}
     </ol>
     {% if collections.appearances.length > 7 %}
-      <div class="talks_pagination">
-        <a href="/talks/#more-talks" class="btn-secondary h4 videos">
-          <span class="btn-secondary__text">Load more videos</span>
-          {% include 'svg/arrow.njk' %}
-        </a>
+      <div class="pagination">
+        {%-
+          set link = {
+          "label": "Load more videos",
+          "url": "/talks/#more-talks"
+          }
+        -%}
+        {{- btnSecondary(link, '', true) -}}
       </div>
     {% endif %}
   </div>

--- a/src/index.njk
+++ b/src/index.njk
@@ -128,7 +128,6 @@ title: null
         {% for event in collections.calendar %}
           {% if loop.index < 4 %}
             <div class="next-events-cards__grid-element">
-              <div class="next-events-cards--hover"></div>
               <a href="{{ event.data.url }}" class="next-events-cards__link"></a>
               <div class="next-events-cards__date-wrapper">
                 <p class="small">{{ event.date | monthDayYear }}</p>

--- a/src/tag.njk
+++ b/src/tag.njk
@@ -35,10 +35,10 @@ permalink: "/blog/tag/{{ paged.tag | slug }}/{% if paged.number > 1 %}/page/{{ p
   </div>
 
   {% if paged.first != true %}
-    {%- set previous -%}/blog/tag/{{ paged.tag | slug }}/{% if paged.number > 2 %}page/{{ paged.number -1 }}/{% endif %}{%- endset -%}
+    {%- set previous -%}/blog/tag/{{ paged.tag | slug }}/{% if paged.number > 2 %}page/{{ paged.number -1 }}/{% endif %}#posts{%- endset -%}
   {% endif %}
   {% if paged.last != true %}
-    {%- set next -%}/blog/tag/{{ paged.tag | slug }}/page/{{ paged.number + 1 }}/{%- endset -%}
+    {%- set next -%}/blog/tag/{{ paged.tag | slug }}/page/{{ paged.number + 1 }}/#posts{%- endset -%}
   {% endif %}
 
   {{ navPagination(previous, next) }}

--- a/utils/transforms/contentParser.js
+++ b/utils/transforms/contentParser.js
@@ -14,26 +14,6 @@ module.exports = function (value, outputPath) {
     const document = DOM.window.document;
 
     /**
-     * Add a span for text-animation
-     */
-    const textAnimations = [...document.querySelectorAll(".text-animation em")];
-    if (textAnimations.length) {
-      textAnimations.forEach(textAnimation => {
-        const span = document.createElement("span");
-        span.classList.add("text-animation__cover");
-        return textAnimation.appendChild(span);
-      });
-    }
-
-    const textAnimationsOffset = [...document.querySelectorAll(".text-animation-offset em")];
-    if (textAnimationsOffset.length) {
-      textAnimationsOffset.forEach(textAnimationOffset => {
-        const span = document.createElement("span");
-        span.classList.add("text-animation__cover-offset");
-        return textAnimationOffset.appendChild(span);
-      });
-    }
-    /**
      * Get all the headings inside the post
      */
     const articleHeadings = [


### PR DESCRIPTION
closes #2386

Pulled out all the icon arrows to use CSS custom properties and draw form the same animation source so future maintenance is easier. 

I tried to reproduce the issue Marco experienced in #2386 with several different Safari devices and couldn't seem to replicate the wobblyness, I suspect it has to do with pixel rounding, judging by the way the arrow seems to move down half a pixel, transform, then move up half a pixel. I've applied a 3d transform and the css `will-change` property which has [fixed animation issues](https://www.nicchan.me/blog/a-use-case-for-will-change/) in the past. Fingers crossed that it is an improvement!