### PR TITLE
feat: show header anchor links on hover

### DIFF
--- a/src/assets/css/components/_post.scss
+++ b/src/assets/css/components/_post.scss
@@ -100,7 +100,8 @@
 .post__heading--anchor {
   position: relative;
 
-  &:focus-within {
+  &:focus-within,
+  &:hover {
     .post__heading-anchor {
       opacity: 1;
       pointer-events: auto;


### PR DESCRIPTION
- Shows heading anchor links when heading are hovered in blog posts
![image](https://github.com/user-attachments/assets/47714139-907d-488b-9714-925e77454c17)

Turns out we already had a transform for this but it never showed on hover, instead a user had to focus the element using a tab.

Caveat:

This doesn't cover content defined as `.njk` files such as the `rust-consulting`. I couldn't figure out why Eleventy doesn't want to transform those the same way :shrug: 