### PR TITLE
Set up redirects for ember and svelte to ember/svelte-consulting

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -180,6 +180,14 @@
   to = "/"
 
 [[redirects]]
+  from = "/ember"
+  to = "/ember-consulting/"
+
+[[redirects]]
+  from = "/svelte"
+  to = "/svelte-consulting/"
+
+[[redirects]]
   from = "/rust"
   to = "/rust-consulting/"
 


### PR DESCRIPTION
https://deploy-preview-2737--objective-northcutt-37494c.netlify.app/ember and https://deploy-preview-2737--objective-northcutt-37494c.netlify.app/svelte now work just like https://deploy-preview-2737--objective-northcutt-37494c.netlify.app/rust so we can easily tell people at conferences, "go to mainmatter.com/ember" or "mainmatter.com/svelte is where it's at"