### PR TITLE
use custom CTA for Svelte custom renderer blog post

### DIFF
--- a/src/assets/css/components/_cta-banner.scss
+++ b/src/assets/css/components/_cta-banner.scss
@@ -136,6 +136,24 @@
   }
 }
 
+.cta-banner__svelteCustomRenderers {
+  background: #191c23;
+
+  h2 {
+    margin-bottom: 1.5rem;
+  }
+
+  p {
+    font-weight: 400;
+  }
+
+  & a.btn-primary {
+    background-color: #ff3e00;
+    color: #fff;
+    border-radius: 6rem;
+  }
+}
+
 .cta__input {
   min-width: 100%;
 }

--- a/src/assets/css/components/_cta-banner.scss
+++ b/src/assets/css/components/_cta-banner.scss
@@ -137,7 +137,7 @@
 }
 
 .cta-banner__svelteCustomRenderers {
-  background: #191c23;
+  background: #23272f;
 
   h2 {
     margin-bottom: 1.5rem;
@@ -151,12 +151,15 @@
     background-color: #ff3e00;
     color: #fff;
     border-radius: 6rem;
+    gap: 0.5em;
+    padding: 0.85em 1.25em;
   }
 }
 
 .cta__input {
   min-width: 100%;
 }
+
 @media (min-width: $breakpoint-s) {
   .cta__input {
     min-width: 32rem;

--- a/src/components/global/svelte-custom-renders.njk
+++ b/src/components/global/svelte-custom-renders.njk
@@ -1,0 +1,14 @@
+{#
+A call-to-action meant to be displayed at the bottom of a blog post.
+#}
+{% from "cta-banner.njk" import ctaBanner %}
+{%
+  set content = {
+    "title": "Support the Svelte Custom Renderers Initiative",
+    "subheading": "Mainmatter has built a working prototype that proves this is not just an idea—it’s feasible and already functional. We now look for funding that will allow us convert the prototype into a robust, production-ready foundation, ready for everyone to use.",
+    "linkUrl": "https://svelte-custom-renderers.com/?utm_source=mainmatter.com",
+    "linkText": "Support the Initiative",
+    "class": "cta-banner__svelteCustomRenderers"
+  }
+%}
+{{ ctaBanner('purple', 'default', content) }}

--- a/src/components/layouts/post.njk
+++ b/src/components/layouts/post.njk
@@ -68,10 +68,10 @@ layout: base
       %}
       {{ imageAspectRatio(imageData, "32/13", "35/19") }}
     {% endif %}
-    {{ serviceCta(tags) }}
+    {{ serviceCta(tags, customCta) }}
     <div class="post">
       <div class="post__content rte container container--lg ">{{ content | safe }}</div>
-      {{ serviceCta(tags) }}
+      {{ serviceCta(tags, customCta) }}
       <nav aria-label="Post Pagination" class="prev-next pagination container container--lg ">
         {% set previous = collections.posts | getPreviousCollectionItem %}
         {% set next = collections.posts | getNextCollectionItem %}

--- a/src/components/service-cta.njk
+++ b/src/components/service-cta.njk
@@ -1,5 +1,7 @@
-{%- macro serviceCta(tags) -%}
-  {% if not customCta %}
+{%- macro serviceCta(tags, customCta) -%}
+  {% if customCta %}
+    {% include customCta %}
+  {% else %}
     {% if tags %}
       {% for tag in tags %}
         {% if tag === "rust" %}

--- a/src/components/service-cta.njk
+++ b/src/components/service-cta.njk
@@ -1,24 +1,26 @@
 {%- macro serviceCta(tags) -%}
-  {% if tags %}
-    {% for tag in tags %}
-      {% if tag === "rust" %}
-        {% include "global/rust-cta.njk" %}
-      {% endif %}
-      {% if tag === "svelte" %}
-        {% include "global/svelte-cta.njk" %}
-      {% endif %}
-      {% if tag === "ember" %}
-        {% include "global/ember-cta.njk" %}
-      {% endif %}
-      {% if tag === "git" %}
-        {% include "global/git-workshop-cta.njk" %}
-      {% endif %}
-      {% if tag === "design" %}
-        {% include "global/interface-inventory-workshop-cta.njk" %}
-      {% endif %}
-      {% if tag === "gravity" %}
-        {% include "global/gravity-cta.njk" %}
-      {% endif %}
-    {% endfor %}
+  {% if not customCta %}
+    {% if tags %}
+      {% for tag in tags %}
+        {% if tag === "rust" %}
+          {% include "global/rust-cta.njk" %}
+        {% endif %}
+        {% if tag === "svelte" %}
+          {% include "global/svelte-cta.njk" %}
+        {% endif %}
+        {% if tag === "ember" %}
+          {% include "global/ember-cta.njk" %}
+        {% endif %}
+        {% if tag === "git" %}
+          {% include "global/git-workshop-cta.njk" %}
+        {% endif %}
+        {% if tag === "design" %}
+          {% include "global/interface-inventory-workshop-cta.njk" %}
+        {% endif %}
+        {% if tag === "gravity" %}
+          {% include "global/gravity-cta.njk" %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
   {% endif %}
 {%- endmacro -%}

--- a/src/posts/2025-05-22-native-apps-with-svelte.md
+++ b/src/posts/2025-05-22-native-apps-with-svelte.md
@@ -2,7 +2,7 @@
 title: "Truly Native Apps with Svelte?"
 authorHandle: paoloricciuti
 tags: [svelte]
-customCta: true
+customCta: "global/svelte-custom-renders.njk"
 bio: "Paolo Ricciuti, Senior Software Engineer"
 description: "How we set up to build an integration with Lynx to make truly native apps in Svelte"
 autoOg: true

--- a/src/posts/2025-05-22-native-apps-with-svelte.md
+++ b/src/posts/2025-05-22-native-apps-with-svelte.md
@@ -2,6 +2,7 @@
 title: "Truly Native Apps with Svelte?"
 authorHandle: paoloricciuti
 tags: [svelte]
+customCta: true
 bio: "Paolo Ricciuti, Senior Software Engineer"
 description: "How we set up to build an integration with Lynx to make truly native apps in Svelte"
 autoOg: true


### PR DESCRIPTION
…so that we can link to https://svelte-custom-renderers.com

![Bildschirmfoto 2025-06-03 um 19 09 27](https://github.com/user-attachments/assets/ce3c251b-0fd7-4dd2-bddf-fe0ef62a1442)
