### PR TITLE
chore: show all blog posts when doing `pnpm serve`

### DIFF
--- a/collections/posts.js
+++ b/collections/posts.js
@@ -1,7 +1,10 @@
 const pathConfig = require("../src/_data/paths.json");
 const sortByDate = require("../utils/sortByDate");
 const now = new Date();
-const livePosts = post => post.date <= now && !post.data.draft;
+// show all the posts that are not drafts and have a date before now unless we are in serve mode
+// so it will show a blog post you are working on locally
+const livePosts = post =>
+  (post.date <= now && !post.data.draft) || process.env.ELEVENTY_RUN_MODE !== "build";
 
 module.exports = collection => {
   return [

--- a/src/components/global/svelte-workshops-cta.njk
+++ b/src/components/global/svelte-workshops-cta.njk
@@ -7,8 +7,9 @@
 >
   <div class="cta-banner__wrapper">
     <div class="cta-banner__main">
-      <div class="cta-banner__text mt-0">We are running a workshop on Svelte and TypeScript in September, taught by
-        Svelte Maintainer Paolo Ricciuti fully remote over multiple afternoons.
+      <div class="cta-banner__text mt-0">
+        We are running a workshop on Svelte and TypeScript in September, taught by Svelte Maintainer
+        Paolo Ricciuti fully remote over multiple afternoons.
       </div>
       <h4 class="cta-banner__subheading mt-2">Practical TypeScript</h4>
       <p class="small">September 15th-18th 2025, 14:00-18:00 CEST</p>


### PR DESCRIPTION
This is something that always bother me: when creating a new blog post is not shown locally because it's in the future.

This changes that by only applying the filter when we are in build mode and not in serve.