### PR TITLE
chore(deps): update pnpm version on netlify

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - uses: pnpm/action-setup@v4
         name: Install pnpm
-        with:
-          version: 9
 
       - name: install dependencies
         run: pnpm install
@@ -44,8 +42,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - uses: pnpm/action-setup@v4
         name: Install pnpm
-        with:
-          version: 9
 
       - name: install dependencies
         run: pnpm install
@@ -75,8 +71,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - uses: pnpm/action-setup@v4
         name: Install pnpm
-        with:
-          version: 9
 
       - name: install dependencies
         run: pnpm install
@@ -105,8 +99,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - uses: pnpm/action-setup@v4
         name: Install pnpm
-        with:
-          version: 9
 
       - name: install dependencies
         run: pnpm install
@@ -133,8 +125,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - uses: pnpm/action-setup@v4
         name: Install pnpm
-        with:
-          version: 9
 
       - name: install dependencies
         run: pnpm install

--- a/.github/workflows/twios.yaml
+++ b/.github/workflows/twios.yaml
@@ -28,8 +28,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - uses: pnpm/action-setup@v2
         name: Install pnpm
-        with:
-          version: 8
       - name: Fetch $TWIOS_BRANCH
         run: |
           git fetch origin $TWIOS_BRANCH
@@ -64,8 +62,6 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - uses: pnpm/action-setup@v2
         name: Install pnpm
-        with:
-          version: 8
       - name: Fetch $TWIOS_PR_REF
         run: |
           git fetch origin $TWIOS_PR_REF

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
     cache_img = 'assets/images'
 
 [build]
-  environment = { NODE_VERSION = "16.17.0" }
+  environment = { NODE_VERSION = "22.13.0" }
   command = "echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> .npmrc && pnpm install && pnpm build"
 
 # serve 404 simplabs' sitemap

--- a/package.json
+++ b/package.json
@@ -85,5 +85,6 @@
   "volta": {
     "node": "22.13.0",
     "pnpm": "9.15.4"
-  }
+  },
+  "packageManager": "pnpm@9.15.4"
 }


### PR DESCRIPTION
Netlify docs https://docs.netlify.com/configure-builds/manage-dependencies/#pnpm

- Updates PNPM used by netlify to `9.15.4`
Netlify uses corepack for managing the package manager version.
- Updates Node used by netlify to `22.13.0`
PNPM requires NODE > 18
- Removes hardcoded pnpm version from github workflows, they'll use `packageManager` directly.
- Adds corepack support for corepack users.

Netlify logs **before**:

```
12:03:42 AM: Installing npm packages using pnpm version 7.5.2
12:03:46 AM:  WARN  Ignoring not compatible lockfile at /opt/build/repo/pnpm-lock.yaml
```

Netlify logs **after**:

```
11:34:26 AM: Installing npm packages using pnpm version 9.15.4
11:34:26 AM: Lockfile is up to date, resolution step is skipped
```