### PR TITLE
Update netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
 [[headers]]
   for = "/*"
   [headers.values]
-  "Content-Security-Policy" = "script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://platform.twitter.com https://plausible.io https://app.netlify.com https://cdnjs.cloudflare.com https://widget.clutch.co; frame-src https://challenges.cloudflare.com https://app.netlify.com  https://www.youtube-nocookie.com https://widget.clutch.co https://platform.twitter.com; object-src 'none';"
+  "Content-Security-Policy" = "script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://platform.twitter.com https://plausible.io https://app.netlify.com https://cdnjs.cloudflare.com https://widget.clutch.co https://www.googletagmanager.com https://www.googleadservices.com https://t.contentsquare.net; frame-src https://challenges.cloudflare.com https://app.netlify.com  https://www.youtube-nocookie.com https://widget.clutch.co https://platform.twitter.com; object-src 'none';"
 
 [build]
   environment = { NODE_VERSION = "22.13.0" }

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,7 @@
 [[headers]]
   for = "/*"
   [headers.values]
-  "Content-Security-Policy" = "script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://platform.twitter.com https://plausible.io https://app.netlify.com https://cdnjs.cloudflare.com https://widget.clutch.co https://www.googletagmanager.com https://www.googleadservices.com https://t.contentsquare.net; frame-src https://challenges.cloudflare.com https://app.netlify.com  https://www.youtube-nocookie.com https://widget.clutch.co https://platform.twitter.com; object-src 'none';"
+  "Content-Security-Policy" = "script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://platform.twitter.com https://plausible.io https://app.netlify.com https://cdnjs.cloudflare.com https://widget.clutch.co https://www.googletagmanager.com https://www.googleadservices.com https://t.contentsquare.net; worker-src 'self' blob:; frame-src https://challenges.cloudflare.com https://app.netlify.com  https://www.youtube-nocookie.com https://widget.clutch.co https://platform.twitter.com; object-src 'none';"
 
 [build]
   environment = { NODE_VERSION = "22.13.0" }


### PR DESCRIPTION
This PR updates our netlify.toml by whitelisting domains used by Google Tag and Contentsquare