### PR TITLE
Blog post/ May Embroider update: change the link to ember conf talk

### DIFF
--- a/src/posts/2024-05-29-embroider-update.md
+++ b/src/posts/2024-05-29-embroider-update.md
@@ -167,5 +167,5 @@ default experience for all Ember users.
 
 To keep up to date with the latest developments on the
 [Embroider Initiative](/ember-initiative/), don't miss Chris Manson's talk at
-[EmberConf](https://www.emberconf.com/schedule/launching-ember-into-the-future-)
-on May 31st.
+[EmberConf](https://www.emberconf.com/talks/launching-ember-into-the-future-) on
+May 31st.


### PR DESCRIPTION
Now that the EmberConf has happened, the link to Chris's talk is under `talks` route instead of `schedule` route.