### PR TITLE
Temporary replace link to Luca's calendar with contact form

### DIFF
--- a/src/rust-consulting.njk
+++ b/src/rust-consulting.njk
@@ -146,7 +146,7 @@ og:
         {%
           set link = {
           "label": 'Book a 1:1 call with Luca',
-          "url": 'https://calendly.com/luca-palmieri/is-rust-the-right-choice-for-us'
+          "url": 'https://mainmatter.com/contact/'
           }
         %}
         {{ btnSecondary( link, 'mt-2' ) }}

--- a/src/rust-consulting.njk
+++ b/src/rust-consulting.njk
@@ -137,8 +137,8 @@ og:
         <h5>Book a free call</h5>
         <h3 class="split-content__subheading h2">Is Rust the right choice for us?</h3>
         <p>
-          Every new technology brings its own risks - Rust is no exception. Our team of in-house
-          Rust experts is here to help you. You walk us through your company's usecase and your
+          Every new technology brings its own risks - Rust is no exception. Our team of Rust
+          experts is here to help you. You walk us through your company's usecase and your
           requirements and we'll do our best to suggest the best course of action. Sometimes Rust
           is not the answer, but if it is, we'll make sure you are on the right track.
         </p>

--- a/src/rust-consulting.njk
+++ b/src/rust-consulting.njk
@@ -137,10 +137,10 @@ og:
         <h5>Book a free call</h5>
         <h3 class="split-content__subheading h2">Is Rust the right choice for us?</h3>
         <p>
-          Every new technology brings its own risks - Rust is no exception. Our team of Rust
-          experts is here to help you. You walk us through your company's usecase and your
-          requirements and we'll do our best to suggest the best course of action. Sometimes Rust
-          is not the answer, but if it is, we'll make sure you are on the right track.
+          Every new technology brings its own risks - Rust is no exception. Our team of Rust experts
+          is here to help you. You walk us through your company's usecase and your requirements and
+          we'll do our best to suggest the best course of action. Sometimes Rust is not the answer,
+          but if it is, we'll make sure you are on the right track.
         </p>
         {%
           set link = {

--- a/src/rust-consulting.njk
+++ b/src/rust-consulting.njk
@@ -137,15 +137,14 @@ og:
         <h5>Book a free call</h5>
         <h3 class="split-content__subheading h2">Is Rust the right choice for us?</h3>
         <p>
-          Every new technology brings its own risks - Rust is no exception. Luca Palmieri, the
-          author of <a href="https://zero2prod.com">Zero to Production in Rust</a> and our in-house
-          Rust expert, is here to help your team. You walk him through your company's usecase and
-          your requirements and he’ll do his best to suggest the best course of action. Sometimes
-          Rust is not the answer, but if it is, he’ll make sure you are on the right track.
+          Every new technology brings its own risks - Rust is no exception. Our team of in-house
+          Rust experts is here to help you. You walk us through your company's usecase and your
+          requirements and we'll do our best to suggest the best course of action. Sometimes Rust
+          is not the answer, but if it is, we'll make sure you are on the right track.
         </p>
         {%
           set link = {
-          "label": 'Book a 1:1 call with Luca',
+          "label": 'Book a 1:1 call with us',
           "url": 'https://mainmatter.com/contact/'
           }
         %}


### PR DESCRIPTION
While Luca's on paternity leave, let's make sure people can still contact us for Rust help :)

This replaces the link to Luca's Calendly (https://calendly.com/luca-palmieri/is-rust-the-right-choice-for-us) with the generic Mainmatter contact form (https://mainmatter.com/contact/).

Other option: just `mailto:info@mainmatter.com`