### PR TITLE
Add Mastodon & Bluesky handle support to author profiles

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -225,6 +225,11 @@ module.exports = function (eleventyConfig) {
     return response.data.replace("<svg", `<svg focusable="false" role="presentation"`);
   });
 
+  eleventyConfig.addShortcode("mastodonHandleUrl", handle => {
+    const [user, server] = handle.split("@").filter(Boolean);
+    return `https://${server}/@${user}`;
+  });
+
   eleventyConfig.setServerOptions({
     watch: ["./dist/assets/css/*.css", "./dist/assets/js/*.js"],
   });

--- a/src/authors/algo_luca.md
+++ b/src/authors/algo_luca.md
@@ -2,5 +2,6 @@
 name: "Luca Palmieri"
 github: LukeMathWalker
 twitter: algo_luca
+mastodon: "@algo_luca@hachyderm.io"
 bio: "Principal Engineering Consultant"
 ---

--- a/src/authors/marcoow.md
+++ b/src/authors/marcoow.md
@@ -3,5 +3,6 @@ name: "Marco Otte-Witte"
 github: marcoow
 twitter: marcoow
 linkedin: marco-otte-witte
+mastodon: "@marcoow@mastodon.social"
 bio: "Founder and Managing Director of Mainmatter"
 ---

--- a/src/authors/marcoow.md
+++ b/src/authors/marcoow.md
@@ -4,5 +4,6 @@ github: marcoow
 twitter: marcoow
 linkedin: marco-otte-witte
 mastodon: "@marcoow@mastodon.social"
+bluesky: marcoow.bsky.social
 bio: "Founder and Managing Director of Mainmatter"
 ---

--- a/src/authors/nickschot.md
+++ b/src/authors/nickschot.md
@@ -2,5 +2,6 @@
 name: "Nick Schot"
 github: nickschot
 twitter: nickschot
+mastodon: "@nickschot@toot.community"
 bio: "Senior Software Engineer"
 ---

--- a/src/authors/nickschot.md
+++ b/src/authors/nickschot.md
@@ -2,6 +2,7 @@
 name: "Nick Schot"
 github: nickschot
 twitter: nickschot
+bluesky: nickschot.bsky.social
 mastodon: "@nickschot@toot.community"
 bio: "Senior Software Engineer"
 ---

--- a/src/authors/oscard0m_.md
+++ b/src/authors/oscard0m_.md
@@ -2,5 +2,6 @@
 name: "Oscar Dominguez"
 github: oscard0m
 twitter: oscard0m_
+mastodon: "@OscarDOM@mastodon.social"
 bio: "Software Engineer"
 ---

--- a/src/authors/paoloricciuti.md
+++ b/src/authors/paoloricciuti.md
@@ -4,5 +4,6 @@ github: paoloricciuti
 twitter: paoloricciuti
 linkedin: paolo-ricciuti-571a91187
 bluesky: paolo.ricciuti.me
+mastodon: "@paoloricciuti@front-end.social"
 bio: 'Senior Software Engineer at Mainmatter, Co-creator of <a href="https://sveltelab.dev">sveltelab.dev</a>'
 ---

--- a/src/authors/paoloricciuti.md
+++ b/src/authors/paoloricciuti.md
@@ -3,5 +3,6 @@ name: "Paolo Ricciuti"
 github: paoloricciuti
 twitter: paoloricciuti
 linkedin: paolo-ricciuti-571a91187
+bluesky: paolo.ricciuti.me
 bio: 'Senior Software Engineer at Mainmatter, Co-creator of <a href="https://sveltelab.dev">sveltelab.dev</a>'
 ---

--- a/src/authors/pichfl.md
+++ b/src/authors/pichfl.md
@@ -1,8 +1,8 @@
 ---
 name: "Florian Pichler"
 github: pichfl
-twitter: pichfl
 linkedin: pichfl
 mastodon: "@fp@social.lol"
+bluesky: pichfl.bsky.social
 bio: "Consultant for Technology and Design at Mainmatter"
 ---

--- a/src/authors/pichfl.md
+++ b/src/authors/pichfl.md
@@ -3,5 +3,6 @@ name: "Florian Pichler"
 github: pichfl
 twitter: pichfl
 linkedin: pichfl
+mastodon: "@fp@social.lol"
 bio: "Consultant for Technology and Design at Mainmatter"
 ---

--- a/src/authors/real_ate.md
+++ b/src/authors/real_ate.md
@@ -3,5 +3,6 @@ name: "Chris Manson"
 github: mansona
 twitter: real_ate
 linkedin: realate
+mastodon: "@real_ate@mastodon.social"
 bio: "Senior Software Engineer, Ember Learning Core Team member"
 ---

--- a/src/authors/real_ate.md
+++ b/src/authors/real_ate.md
@@ -1,7 +1,6 @@
 ---
 name: "Chris Manson"
 github: mansona
-twitter: real_ate
 linkedin: realate
 mastodon: "@real_ate@mastodon.social"
 bio: "Senior Software Engineer, Ember Learning Core Team member"

--- a/src/authors/zeppelin.md
+++ b/src/authors/zeppelin.md
@@ -1,7 +1,7 @@
 ---
 name: "Gabor Babicz"
 github: zeppelin
-twitter: xeppelin
+mastodon: "@gabor@babicz.social"
 linkedin: xeppelin
 bio: "Senior Software Engineer"
 ---

--- a/src/components/author-socials.njk
+++ b/src/components/author-socials.njk
@@ -29,6 +29,14 @@
           </a>
         </li>
       {% endif %}
+      {% if author.data.bluesky %}
+        <li>
+          <a class="author-socials__icon" href="https://bsky.app/profile/{{ author.data.bluesky }}">
+            {% include 'svg/social-bluesky.njk' %}
+            <span class="screenreader">{{ author.data.bluesky }} on Bluesky</span>
+          </a>
+        </li>
+      {% endif %}
     </ul>
   {% endif %}
 {%- endmacro -%}

--- a/src/components/author-socials.njk
+++ b/src/components/author-socials.njk
@@ -21,6 +21,14 @@
           </a>
         </li>
       {% endif %}
+      {% if author.data.mastodon %}
+        <li>
+          <a class="author-socials__icon" href="{% mastodonHandleUrl author.data.mastodon %}">
+            {% include 'svg/social-mastodon.njk' %}
+            <span class="screenreader">{{ author.data.mastodon }} on Mastodon</span>
+          </a>
+        </li>
+      {% endif %}
     </ul>
   {% endif %}
 {%- endmacro -%}


### PR DESCRIPTION
Mastodon example:

<img width="372" alt="image" src="https://github.com/user-attachments/assets/893bf6ac-d74a-4760-a9ec-113a689b8d79">

Bluesky example:

<img width="421" alt="image" src="https://github.com/user-attachments/assets/8a358250-6094-428e-afdc-0343c67599bb">
