### PR TITLE
fix handling of animated gifs

### DIFF
--- a/utils/transforms/contentParser.js
+++ b/utils/transforms/contentParser.js
@@ -114,8 +114,12 @@ module.exports = function (value, outputPath) {
         }
 
         let formats = ["webp", imageData.fileType];
-        if (imageData.fileType === "gif") {
-          formats = ["gif"];
+        let sharpOptions = {};
+        if (imageData.fileType === "gif" || imageData.fileType === "webp") {
+          formats = ["gif", "webp"];
+          sharpOptions = {
+            animated: true,
+          };
         }
 
         let url = "./static" + imageData.src;
@@ -123,6 +127,7 @@ module.exports = function (value, outputPath) {
           svgShortCircuit: true,
           widths: sizes,
           formats,
+          sharpOptions,
           urlPath: imageData.directory,
           outputDir: "./dist/" + imageData.directory,
           filenameFormat: function (id, src, width, format) {


### PR DESCRIPTION
This should fix handling of animated gifs. Currently animated gifs are converted into static gifs, e.g. in [this post](https://mainmatter.com/blog/2021/12/08/validations-in-ember-apps/).

This was first attempted in #2356 but apparently that didn't actually fix the problem. According to the [11ty docs](https://www.11ty.dev/docs/plugins/image/#output-animated-gif-or-webp), this should be the right fix.

**Update:** it in fact works, see e.g. here: https://deploy-preview-2461--objective-northcutt-37494c.netlify.app/blog/2021/12/08/validations-in-ember-apps/