### PR TITLE
Improve link crawler stability

### DIFF
--- a/scripts/crawl.js
+++ b/scripts/crawl.js
@@ -14,7 +14,7 @@ server.listen(3000, function () {
   let errors = 0;
 
   const siteChecker = new SiteChecker(
-    {},
+    { maxSocketsPerHost: 1 },
     {
       link(result) {
         if (result.broken) {


### PR DESCRIPTION
…by limiting the number of requests that are checked concurrently per host to 1 which should reduce the stress on the local Express server and make the job more stable.

If this doesn't turn out to be sufficient, we can add [rate limiting](https://github.com/stevenvachon/broken-link-checker?tab=readme-ov-file#ratelimit).