### PR TITLE
stop duplicating author data for each workshop

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -133,9 +133,8 @@ module.exports = async function (eleventyConfig) {
       .sort((a, b) => Date.parse(a.startDate) - Date.parse(b.startDate));
   });
 
-  eleventyConfig.addFilter("getAuthor", (authors, label) => {
-    let author = authors.filter(a => a.key === label)[0];
-    return author;
+  eleventyConfig.addFilter("getAuthor", (authors, handle) => {
+    return authors.find(a => a.fileSlug === handle);
   });
 
   /*

--- a/src/authors/algo_luca.md
+++ b/src/authors/algo_luca.md
@@ -4,4 +4,6 @@ github: LukeMathWalker
 twitter: algo_luca
 mastodon: "@algo_luca@hachyderm.io"
 bio: "Principal Engineering Consultant"
+title: Principal Engineering Consultant
+longBio: Luca Palmieri builds technology products for a living. His current focus is on backend development,  software architecture and the Rust programming language. He is the author of "Zero to Production in Rust".
 ---

--- a/src/authors/ddprrt.md
+++ b/src/authors/ddprrt.md
@@ -3,4 +3,6 @@ name: "Stefan Baumgartner"
 github: ddprrt
 twitter: ddprrt
 bio: "Architect and Independent Trainer"
+title: Architect and Independent Trainer
+longBio: Stefan Baumgartner is an architect and developer based in Austria who specializes in serverless technologies. He has authored two books on TypeScript and is also the organizer of the Rust Linz meetup.
 ---

--- a/src/authors/hdoordt.md
+++ b/src/authors/hdoordt.md
@@ -3,4 +3,6 @@ name: "Henk Oordt"
 github: hdoordt
 linkedin: hdoordt
 bio: "Senior Software Engineering Consultant"
+title: Senior Software Engineering Consultant
+longBio: Henk is a long time Rust engineer with a diverse background in developing Rust applications and others the trade, and has been writing embedded Rust since the early days. As a member of Rust's <a href="https://github.com/rust-embedded/wg/">embedded working group</a>, Henk works on creating educational content on embedded Rust, such as Rust's Discovery book.
 ---

--- a/src/authors/marcoow.md
+++ b/src/authors/marcoow.md
@@ -5,5 +5,7 @@ twitter: marcoow
 linkedin: marco-otte-witte
 mastodon: "@marcoow@mastodon.social"
 bluesky: marcoow.bsky.social
-bio: "Founder and Managing Director of Mainmatter"
+bio: Founder and Managing Director of Mainmatter
+title: Founder and Managing Director of Mainmatter
+longBio: Marco has been working in tech with startups and enterprises for 2 decades. He's helped companies bring relevant products to market in various industries – among them Blackberry, Generali and Experteer.
 ---

--- a/src/authors/paoloricciuti.md
+++ b/src/authors/paoloricciuti.md
@@ -6,4 +6,6 @@ linkedin: paolo-ricciuti-571a91187
 bluesky: paolo.ricciuti.me
 mastodon: "@paoloricciuti@front-end.social"
 bio: "Senior Software Engineer at Mainmatter, Svelte Maintainer"
+title: Senior Frontend Engineer
+longBio: Paolo is a huge nerd and Svelte maintainer. He's also one of the creators of <a href="https://sveltelab.dev">sveltelab.dev</a> - a REPL for SvelteKit.
 ---

--- a/src/authors/pichfl.md
+++ b/src/authors/pichfl.md
@@ -5,4 +5,6 @@ linkedin: pichfl
 mastodon: "@fp@social.lol"
 bluesky: pichfl.bsky.social
 bio: "Consultant for Technology and Design at Mainmatter"
+title: Consultant for Technology and Design
+longBio: Florian bridges the gap between development and design, mentoring clients along the way. He created user experiences and design systems for established brands like Audi, BASF, BMW, and Zurich Insurance.
 ---

--- a/src/authors/real_ate.md
+++ b/src/authors/real_ate.md
@@ -4,5 +4,7 @@ github: mansona
 linkedin: realate
 mastodon: "@real_ate@mastodon.social"
 bluesky: chris.manson.ie
-bio: "Senior Software Engineer, Ember Learning Core Team member"
+bio: "Senior Software Engineer, Ember Tooling Core Team and Learning Core Team member"
+title: Senior Software Engineer
+longBio: Chris is a member of the Ember Core Tooling Team and the Ember Core Learning team and has been working with Ember since 2011. Chris has been working on shipping the Ember Polaris Edition as part of both the Embroider Initiative and the Ember Initiative
 ---

--- a/src/authors/zeppelin.md
+++ b/src/authors/zeppelin.md
@@ -4,4 +4,6 @@ github: zeppelin
 mastodon: "@gabor@babicz.social"
 linkedin: xeppelin
 bio: "Senior Software Engineer"
+title: "Senior Frontend Engineer"
+longBio: Gabor was a very early adopter of Ember in the pre-1.0 years of the framework and has since successfully completed numerous projects with it. He helps teams build applications and teaches best practices along the way.
 ---

--- a/src/components/layouts/workshop.njk
+++ b/src/components/layouts/workshop.njk
@@ -74,7 +74,7 @@ layout: "base"
           <div class="author__details mt-3 author__details--full-width">
             <p>
               {% if lead.bio %}
-                {{ lead.bio }}
+                {{ lead.bio | safe }}
               {% else %}
                 {{ author.data.longBio | safe }}
               {% endif %}

--- a/src/components/layouts/workshop.njk
+++ b/src/components/layouts/workshop.njk
@@ -54,24 +54,31 @@ layout: "base"
         Your mentor{%- if (leads | default([])).length > 1 -%}s{%- endif -%}
       </h2>
       {%- for lead in leads -%}
+
+        {% set author = collections.authors | getAuthor(lead.handle) %}
+
         <div class="author__wrapper">
           <div class="author">
             <div class="workshop-authors__image-wrapper author__image-wrapper">
-              {% image lead.image, lead.name, '3.75rem', 'eager', 'author__lead-image', [120] %}
+              {% image "/assets/images/authors/" + lead.handle + ".jpg", author.data.name, '3.75rem', 'eager', 'author__lead-image', [120] %}
             </div>
             <div class="author__text-wrapper">
               <div class="author__name-wrapper">
-                <h4 class="author__name">{{ lead.name }}</h4>
-                {% if lead.handle %}
-                  {{ authorSocials(lead.handle) }}
-                {% endif %}
+                <h4 class="author__name">{{ author.data.name }}</h4>
+                {{ authorSocials(lead.handle) }}
               </div>
 
-              <p class="author__title large">{{ lead.title }}</p>
+              <p class="author__title large">{{ author.data.title }}</p>
             </div>
           </div>
           <div class="author__details mt-3 author__details--full-width">
-            <p>{{ lead.bio | safe }}</p>
+            <p>
+              {% if lead.bio %}
+                {{ lead.bio }}
+              {% else %}
+                {{ author.data.longBio | safe }}
+              {% endif %}
+            </p>
           </div>
         </div>
       {%- endfor -%}

--- a/src/workshops/advanced-testing-in-rust.md
+++ b/src/workshops/advanced-testing-in-rust.md
@@ -67,13 +67,7 @@ topics:
 
 
 leads:
-  - name: Luca Palmieri
-    title: Principal Engineering Consultant
-    handle: algo_luca
-    image: /assets/images/authors/algo_luca.jpg
-    bio: >
-      Luca Palmieri builds technology products for a living. His current focus is on backend development,  software architecture and the Rust programming language. He is the author of "Zero to Production in Rust".
-
+  - handle: algo_luca
 
 quotes:
   - text: "Extremely well set up!"

--- a/src/workshops/an-introduction-to-testing-in-rust.md
+++ b/src/workshops/an-introduction-to-testing-in-rust.md
@@ -56,12 +56,7 @@ topics:
 
 
 leads:
-  - name: Luca Palmieri
-    title: Principal Engineering Consultant
-    handle: algo_luca
-    image: /assets/images/authors/algo_luca.jpg
-    bio: >
-      Luca Palmieri builds technology products for a living. His current focus is on backend development,  software architecture and the Rust programming language. He is the author of "Zero to Production in Rust".
+  - handle: algo_luca
 ---
 
 <!--break-->

--- a/src/workshops/authentication-for-svelte-sveltekit.md
+++ b/src/workshops/authentication-for-svelte-sveltekit.md
@@ -38,12 +38,7 @@ topics:
 
 
 leads:
-  - name: Paolo Ricciuti
-    title: Senior Frontend Engineer
-    handle: paoloricciuti
-    image: /assets/images/authors/paoloricciuti.jpg
-    bio: >
-      Paolo is a huge nerd and Svelte maintainer. He's also one of the creators of <a href="https://sveltelab.dev">sveltelab.dev</a> - a REPL for SvelteKit.
+  - handle: paoloricciuti
 ---
 
 <!--break-->

--- a/src/workshops/build-production-ready-apis-in-rust.md
+++ b/src/workshops/build-production-ready-apis-in-rust.md
@@ -73,12 +73,7 @@ topics:
 
 
 leads:
-  - name: Luca Palmieri
-    title: Principal Engineering Consultant
-    handle: algo_luca
-    image: /assets/images/authors/algo_luca.jpg
-    bio: >
-      Luca Palmieri builds technology products for a living. His current focus is on backend development, software architecture and the Rust programming language. He is the author of "Zero to Production in Rust".
+  - handle: algo_luca
 ---
 
 <!--break-->

--- a/src/workshops/design-system-kickoff-interface-inventory.md
+++ b/src/workshops/design-system-kickoff-interface-inventory.md
@@ -43,13 +43,7 @@ topics:
 
 
 leads:
-  - name: Florian Pichler
-    title: Consultant for Technology and Design
-    handle: pichfl
-    authorHandle: pichfl
-    image: /assets/images/authors/pichfl.jpg
-    bio: >
-      Florian bridges the gap between development and design, mentoring clients along the way. He created user experiences and design systems for established brands like Audi, BASF, BMW, and Zurich Insurance.
+  - handle: pichfl
 ---
 
 Interface inventories are a key first step to create alignment and advocate transitioning to using design patterns in an organization. To get the most out of this workshop, bring in a cross-disciplinary team – we encourage people from every department that builds your product to join. Designers, developers, project managers, business owners, QA – are all welcome. These are the benefits of having an interface inventory:

--- a/src/workshops/digital-product-strategy.md
+++ b/src/workshops/digital-product-strategy.md
@@ -43,22 +43,8 @@ topics:
 
 
 leads:
-  - name: Florian Pichler
-    title: Consultant for Technology and Design
-    handle: pichfl
-    authorHandle: pichfl
-    image: /assets/images/authors/pichfl.jpg
-    bio: >
-      Florian bridges the gap between development and design, mentoring clients along the way. He created user experiences and design systems for established brands like Audi, BASF, BMW, and Zurich Insurance.
-
-
-  - name: Marco Otte-Witte
-    title: Founder and Managing Director at Mainmatter
-    handle: marcoow
-    authorHandle: marcoow
-    image: /assets/images/authors/marcoow.jpg
-    bio: >
-      Marco has been working in tech with startups and enterprises for 2 decades. He's helped companies bring relevant products to market in various industries – among them Blackberry, Generali and Experteer.
+  - handle: pichfl
+  - handle: marcoow
 ---
 
 <!--break-->

--- a/src/workshops/effective-git.md
+++ b/src/workshops/effective-git.md
@@ -43,22 +43,12 @@ topics:
 
 
 leads:
-  - name: Chris Manson
-    title: Senior Engineering Consultant
-    handle: real_ate
-    authorHandle: real_ate
-    image: /assets/images/authors/real_ate.jpg
+  - handle: real_ate
     bio: >
       Chris has had a long history with version control systems, with his very first Open Source experience being involved in the transition of the massive KDE codebase from CVS to Git. These days Chris is deeply involved in the JAM Stack movement, giving him a new outlet for his love for Git.
 
 
-  - name: Marco Otte-Witte
-    title: Founder and Managing Director at Mainmatter
-    handle: marcoow
-    authorHandle: marcoow
-    image: /assets/images/authors/marcoow.jpg
-    bio: >
-      Marco has been working in tech with startups and enterprises for 2 decades. He's helped companies bring relevant products to market in various industries – among them Blackberry, Generali and Experteer.
+  - handle: marcoow
 ---
 
 <!--break-->

--- a/src/workshops/foundations-of-embedded-rust.md
+++ b/src/workshops/foundations-of-embedded-rust.md
@@ -55,10 +55,5 @@ topics:
 
 
 leads:
-  - name: Henk Oordt
-    title: Senior Software Engineering Consultant
-    handle: hdoordt
-    image: /assets/images/authors/hdoordt.jpg
-    bio: >
-      Henk is a long time Rust engineer with a diverse background in developing Rust applications and others the trade, and has been writing embedded Rust since the early days. As a member of Rust's <a href="https://github.com/rust-embedded/wg/">embedded working group</a>, Henk works on creating educational content on embedded Rust, such as Rust's Discovery book.
+  - handle: hdoordt
 ---

--- a/src/workshops/hands-on-ember.md
+++ b/src/workshops/hands-on-ember.md
@@ -63,21 +63,8 @@ optional_topics:
 
 
 leads:
-  - name: Gabor Babicz
-    title: Senior Frontend Engineer
-    handle: zeppelin
-    image: /assets/images/authors/zeppelin.jpg
-    bio: >
-      Gabor was a very early adopter of Ember in the pre-1.0 years of the framework and has since successfully completed numerous projects with it. He helps teams build applications and teaches best practices along the way.
-
-
-  - name: Marco Otte-Witte
-    title: Founder and Managing Director at Mainmatter
-    handle: marcoow
-    authorHandle: marcoow
-    image: /assets/images/authors/marcoow.jpg
-    bio: >
-      Marco has been working in tech with startups and enterprises for 2 decades. He's helped companies bring relevant products to market in various industries – among them Blackberry, Generali and Experteer.
+  - handle: zeppelin
+  - handle: marcoow
 ---
 
 <!--break-->

--- a/src/workshops/introduction-to-rust-for-web-developers.md
+++ b/src/workshops/introduction-to-rust-for-web-developers.md
@@ -36,12 +36,7 @@ topics:
 
 
 leads:
-  - name: Stefan Baumgartner
-    title: Architect and Independent Trainer
-    handle: ddprrt
-    image: /assets/images/authors/ddprrt.jpg
-    bio: >
-      Stefan Baumgartner is an architect and developer based in Austria who specializes in serverless technologies. He has authored two books on TypeScript and is also the organizer of the Rust Linz meetup.
+  - handle: ddprrt
 ---
 
 <!--break-->

--- a/src/workshops/learn-rust-starting-from-scratch.md
+++ b/src/workshops/learn-rust-starting-from-scratch.md
@@ -47,13 +47,7 @@ topics:
 
 
 leads:
-  - name: Luca Palmieri
-    title: Principal Engineering Consultant
-    handle: algo_luca
-    image: /assets/images/authors/algo_luca.jpg
-    bio: >
-      Luca Palmieri builds technology products for a living. His current focus is on backend development,  software architecture and the Rust programming language. He is the author of "Zero to Production in Rust".
-
+  - handle: algo_luca
 
 quotes:
   - text: "Amazing support from Luca! Detailed explanation of different topics whenever requested."

--- a/src/workshops/progressive-enhancement-with-sveltekit.md
+++ b/src/workshops/progressive-enhancement-with-sveltekit.md
@@ -48,12 +48,7 @@ topics:
 
 
 leads:
-  - name: Paolo Ricciuti
-    title: Senior Frontend Engineer
-    handle: paoloricciuti
-    image: /assets/images/authors/paoloricciuti.jpg
-    bio: >
-      Paolo is a huge nerd and Svelte maintainer. He's also one of the creators of <a href="https://sveltelab.dev">sveltelab.dev</a> - a REPL for SvelteKit.
+  - handle: paoloricciuti
 ---
 
 <!--break-->

--- a/src/workshops/rust-python-interoperability.md
+++ b/src/workshops/rust-python-interoperability.md
@@ -45,13 +45,7 @@ topics:
 
 
 leads:
-  - name: Luca Palmieri
-    title: Principal Engineering Consultant
-    handle: algo_luca
-    image: /assets/images/authors/algo_luca.jpg
-    bio: >
-      Luca Palmieri builds technology products for a living. His current focus is on backend development, software architecture and the Rust programming language. He is the author of "Zero to Production in Rust".
-
+  - handle: algo_luca
 
 quotes:
   - text: "[…] Really enjoyed the training. The approach of self-paced, bit of background reading and including solutions, works for me."

--- a/src/workshops/svelte-5-runes.md
+++ b/src/workshops/svelte-5-runes.md
@@ -53,12 +53,7 @@ topics:
 
 
 leads:
-  - name: Paolo Ricciuti
-    title: Senior Frontend Engineer
-    handle: paoloricciuti
-    image: /assets/images/authors/paoloricciuti.jpg
-    bio: >
-      Paolo is a huge nerd and Svelte maintainer. He's also one of the creators of <a href="https://sveltelab.dev">sveltelab.dev</a> - a REPL for SvelteKit.
+  - handle: paoloricciuti
 ---
 
 <!--break-->

--- a/src/workshops/svelte-and-sveltekit.md
+++ b/src/workshops/svelte-and-sveltekit.md
@@ -48,12 +48,7 @@ topics:
 
 
 leads:
-  - name: Paolo Ricciuti
-    title: Senior Frontend Engineer
-    handle: paoloricciuti
-    image: /assets/images/authors/paoloricciuti.jpg
-    bio: >
-      Huge nerd, Svelte Ambassador and lover. He's one of the creators of <a href="https://sveltelab.dev">sveltelab.dev</a> - a REPL for SvelteKit - built during the first Svelte hackathon that granted him and his co-creator the first place for best integration.
+  - handle: paoloricciuti
 ---
 
 <!--break-->

--- a/src/workshops/svelte-without-svelte.md
+++ b/src/workshops/svelte-without-svelte.md
@@ -43,12 +43,7 @@ topics:
 
 
 leads:
-  - name: Paolo Ricciuti
-    title: Senior Frontend Engineer
-    handle: paoloricciuti
-    image: /assets/images/authors/paoloricciuti.jpg
-    bio: >
-      Paolo is a huge nerd and Svelte maintainer. He's also one of the creators of <a href="https://sveltelab.dev">sveltelab.dev</a> - a REPL for SvelteKit.
+  - handle: paoloricciuti
 ---
 
 <!--break-->

--- a/src/workshops/telemetry-for-rust-apis.md
+++ b/src/workshops/telemetry-for-rust-apis.md
@@ -33,13 +33,7 @@ topics:
 
 
 leads:
-  - name: Luca Palmieri
-    title: Principal Engineering Consultant
-    handle: algo_luca
-    image: /assets/images/authors/algo_luca.jpg
-    bio: >
-      Luca Palmieri builds technology products for a living. His current focus is on backend development, software architecture and the Rust programming language. He is the author of "Zero to Production in Rust".
-
+  - handle: algo_luca
 
 quotes:
   - text: "Throughly Enjoyed the excercises format. Looking forward to more workshops for middle to advanced rust developers […]"

--- a/src/workshops/testing-svelte-sveltekit-applications.md
+++ b/src/workshops/testing-svelte-sveltekit-applications.md
@@ -38,12 +38,7 @@ topics:
 
 
 leads:
-  - name: Paolo Ricciuti
-    title: Senior Frontend Engineer
-    handle: paoloricciuti
-    image: /assets/images/authors/paoloricciuti.jpg
-    bio: >
-      Paolo is a huge nerd and Svelte maintainer. He's also one of the creators of <a href="https://sveltelab.dev">sveltelab.dev</a> - a REPL for SvelteKit.
+  - handle: paoloricciuti
 ---
 
 <!--break-->


### PR DESCRIPTION
There is some serious duplication happening on our website 🙈 we have author data that we're not using in a lot of places and we're just duplicating the same information everywhere.

This simplifies things a bit when it comes to titles and bios that show up on the workshops pages, there can be some further unification between title, bio, and longBio fields but that can happen later 👍 