### PR TITLE
drop Effective Git workshop down the list

### DIFF
--- a/src/services/workshops.njk
+++ b/src/services/workshops.njk
@@ -24,7 +24,6 @@ og:
   set workshops = [
   collections.workshops | findByCollectionSlug("design-system-kickoff-interface-inventory"),
   collections.workshops | findByCollectionSlug("digital-product-strategy"),
-  collections.workshops | findByCollectionSlug("effective-git"),
   collections.workshops | findByCollectionSlug("svelte-and-sveltekit"),
   collections.workshops | findByCollectionSlug("hands-on-ember"),
   collections.workshops | findByCollectionSlug("learn-rust-starting-from-scratch"),
@@ -39,7 +38,8 @@ og:
   collections.workshops | findByCollectionSlug("authentication-for-svelte-sveltekit"),
   collections.workshops | findByCollectionSlug("rust-python-interoperability"),
   collections.workshops | findByCollectionSlug("foundations-of-embedded-rust"),
-  collections.workshops | findByCollectionSlug("svelte-without-svelte")
+  collections.workshops | findByCollectionSlug("svelte-without-svelte"),
+  collections.workshops | findByCollectionSlug("effective-git")
   ]
 %}
 {{


### PR DESCRIPTION
We discussed this and we thought that it's a bit overkill to have Effective Git on the top row of workshops, so we are dropping it to the bottom of the list