### PR TITLE
make marketing opt-in non-mandatory for download forms

### DIFF
--- a/src/rust-adoption-handbook.njk
+++ b/src/rust-adoption-handbook.njk
@@ -127,7 +127,6 @@ og:
                   id="marketing_opt_in"
                   type="checkbox"
                   name="marketing_opt_in"
-                  required
                 />
                 <span>I agree to receive other communication from Mainmatter.</span>
               </label>

--- a/src/travel.njk
+++ b/src/travel.njk
@@ -121,7 +121,6 @@ og:
                   id="marketing_opt_in"
                   type="checkbox"
                   name="marketing_opt_in"
-                  required
                 />
                 <span>I agree to receive other communication from Mainmatter.</span>
               </label>


### PR DESCRIPTION
We're not doing ourselves (and our conversions) a favor by only sending the PDFs to people that also opt-in to **other** marketing communication