### PR TITLE
redirect exercises subdomain to rust-exercises.com

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -245,6 +245,11 @@
   to = "https://mainmatter.com/blog/2025/03/11/global-state-in-svelte-5/"
   force = true
 
+# redirect exercises.mainmatter.com to Rust Exercises
+[[redirects]]
+  from = "https://exercises.mainmatter.com/*"
+  to = "https://rust-exercises.com"
+
 # serve 404 for all paths that don't exist
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
The subdomain doesn't actually exist but ChatGPT hallucinated it and we can make it work.