### PR TITLE
fix link to beginner testing workshop

### DIFF
--- a/src/services/workshops/rust.njk
+++ b/src/services/workshops/rust.njk
@@ -59,7 +59,7 @@ description: "We provide a number of workshops to enable teams to succeed with R
   "eyebrow": "Bookable for teams",
   "title": "Testing in Rust: an introduction",
   "logo": "rust",
-  "link": "services/workshops/introduction-to-rust-for-web-developers/"
+  "link": "services/workshops/an-introduction-to-testing-in-rust/"
   }
 %}
 {%


### PR DESCRIPTION
it's currently pointing to the intro-for-web-devs workshop