### PR TITLE
skip CI steps on scheduled CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
   lint:
     name: Linting
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'schedule' }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -34,6 +35,7 @@ jobs:
   visual-regressions:
     name: 'Visual Regressions'
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'schedule' }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -62,6 +64,7 @@ jobs:
   performance:
     name: 'Performance'
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'schedule' }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -91,6 +94,7 @@ jobs:
   crawl:
     name: 'Crawl Links'
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'schedule' }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -118,6 +122,7 @@ jobs:
   gravity:
     name: 'Gravity'
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'schedule' }}
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
…since nothing can have broken but this should still be enough to trigger Netlify. Also, scheduled runs currently fail since the specific refs we need are not available since there is no PR