### PR TITLE
Website fixes

### DIFF
--- a/src/assets/css/app.scss
+++ b/src/assets/css/app.scss
@@ -79,4 +79,4 @@
 
 @use "base/utility";
 
-@import "utils/silktide-consent-manager";
+@use "utils/silktide-consent-manager";

--- a/src/assets/css/components/_image-list.scss
+++ b/src/assets/css/components/_image-list.scss
@@ -1,11 +1,54 @@
+@use "../base/breakpoints" as *;
+
 .image-list__image {
   text-align: center;
 
   img,
   svg {
-    max-height: 10rem;
-    max-width: 10rem;
+    height: 10rem;
+    width: 10rem;
+    object-fit: contain;
     margin: 0 auto;
     display: block;
+  }
+
+  &--100-exercises-to-learn-rust {
+    img {
+      max-height: 15rem;
+    }
+  }
+}
+
+#image-list {
+  .logo-list__list {
+    width: auto;
+    gap: 0;
+  }
+
+  .logo-list__inner {
+    gap: 0;
+    width: max-content;
+  }
+
+  .logo-list__list--duplicate {
+    margin-left: 0;
+  }
+
+  .logo-list__item {
+    flex-shrink: 0;
+    flex-grow: 0;
+    padding-left: 6rem;
+  }
+
+  @media (min-width: $breakpoint-s) {
+    .logo-list__item {
+      padding-left: 6rem;
+    }
+  }
+
+  @media (min-width: $breakpoint-l) {
+    .logo-list__item {
+      padding-left: 8rem;
+    }
   }
 }

--- a/src/assets/js/nav.js
+++ b/src/assets/js/nav.js
@@ -19,14 +19,15 @@ const throttle = (fn, delay) => {
   };
 };
 
-window.addEventListener(
-  "scroll",
-  throttle(() => {
-    if (window.scrollY > 10) {
-      nav.classList.add("nav__scrolled");
-    } else {
-      nav.classList.remove("nav__scrolled");
-    }
-  }, 100),
-  { passive: true }
-);
+const handleScroll = () => {
+  if (window.scrollY > 10) {
+    nav.classList.add("nav__scrolled");
+  } else {
+    nav.classList.remove("nav__scrolled");
+  }
+};
+
+// Run once immediately to handle reloads mid-page
+handleScroll();
+
+window.addEventListener("scroll", throttle(handleScroll, 100), { passive: true });

--- a/src/components/contact-form-LP.njk
+++ b/src/components/contact-form-LP.njk
@@ -89,7 +89,6 @@
                 type="text"
                 name="referral_source"
                 placeholder="How did you find us?"
-                required
               />
               <label class="contact-form__label h4" for="contact-referral-source">
                 How did you find us?

--- a/src/components/contact-form.njk
+++ b/src/components/contact-form.njk
@@ -81,7 +81,6 @@
               type="text"
               name="referral_source"
               placeholder="How did you find us?"
-              required
             />
             <label class="contact-form__label h4" for="contact-referral-source">
               How did you find us?

--- a/src/components/image-list.njk
+++ b/src/components/image-list.njk
@@ -1,5 +1,5 @@
 {#
-List of images.
+List of images. Based on logo-list.njk. 
 
 Configuration Options:
 images: An array of arrays, where each inner array contains an image name (file name) and the file extension (an image extension such as 'png'/'jpg' or 'svg').
@@ -53,7 +53,7 @@ Example usage:
         class="logo-list__inner"
         data-marquee
         {% if not animate %}data-marquee-disable{% endif %}
-        style="--marquee-image-count: {{ images | length }};"
+        style="--marquee-logo-count: {{ images | length }};"
       >
         <ul class="logo-list__list">
           {% for image in images %}

--- a/src/components/image-list.njk
+++ b/src/components/image-list.njk
@@ -17,7 +17,7 @@ Example usage:
 
   <li class="logo-list__item">
     <div
-      class="logo-list__image image-list__image"
+      class="logo-list__image image-list__image image-list__image--{{ fileName | slug }}"
       aria-label="{{ fileName | replace('-', ' ') | title }}"
     >
       {% if fileExt == 'svg' %}
@@ -29,7 +29,7 @@ Example usage:
         <img
           src="/assets/images{{ imagePath }}"
           alt="{{ fileName | replace('-', ' ') | title }}"
-          loading="lazy"
+          {% if not eager %}loading="lazy"{% endif %}
         />
       {% endif %}
     </div>
@@ -62,7 +62,7 @@ Example usage:
         </ul>
         <ul class="logo-list__list logo-list__list--duplicate" aria-hidden="true">
           {% for image in images %}
-            {{ listItem(image) }}
+            {{ listItem(image, eager=true) }}
           {% endfor %}
         </ul>
       </div>


### PR DESCRIPTION
1. Contact form: make "How did you hear from us" not required
2. Homepage image-list: fix image overlap and scrolling gaps
3. _silktide-onsent-manager.scss: move from "import ....scss" to "use" to heed the deprecation warning
4. Nav bar: add nav__scrolled styling on mid-page reloads. 