### PR TITLE
quick fix: set the size of h4 to be the same as h3

### DIFF
--- a/src/assets/css/components/_rte.scss
+++ b/src/assets/css/components/_rte.scss
@@ -24,7 +24,7 @@
     line-height: 1.25;
   }
 
-  h3 {
+  h3, h4 {
     font-weight: 700;
     font-size: rem-calc(24);
     line-height: 1.5;
@@ -180,7 +180,9 @@
   }
 
   h3,
-  .h3 {
+  .h3,
+  h4,
+  .h4 {
     font-family: var(--font-base);
     font-weight: 700;
     font-size: rem-calc(16);
@@ -217,7 +219,7 @@
       font-size: rem-calc(44);
     }
 
-    h3 {
+    h3, h4 {
       margin: 2.5rem 0 1rem;
     }
 


### PR DESCRIPTION
This is something that will need to be fixed properly later but for now we need h4 to not be bigger than h3 🙈 

You can see the problem here: https://deploy-preview-2648--objective-northcutt-37494c.netlify.app/blog/2025/03/07/ember-vite-codemod/#the-transform

`The Transform` is a h3 and `A simple text replacement` is a h4. I've tested this locally and this fixes it 👍 