### PR TITLE
ci(workflow): remove schedule in workflows/ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request: {}
-  schedule:
-    - cron:  '0 3 * * *' # daily, at 3am
 
 jobs:
   lint:


### PR DESCRIPTION
We don't need to run the workflow at night