### PR TITLE
Workshop fixes

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -126,12 +126,10 @@ module.exports = function (eleventyConfig) {
     return Boolean(collection?.find(({ page }) => page.url === url));
   });
 
-  eleventyConfig.addFilter("future", collection => {
-    return collection.filter(item => {
-      if (Number.isNaN(Date.parse(item.startDate)))
-        return console.log("Workshop has invalid date!");
-      return Date.parse(item.startDate) > new Date();
-    });
+  eleventyConfig.addFilter("upcoming", collection => {
+    return collection
+      .filter(item => Date.parse(item.startDate) > new Date())
+      .sort((a, b) => Date.parse(a.startDate) - Date.parse(b.startDate));
   });
 
   /*

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -128,8 +128,9 @@ module.exports = function (eleventyConfig) {
 
   eleventyConfig.addFilter("future", collection => {
     return collection.filter(item => {
-      if (Number.isNaN(Date.parse(item.endDate))) return console.log("Workshop has invalid date!");
-      return Date.parse(item.endDate) > new Date();
+      if (Number.isNaN(Date.parse(item.startDate)))
+        return console.log("Workshop has invalid date!");
+      return Date.parse(item.startDate) > new Date();
     });
   });
 

--- a/src/_data/publicRustWorkshops.json
+++ b/src/_data/publicRustWorkshops.json
@@ -1,19 +1,19 @@
 {
   "workshops": [
     {
-      "endDate": "2025-01-24T18:00+01:00",
+      "startDate": "2025-01-23T14:00+01:00",
       "date": "Jan 23rd + 24th, 2025, 14:00-18:00 CET",
       "text": "Remote Workshop: Testing for Rust projects – going beyond the basics",
       "link": "https://ti.to/mainmatter/rust-testing-jan-2025"
     },
     {
-      "endDate": "2025-02-28T18:00+01:00",
+      "startDate": "2025-02-27T14:00+01:00",
       "date": "Feb 27th + 28th, 2025, 14:00-18:00 CET",
       "text": "Remote Workshop: Rust-Python Interoperability",
       "link": "https://ti.to/mainmatter/rust-python-feb-2025"
     },
     {
-      "endDate": "2025-02-21T18:00+01:00",
+      "startDate": "2025-01-30T14:00+01:00",
       "date": "Jan 30th – Feb 21st, 2025, 14:00-18:00 CET",
       "text": "Remote Workshop: Learn Rust, starting from scratch",
       "link": "https://ti.to/mainmatter/rust-from-scratch-jan-2025"

--- a/src/services/workshops/rust.njk
+++ b/src/services/workshops/rust.njk
@@ -90,7 +90,7 @@ image: "/assets/images/workshops/rust-og-image.jpg"
 %}
 {% set workshops = [workshop_1, workshop_2, workshop_3, workshop_4, workshop_5, workshop_6, workshop_7, workshop_8] %}
 {{
-  workshopsList('Our training offering', 'We specialize on Rust on the backend: API services, workers, data pipelines. That focus shapes our training offering.
+  workshopsList('Our training offering', 'We teach Rust across a range of use-cases: API services, workers, data pipelines, native extensions, WASM, and more.
   We can walk alongside you on a journey from zero to hero,
   starting from the basics of the language all the way to advanced testing techniques and comprehensive
   telemetry instrumentation.', workshops)

--- a/src/services/workshops/rust.njk
+++ b/src/services/workshops/rust.njk
@@ -95,7 +95,7 @@ image: "/assets/images/workshops/rust-og-image.jpg"
   starting from the basics of the language all the way to advanced testing techniques and comprehensive
   telemetry instrumentation.', workshops)
 }}
-{% set futurePublicWorkshops = publicRustWorkshops.workshops | future %}
+{% set futurePublicWorkshops = publicRustWorkshops.workshops | upcoming %}
 {{ publicWorkshops(futurePublicWorkshops) }}
 
 <section class="my-10">

--- a/src/services/workshops/svelte.njk
+++ b/src/services/workshops/svelte.njk
@@ -71,7 +71,7 @@ og:
   We can get teams up to speed with Svelte from scratch,
   or help them tackle a range of specific topics.", workshops)
 }}
-{% set futurePublicWorkshops = publicSvelteWorkshops.workshops | future %}
+{% set futurePublicWorkshops = publicSvelteWorkshops.workshops | upcoming %}
 {{ publicWorkshops(futurePublicWorkshops) }}
 
 <section class="my-10">


### PR DESCRIPTION
* Remove the mention of our focus being backend from the Rust workshops page intro. While that's true, we don't want to send people away who are looking for a Rust workshop for their C team that's working on embedded topics or so (think BMW).
* Filter public workshops by start date, not end date – once the workshop has started and it's too late to join, it should disappear.