### PR TITLE
add ids to events so we can link to them

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -208,6 +208,14 @@
   from = "/embroider-initiative"
   to = "/ember-initiative/"
 
+# redirect /svelte-week to July '25 workshops
+[[redirects]]
+  from = "/svelte-week"
+  to = "/events/#svelte-5-and-runes"
+[[redirects]]
+  from = "/svelteweek"
+  to = "/events/#svelte-5-and-runes"
+
 # redirect old "Web-based Services in Rust" landing page to regular workshop
 [[redirects]]
   from = "https://rust-web-services-workshop.mainmatter.com/*"

--- a/src/components/event-card.njk
+++ b/src/components/event-card.njk
@@ -12,6 +12,7 @@ event: A event object
   <li
     class="event-card event-card--{{ event.data.color }}"
     data-background-color="{{ event.data.color }}"
+    id="{{ event.data.title | slug }}"
   >
     {% if event.data.hero.image %}
       <div class="card__background-wrapper">


### PR DESCRIPTION
e.g. https://deploy-preview-2747--objective-northcutt-37494c.netlify.app/events/#svelte-5-and-runes

Also this adds a nicer URL `/svelte-week` that links to the first workshop in the list