### PR TITLE
Fix sitemap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,3 +138,30 @@ jobs:
         run: pnpm dlx @gravityci/cli "dist/**/!(*.js.map)"
         env:
           GRAVITY_TOKEN: ${{ secrets.GRAVITY_TOKEN }}
+
+  sitemap:
+    name: 'Validate sitemap'
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/setup-node@v4
+        with:
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install xmllint
+        run: sudo apt-get -y install libxml2-utils
+
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+    
+      - name: install dependencies
+        run: pnpm install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    
+      - name: build
+        run: pnpm build
+    
+      - name: Validate sitemap
+        run: xmllint --noout dist/sitemap.xml

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@ lib/generate-blog/lib/templates/**/*
 lib/generate-resources/lib/templates/**/*
 lib/global-css/css/vendor/normalize.css
 src/ui/components/Header/template.hbs
+src/sitemap.njk
 
 src/feed.njk
 src/atom.njk

--- a/src/sitemap.njk
+++ b/src/sitemap.njk
@@ -3,5 +3,4 @@ permalink: sitemap.xml
 layout: null
 eleventyExcludeFromCollections: true
 ---
-
 {% sitemap collections.all %}


### PR DESCRIPTION
I broke the sitemap when adding Prettier for the `.njk` templates in #2340 as that introduced an extra empty line in the beginning which is not allowed in XML files apparently. This removes that extra line, ignores the sitemap template in Prettier and adds basic validation of the sitemap to CI to prevent this in the future.