### PR TITLE
chore: add mainmatter content review skill

### DIFF
--- a/.agents/skills/mainmatter-content-review/SKILL.md
+++ b/.agents/skills/mainmatter-content-review/SKILL.md
@@ -1,62 +1,37 @@
 ---
 name: mainmatter-content-review
 description: >
-  Review Mainmatter-authored content (blog posts, case studies, marketing pages,
-  landing pages, white papers, workshop materials, conference talks, newsletters,
-  social posts) for typos, grammatical errors, English correctness, and alignment
-  with the Mainmatter voice. Use this skill whenever anyone at Mainmatter asks to
-  proofread, review, copy-edit, check, fix, polish, or improve a piece of written
-  content, or shares a GitHub PR, Notion page, markdown file, or raw text for
-  review. Trigger on phrases like "review this post", "check this for typos",
-  "is this in Mainmatter voice", "copy-edit this", "proofread the PR", "look
-  over this draft", "does this read right", "tone check", "how does this sound",
-  or "fix the English". Also trigger on Notion URLs referencing drafts, case
-  studies, blog outlines, SEO or content pages, and on GitHub PRs touching
-  src/*.njk files, blog markdown files, cases/*, or other prose-heavy files.
-  This skill reviews prose only, never code.
+  Review Mainmatter-authored content (blog posts, case studies, marketing pages, landing pages, white papers, workshop materials, conference talks, newsletters, social posts) for typos, grammatical errors, English correctness, and alignment with the Mainmatter voice. Use this skill whenever anyone at Mainmatter asks to proofread, review, copy-edit, check, fix, polish, or improve a piece of written content, or shares a GitHub PR, Notion page, markdown file, or raw text for review. Trigger on phrases like "review this post", "check this for typos", "is this in Mainmatter voice", "copy-edit this", "proofread the PR", "look over this draft", "does this read right", "tone check", "how does this sound", or "fix the English". Also trigger on Notion URLs referencing drafts, case studies, blog outlines, SEO or content pages, and on GitHub PRs touching src/*.njk files, blog markdown files, cases/*, or other prose-heavy files. This skill reviews prose only, never code.
 ---
 
 # Mainmatter content review
 
-Review Mainmatter content for language correctness and voice fit. The team is
-international, so English is most authors' second language: the skill is tuned
-to catch translation smells and L2 patterns without being precious about
-US-vs-UK preferences. The skill reads international English — either US or UK
-spelling is fine, as long as one document is consistent.
+Review Mainmatter content for language correctness and voice fit. The team is international, so English is most authors' second language: the skill is tuned to catch translation smells and L2 patterns without being precious about US-vs-UK preferences. The skill reads international English — either US or UK spelling is fine, as long as one document is consistent.
 
-The skill's job is to help a writer find the balance between their own voice
-and the Mainmatter writing standard. It is not a style police. It surfaces
-concrete, actionable suggestions with a clear before/after, so the writer can
-accept or reject each one fast.
+The skill's job is to help a writer find the balance between their own voice and the Mainmatter writing standard. It is not a style police. It surfaces concrete, actionable suggestions with a clear before/after, so the writer can accept or reject each one fast.
 
 ## Inputs
 
 Accept any of:
-- **GitHub PR URL** (e.g. `https://github.com/mainmatter/mainmatter.com/pull/2857`) —
-  diff the PR branch against master, isolate prose changes, review those.
+
+- **GitHub PR URL** (e.g. `https://github.com/mainmatter/mainmatter.com/pull/2857`) — diff the PR branch against master, isolate prose changes, review those.
 - **Notion page URL** — fetch via Notion MCP, review the page content.
-- **Markdown, .txt, or .docx file** uploaded or passed by path — review the full
-  document.
+- **Markdown, .txt, or .docx file** uploaded or passed by path — review the full document.
 - **Raw text** pasted into the chat — review in-place.
 
-If the input is ambiguous (e.g. a repo URL without a PR number), ask what to
-review. If the PR or page is large and mixes code with prose, make clear which
-parts were reviewed and which were skipped.
+If the input is ambiguous (e.g. a repo URL without a PR number), ask what to review. If the PR or page is large and mixes code with prose, make clear which parts were reviewed and which were skipped.
 
 ## What this skill reviews (and doesn't)
 
 Reviews:
-- Prose in blog posts, case studies, landing page copy, marketing pages,
-  workshop and talk outlines, newsletters, social posts, SEO metadata (title,
-  description, name), and the prose portions of `.njk`, `.md`, `.mdx` files.
-- Human-readable fields in structured files: `title`, `description`, `name`,
-  `og:*` text, schema.org text fields.
+
+- Prose in blog posts, case studies, landing page copy, marketing pages, workshop and talk outlines, newsletters, social posts, SEO metadata (title, description, name), and the prose portions of `.njk`, `.md`, `.mdx` files.
+- Human-readable fields in structured files: `title`, `description`, `name`, `og:*` text, schema.org text fields.
 
 Does not review:
-- Source code, code blocks, shell commands, configuration values, dependency
-  versions, imports, exports, or the technical correctness of anything.
-- Auto-generated content (lockfiles, build output, transcripts) unless the user
-  explicitly asks.
+
+- Source code, code blocks, shell commands, configuration values, dependency versions, imports, exports, or the technical correctness of anything.
+- Auto-generated content (lockfiles, build output, transcripts) unless the user explicitly asks.
 
 When in doubt, skip and note it at the top of the output.
 
@@ -64,10 +39,7 @@ When in doubt, skip and note it at the top of the output.
 
 ### Step 1: Fetch the content
 
-- **GitHub PR**: clone the PR branch shallowly and diff against `master`.
-  Use the clone tool when `web_fetch` is rate-limited — the `github.com` domain
-  is allowed for bash. The repo is generally `mainmatter/mainmatter.com` but
-  can be any Mainmatter repo.
+- **GitHub PR**: clone the PR branch shallowly and diff against `master`. Use the clone tool when `web_fetch` is rate-limited — the `github.com` domain is allowed for bash. The repo is generally `mainmatter/mainmatter.com` but can be any Mainmatter repo.
 
   ```bash
   git clone --depth 50 --branch <branch> https://github.com/<org>/<repo>.git /home/claude/review
@@ -76,38 +48,28 @@ When in doubt, skip and note it at the top of the output.
   git diff master..<branch> -- <prose-files>
   ```
 
-  Prose-file filter (rough heuristic): `*.md`, `*.mdx`, `*.njk`, `*.html`,
-  `*.txt`, plus text fields within `*.yaml`, `*.json` when they are clearly
-  human-facing (title, description, name, body, content).
+  Prose-file filter (rough heuristic): `*.md`, `*.mdx`, `*.njk`, `*.html`, `*.txt`, plus text fields within `*.yaml`, `*.json` when they are clearly human-facing (title, description, name, body, content).
 
-- **Notion page**: call `Notion:notion-fetch` on the page URL. Extract plain
-  text content and preserve section structure so location references are
-  meaningful.
+- **Notion page**: call `Notion:notion-fetch` on the page URL. Extract plain text content and preserve section structure so location references are meaningful.
 
-- **Uploaded file**: read from `/mnt/user-data/uploads/`. For `.docx`, follow
-  `/mnt/skills/public/docx/SKILL.md` to extract text.
+- **Uploaded file**: read from `/mnt/user-data/uploads/`. For `.docx`, follow `/mnt/skills/public/docx/SKILL.md` to extract text.
 
 - **Raw text**: take it as-is.
 
 ### Step 2: Identify prose spans
 
 Separate prose from non-prose before reviewing:
-- Skip fenced code blocks (```), inline code (`` ` ``), YAML keys and non-text
-  values, shell output, HTML tag names/attributes (review attribute **values**
-  only when they are user-facing text like `alt`, `title`, `aria-label`,
-  `<meta content="...">`).
-- In `.njk` frontmatter, review values for keys: `title`, `description`,
-  `name`, `og:*` text, `description`, schema.org text fields. Skip: permalinks,
-  image paths, type enums, booleans, arrays of tech keywords.
-- In Notion pages, skip property values that are enums, dates, or IDs. Review
-  rich text content.
+
+- Skip fenced code blocks (``), inline code (` ` ``), YAML keys and non-text values, shell output, HTML tag names/attributes (review attribute **values** only when they are user-facing text like `alt`, `title`, `aria-label`, `<meta content="...">`).
+- In `.njk` frontmatter, review values for keys: `title`, `description`, `name`, `og:*` text, `description`, schema.org text fields. Skip: permalinks, image paths, type enums, booleans, arrays of tech keywords.
+- In Notion pages, skip property values that are enums, dates, or IDs. Review rich text content.
 
 ### Step 3: Run the review
 
 Run the six checks below against the prose spans. For each finding, capture:
+
 - **Location** — file + line, or section heading for Notion.
-- **Category** — one of: Typo, Grammar, Punctuation, Consistency, Voice,
-  Clarity.
+- **Category** — one of: Typo, Grammar, Punctuation, Consistency, Voice, Clarity.
 - **Severity** — `must-fix`, `should-fix`, `nice-to-have`.
 - **Before / After** — exact text.
 - **Why** — one short sentence.
@@ -115,113 +77,71 @@ Run the six checks below against the prose spans. For each finding, capture:
 #### Check 1: Spelling and typos
 
 - Flag misspellings.
-- Pay special attention to product, framework, and person names:
-  Mainmatter (one word, capital M only at the start), Svelte, SvelteKit,
-  Ember.js (with `.js`), Rust, EuroRust, EmberFest, Svelte Summit, Embroider,
-  Vite, TypeScript, JavaScript.
-- Flag capitalization errors in product names (e.g. `svelte`, `ember`,
-  `Typescript`, `Javascript` — all wrong in prose).
-- Flag Mainmatter engineers' names when misspelled: Luca Palmieri,
-  Chris Manson, Paolo Ricciuti, Marco Otte-Witte, Marine Dunstetter, etc.
-  If unsure about a name spelling, note it as uncertain rather than silently
-  correcting.
+- Pay special attention to product, framework, and person names: Mainmatter (one word, capital M only at the start), Svelte, SvelteKit, Ember.js (with `.js`), Rust, EuroRust, EmberFest, Svelte Summit, Embroider, Vite, TypeScript, JavaScript.
+- Flag capitalization errors in product names (e.g. `svelte`, `ember`, `Typescript`, `Javascript` — all wrong in prose).
+- Flag Mainmatter engineers' names when misspelled: Luca Palmieri, Chris Manson, Paolo Ricciuti, Marco Otte-Witte, Marine Dunstetter, etc. If unsure about a name spelling, note it as uncertain rather than silently correcting.
 
 #### Check 2: Grammar
 
-Subject-verb agreement, article usage (`a/an/the`), preposition choice, tense
-consistency, pronoun reference, dangling modifiers, sentence fragments.
+Subject-verb agreement, article usage (`a/an/the`), preposition choice, tense consistency, pronoun reference, dangling modifiers, sentence fragments.
 
-Treat "Mainmatter" as singular in prose ("Mainmatter is", "Mainmatter offers"),
-not plural ("Mainmatter are"). Published Mainmatter content is consistent on
-this — flag inconsistencies when one document mixes both.
+Treat "Mainmatter" as singular in prose ("Mainmatter is", "Mainmatter offers"), not plural ("Mainmatter are"). Published Mainmatter content is consistent on this — flag inconsistencies when one document mixes both.
 
 #### Check 3: Punctuation
 
-Comma splices, missing commas before conjunctions in long sentences, run-on
-sentences, mismatched quotes, inconsistent use of em dashes vs. hyphens vs.
-en dashes. Em dashes are fine in Mainmatter content (`—`, not `--`).
+Comma splices, missing commas before conjunctions in long sentences, run-on sentences, mismatched quotes, inconsistent use of em dashes vs. hyphens vs. en dashes. Em dashes are fine in Mainmatter content (`—`, not `--`).
 
 #### Check 4: Consistency
 
 Within a single document:
-- US vs. UK spelling — pick one and stick to it (flag mixes like "organize"
-  alongside "optimisation").
+
+- US vs. UK spelling — pick one and stick to it (flag mixes like "organize" alongside "optimisation").
 - Title Case vs. sentence case in headings — pick one.
-- Product names: always `Ember.js` (not `Ember` inconsistently, though
-  `Ember` alone is fine when the context is clear).
-- Hyphenation of compounds: `open source` (noun) vs. `open-source` (adjective);
-  `cloud native` vs. `cloud-native`. Match the doc's chosen style.
+- Product names: always `Ember.js` (not `Ember` inconsistently, though `Ember` alone is fine when the context is clear).
+- Hyphenation of compounds: `open source` (noun) vs. `open-source` (adjective); `cloud native` vs. `cloud-native`. Match the doc's chosen style.
 
 #### Check 5: Voice and tone (Mainmatter voice)
 
-Read `references/mainmatter-voice.md` for the full voice guide and a checklist
-of patterns to reinforce and to flag. Core tests:
+Read `references/mainmatter-voice.md` for the full voice guide and a checklist of patterns to reinforce and to flag. Core tests:
 
-- **Confident without bluster.** Flag empty marketing language
-  ("cutting-edge", "world-class", "best-in-class", "next-generation",
-  "revolutionary") unless backed by specific, falsifiable evidence. Flag
-  over-hedging too ("we might possibly be able to perhaps").
-- **Technical and concrete.** Flag claims that don't land in specifics.
-  "We improved performance" is weak; "We cut p95 latency from 420 ms to
-  110 ms" is Mainmatter-shaped.
-- **Approachable to both devs and decision-makers.** Flag walls of jargon
-  unexplained (a manager skims off), and flag empty business-speak a
-  developer would roll their eyes at ("synergize", "stakeholder alignment",
-  "holistic solution").
+- **Confident without bluster.** Flag empty marketing language ("cutting-edge", "world-class", "best-in-class", "next-generation", "revolutionary") unless backed by specific, falsifiable evidence. Flag over-hedging too ("we might possibly be able to perhaps").
+- **Technical and concrete.** Flag claims that don't land in specifics. "We improved performance" is weak; "We cut p95 latency from 420 ms to 110 ms" is Mainmatter-shaped.
+- **Approachable to both devs and decision-makers.** Flag walls of jargon unexplained (a manager skims off), and flag empty business-speak a developer would roll their eyes at ("synergize", "stakeholder alignment", "holistic solution").
 - **Active voice.** Flag passive where active works.
-- **No AI slop.** Flag "It's not just X — it's Y", "Let's dive in", "In
-  today's fast-paced world", "It's worth noting that", "Navigate the
-  complexities of", and similar LLM tics.
-- **No filler.** Flag "very", "really", "quite", "simply", "just" when they
-  add nothing. Flag "In order to" when "to" works.
+- **No AI slop.** Flag "It's not just X — it's Y", "Let's dive in", "In today's fast-paced world", "It's worth noting that", "Navigate the complexities of", and similar LLM tics.
+- **No filler.** Flag "very", "really", "quite", "simply", "just" when they add nothing. Flag "In order to" when "to" works.
 
-Voice findings are usually `should-fix` or `nice-to-have`, not `must-fix` —
-the author's own voice matters. Suggest, don't mandate.
+Voice findings are usually `should-fix` or `nice-to-have`, not `must-fix` — the author's own voice matters. Suggest, don't mandate.
 
 #### Check 6: Translation smells and L2 patterns
 
-Read `references/l2-english-patterns.md` for the full list. Most common ones
-to scan for:
+Read `references/l2-english-patterns.md` for the full list. Most common ones to scan for:
 
-- **Article errors**: missing or extra `the`, `a`, `an`. L2 speakers from
-  German, Slavic, or Romance backgrounds frequently miss or over-use
-  articles.
-- **Preposition errors**: "discuss about", "depend of", "consist in",
-  "suffer of", "on the internet" vs. "in the internet".
-- **False friends** from German, French, Italian, Spanish: e.g.
-  "actually" (should be "currently" from German "aktuell"),
-  "eventually" (not "possibly"), "sensible" (not "sensitive"),
-  "deliver in time" (should be "on time").
+- **Article errors**: missing or extra `the`, `a`, `an`. L2 speakers from German, Slavic, or Romance backgrounds frequently miss or over-use articles.
+- **Preposition errors**: "discuss about", "depend of", "consist in", "suffer of", "on the internet" vs. "in the internet".
+- **False friends** from German, French, Italian, Spanish: e.g. "actually" (should be "currently" from German "aktuell"), "eventually" (not "possibly"), "sensible" (not "sensitive"), "deliver in time" (should be "on time").
 - **Word-order calques**: adverb placement, adjective order.
-- **Over-literal translations**: "in the last time" (recently), "since
-  long time" (for a long time).
-- **Verb pattern errors**: "help them deliver" (correct) vs. "support them
-  deliver" (ungrammatical).
+- **Over-literal translations**: "in the last time" (recently), "since long time" (for a long time).
+- **Verb pattern errors**: "help them deliver" (correct) vs. "support them deliver" (ungrammatical).
 
 ### Step 4: Write the output
 
-Create a markdown file at `/mnt/user-data/outputs/content-review-<slug>-<YYYY-MM-DD>.md`
-where `<slug>` is a short identifier (PR number, page name, filename).
+Create a markdown file at `/mnt/user-data/outputs/content-review-<slug>-<YYYY-MM-DD>.md` where `<slug>` is a short identifier (PR number, page name, filename).
 
-For short reviews (< 8 findings) and when the source was a chat paste, respond
-inline in the chat instead of creating a file.
+For short reviews (< 8 findings) and when the source was a chat paste, respond inline in the chat instead of creating a file.
 
 Follow the output format below exactly.
 
 ## Output format
 
-```markdown
+````markdown
 # Content review: <source title or PR number>
 
-**Source:** <URL or filename>
-**Reviewed:** <date>
-**Files checked:** <list>
-**Scope note:** <one line on what was reviewed / skipped>
+**Source:** <URL or filename> **Reviewed:** <date> **Files checked:** <list> **Scope note:** <one line on what was reviewed / skipped>
 
 ## Summary
 
-<2–3 sentence overview: how many findings by category, overall voice read,
-anything the author nailed particularly well.>
+<2–3 sentence overview: how many findings by category, overall voice read, anything the author nailed particularly well.>
 
 ## Must-fix
 
@@ -233,32 +153,34 @@ anything the author nailed particularly well.>
 - Mainmtter offers hands-on Rust training for engineering teams.
 + Mainmatter offers hands-on Rust training for engineering teams.
 ```
+````
 
 **Why:** Company name is misspelled.
 
 ---
 
 ### 2. <Category>: <short description>
+
 ...
 
 ## Should-fix
 
 ### 3. <Category>: <short description>
+
 ...
 
 ## Nice-to-have
 
 ### 4. <Category>: <short description>
+
 ...
 
 ## Voice notes (not line-level)
 
-<Only include this section if there are document-level voice observations
-that don't fit a single line change. Keep to 1–4 short bullets.>
+<Only include this section if there are document-level voice observations that don't fit a single line change. Keep to 1–4 short bullets.>
 
-- <Observation, e.g. "Opening paragraph is strong on specifics; middle third
-  drifts into generic SaaS language — consider re-anchoring with a concrete
-  example from the engagement.">
+- <Observation, e.g. "Opening paragraph is strong on specifics; middle third drifts into generic SaaS language — consider re-anchoring with a concrete example from the engagement.">
+
 ```
 
 Rules for the output:
@@ -324,3 +246,4 @@ writer to ignore the review.
 
 Read these references when the inline guidance above isn't enough to decide
 a specific case.
+```

--- a/.agents/skills/mainmatter-content-review/SKILL.md
+++ b/.agents/skills/mainmatter-content-review/SKILL.md
@@ -1,0 +1,326 @@
+---
+name: mainmatter-content-review
+description: >
+  Review Mainmatter-authored content (blog posts, case studies, marketing pages,
+  landing pages, white papers, workshop materials, conference talks, newsletters,
+  social posts) for typos, grammatical errors, English correctness, and alignment
+  with the Mainmatter voice. Use this skill whenever anyone at Mainmatter asks to
+  proofread, review, copy-edit, check, fix, polish, or improve a piece of written
+  content, or shares a GitHub PR, Notion page, markdown file, or raw text for
+  review. Trigger on phrases like "review this post", "check this for typos",
+  "is this in Mainmatter voice", "copy-edit this", "proofread the PR", "look
+  over this draft", "does this read right", "tone check", "how does this sound",
+  or "fix the English". Also trigger on Notion URLs referencing drafts, case
+  studies, blog outlines, SEO or content pages, and on GitHub PRs touching
+  src/*.njk files, blog markdown files, cases/*, or other prose-heavy files.
+  This skill reviews prose only, never code.
+---
+
+# Mainmatter content review
+
+Review Mainmatter content for language correctness and voice fit. The team is
+international, so English is most authors' second language: the skill is tuned
+to catch translation smells and L2 patterns without being precious about
+US-vs-UK preferences. The skill reads international English — either US or UK
+spelling is fine, as long as one document is consistent.
+
+The skill's job is to help a writer find the balance between their own voice
+and the Mainmatter writing standard. It is not a style police. It surfaces
+concrete, actionable suggestions with a clear before/after, so the writer can
+accept or reject each one fast.
+
+## Inputs
+
+Accept any of:
+- **GitHub PR URL** (e.g. `https://github.com/mainmatter/mainmatter.com/pull/2857`) —
+  diff the PR branch against master, isolate prose changes, review those.
+- **Notion page URL** — fetch via Notion MCP, review the page content.
+- **Markdown, .txt, or .docx file** uploaded or passed by path — review the full
+  document.
+- **Raw text** pasted into the chat — review in-place.
+
+If the input is ambiguous (e.g. a repo URL without a PR number), ask what to
+review. If the PR or page is large and mixes code with prose, make clear which
+parts were reviewed and which were skipped.
+
+## What this skill reviews (and doesn't)
+
+Reviews:
+- Prose in blog posts, case studies, landing page copy, marketing pages,
+  workshop and talk outlines, newsletters, social posts, SEO metadata (title,
+  description, name), and the prose portions of `.njk`, `.md`, `.mdx` files.
+- Human-readable fields in structured files: `title`, `description`, `name`,
+  `og:*` text, schema.org text fields.
+
+Does not review:
+- Source code, code blocks, shell commands, configuration values, dependency
+  versions, imports, exports, or the technical correctness of anything.
+- Auto-generated content (lockfiles, build output, transcripts) unless the user
+  explicitly asks.
+
+When in doubt, skip and note it at the top of the output.
+
+## Workflow
+
+### Step 1: Fetch the content
+
+- **GitHub PR**: clone the PR branch shallowly and diff against `master`.
+  Use the clone tool when `web_fetch` is rate-limited — the `github.com` domain
+  is allowed for bash. The repo is generally `mainmatter/mainmatter.com` but
+  can be any Mainmatter repo.
+
+  ```bash
+  git clone --depth 50 --branch <branch> https://github.com/<org>/<repo>.git /home/claude/review
+  cd /home/claude/review
+  git fetch origin master:master --depth 50
+  git diff master..<branch> -- <prose-files>
+  ```
+
+  Prose-file filter (rough heuristic): `*.md`, `*.mdx`, `*.njk`, `*.html`,
+  `*.txt`, plus text fields within `*.yaml`, `*.json` when they are clearly
+  human-facing (title, description, name, body, content).
+
+- **Notion page**: call `Notion:notion-fetch` on the page URL. Extract plain
+  text content and preserve section structure so location references are
+  meaningful.
+
+- **Uploaded file**: read from `/mnt/user-data/uploads/`. For `.docx`, follow
+  `/mnt/skills/public/docx/SKILL.md` to extract text.
+
+- **Raw text**: take it as-is.
+
+### Step 2: Identify prose spans
+
+Separate prose from non-prose before reviewing:
+- Skip fenced code blocks (```), inline code (`` ` ``), YAML keys and non-text
+  values, shell output, HTML tag names/attributes (review attribute **values**
+  only when they are user-facing text like `alt`, `title`, `aria-label`,
+  `<meta content="...">`).
+- In `.njk` frontmatter, review values for keys: `title`, `description`,
+  `name`, `og:*` text, `description`, schema.org text fields. Skip: permalinks,
+  image paths, type enums, booleans, arrays of tech keywords.
+- In Notion pages, skip property values that are enums, dates, or IDs. Review
+  rich text content.
+
+### Step 3: Run the review
+
+Run the six checks below against the prose spans. For each finding, capture:
+- **Location** — file + line, or section heading for Notion.
+- **Category** — one of: Typo, Grammar, Punctuation, Consistency, Voice,
+  Clarity.
+- **Severity** — `must-fix`, `should-fix`, `nice-to-have`.
+- **Before / After** — exact text.
+- **Why** — one short sentence.
+
+#### Check 1: Spelling and typos
+
+- Flag misspellings.
+- Pay special attention to product, framework, and person names:
+  Mainmatter (one word, capital M only at the start), Svelte, SvelteKit,
+  Ember.js (with `.js`), Rust, EuroRust, EmberFest, Svelte Summit, Embroider,
+  Vite, TypeScript, JavaScript.
+- Flag capitalization errors in product names (e.g. `svelte`, `ember`,
+  `Typescript`, `Javascript` — all wrong in prose).
+- Flag Mainmatter engineers' names when misspelled: Luca Palmieri,
+  Chris Manson, Paolo Ricciuti, Marco Otte-Witte, Marine Dunstetter, etc.
+  If unsure about a name spelling, note it as uncertain rather than silently
+  correcting.
+
+#### Check 2: Grammar
+
+Subject-verb agreement, article usage (`a/an/the`), preposition choice, tense
+consistency, pronoun reference, dangling modifiers, sentence fragments.
+
+Treat "Mainmatter" as singular in prose ("Mainmatter is", "Mainmatter offers"),
+not plural ("Mainmatter are"). Published Mainmatter content is consistent on
+this — flag inconsistencies when one document mixes both.
+
+#### Check 3: Punctuation
+
+Comma splices, missing commas before conjunctions in long sentences, run-on
+sentences, mismatched quotes, inconsistent use of em dashes vs. hyphens vs.
+en dashes. Em dashes are fine in Mainmatter content (`—`, not `--`).
+
+#### Check 4: Consistency
+
+Within a single document:
+- US vs. UK spelling — pick one and stick to it (flag mixes like "organize"
+  alongside "optimisation").
+- Title Case vs. sentence case in headings — pick one.
+- Product names: always `Ember.js` (not `Ember` inconsistently, though
+  `Ember` alone is fine when the context is clear).
+- Hyphenation of compounds: `open source` (noun) vs. `open-source` (adjective);
+  `cloud native` vs. `cloud-native`. Match the doc's chosen style.
+
+#### Check 5: Voice and tone (Mainmatter voice)
+
+Read `references/mainmatter-voice.md` for the full voice guide and a checklist
+of patterns to reinforce and to flag. Core tests:
+
+- **Confident without bluster.** Flag empty marketing language
+  ("cutting-edge", "world-class", "best-in-class", "next-generation",
+  "revolutionary") unless backed by specific, falsifiable evidence. Flag
+  over-hedging too ("we might possibly be able to perhaps").
+- **Technical and concrete.** Flag claims that don't land in specifics.
+  "We improved performance" is weak; "We cut p95 latency from 420 ms to
+  110 ms" is Mainmatter-shaped.
+- **Approachable to both devs and decision-makers.** Flag walls of jargon
+  unexplained (a manager skims off), and flag empty business-speak a
+  developer would roll their eyes at ("synergize", "stakeholder alignment",
+  "holistic solution").
+- **Active voice.** Flag passive where active works.
+- **No AI slop.** Flag "It's not just X — it's Y", "Let's dive in", "In
+  today's fast-paced world", "It's worth noting that", "Navigate the
+  complexities of", and similar LLM tics.
+- **No filler.** Flag "very", "really", "quite", "simply", "just" when they
+  add nothing. Flag "In order to" when "to" works.
+
+Voice findings are usually `should-fix` or `nice-to-have`, not `must-fix` —
+the author's own voice matters. Suggest, don't mandate.
+
+#### Check 6: Translation smells and L2 patterns
+
+Read `references/l2-english-patterns.md` for the full list. Most common ones
+to scan for:
+
+- **Article errors**: missing or extra `the`, `a`, `an`. L2 speakers from
+  German, Slavic, or Romance backgrounds frequently miss or over-use
+  articles.
+- **Preposition errors**: "discuss about", "depend of", "consist in",
+  "suffer of", "on the internet" vs. "in the internet".
+- **False friends** from German, French, Italian, Spanish: e.g.
+  "actually" (should be "currently" from German "aktuell"),
+  "eventually" (not "possibly"), "sensible" (not "sensitive"),
+  "deliver in time" (should be "on time").
+- **Word-order calques**: adverb placement, adjective order.
+- **Over-literal translations**: "in the last time" (recently), "since
+  long time" (for a long time).
+- **Verb pattern errors**: "help them deliver" (correct) vs. "support them
+  deliver" (ungrammatical).
+
+### Step 4: Write the output
+
+Create a markdown file at `/mnt/user-data/outputs/content-review-<slug>-<YYYY-MM-DD>.md`
+where `<slug>` is a short identifier (PR number, page name, filename).
+
+For short reviews (< 8 findings) and when the source was a chat paste, respond
+inline in the chat instead of creating a file.
+
+Follow the output format below exactly.
+
+## Output format
+
+```markdown
+# Content review: <source title or PR number>
+
+**Source:** <URL or filename>
+**Reviewed:** <date>
+**Files checked:** <list>
+**Scope note:** <one line on what was reviewed / skipped>
+
+## Summary
+
+<2–3 sentence overview: how many findings by category, overall voice read,
+anything the author nailed particularly well.>
+
+## Must-fix
+
+### 1. <Category>: <short description>
+
+**Location:** `path/to/file.njk`, line 27 (or section "Heading")
+
+```diff
+- Mainmtter offers hands-on Rust training for engineering teams.
++ Mainmatter offers hands-on Rust training for engineering teams.
+```
+
+**Why:** Company name is misspelled.
+
+---
+
+### 2. <Category>: <short description>
+...
+
+## Should-fix
+
+### 3. <Category>: <short description>
+...
+
+## Nice-to-have
+
+### 4. <Category>: <short description>
+...
+
+## Voice notes (not line-level)
+
+<Only include this section if there are document-level voice observations
+that don't fit a single line change. Keep to 1–4 short bullets.>
+
+- <Observation, e.g. "Opening paragraph is strong on specifics; middle third
+  drifts into generic SaaS language — consider re-anchoring with a concrete
+  example from the engagement.">
+```
+
+Rules for the output:
+
+- **One finding per section.** Don't combine unrelated issues under one
+  header, even in the same line.
+- **Exact before/after.** The `+` line should be copy-paste ready. No
+  ellipses in the "After" unless the surrounding context is truly unchanged.
+- **Show enough context.** If the fix changes a single word, include the full
+  sentence so the writer can locate it without ambiguity.
+- **Group by severity, not by file.** Writers want to see the important
+  things first. Use file paths in the location to keep grouping readable.
+- **Short reasons.** One sentence each. The writer either agrees or doesn't —
+  they don't need a paragraph.
+- **Neutral tone.** The author is a colleague, often an L2 writer, often
+  under deadline. Don't condescend, don't pile on.
+
+## Severity guidelines
+
+- **Must-fix**: typos, broken grammar, factually wrong product names,
+  inconsistencies that will make a reader reread. Anything a professional
+  proofreader would always flag.
+- **Should-fix**: L2 patterns that read as unnatural, voice issues that
+  weaken a key claim, marketing language in a spot where a concrete claim
+  would be stronger.
+- **Nice-to-have**: preference-level suggestions, stylistic smoothing,
+  optional cuts for tightness.
+
+When uncertain between two levels, go lower. Over-flagging trains the
+writer to ignore the review.
+
+## Edge cases
+
+- **Quoting an external source**: don't correct typos inside verbatim quotes
+  from third parties. Flag only if the quote is broken in a way that's
+  clearly a transcription error.
+- **Deliberate informality**: social posts and some blog intros use
+  conversational language by design. If the whole piece reads conversational,
+  don't flag informality — adjust the bar to match the register.
+- **Author voice vs. Mainmatter voice**: Marine, Paolo, Luca, Chris, Marco
+  and others each have recognizable voices. Preserve them. Flag voice
+  issues only when something works against the writer rather than for them.
+- **Schema.org and SEO metadata**: these are user-facing (they appear in
+  search snippets, knowledge panels, llms.txt), so review them as prose.
+  But keep descriptions within the length constraints implied by the
+  platform (meta descriptions ≤ 160 chars, titles ≤ 60 chars) — flag if a
+  suggested rewrite exceeds the constraint.
+- **Conflicting US/UK spelling in a codebase that already mixes**: if the
+  rest of the repo is clearly one variant, recommend that one. Otherwise
+  pick the most common variant in the current document and align to it.
+- **Large PRs with many files**: if the PR has 20+ prose-containing files,
+  ask the user which files to prioritize. Offer a quick "headlines only"
+  pass as an alternative.
+
+## Reference files
+
+- `references/mainmatter-voice.md` — full voice guide with examples of what
+  to reinforce and what to flag.
+- `references/l2-english-patterns.md` — common L2 English patterns and
+  translation smells with examples.
+- `references/terminology.md` — canonical spellings of Mainmatter product
+  names, service names, people names, and preferred terms.
+
+Read these references when the inline guidance above isn't enough to decide
+a specific case.

--- a/.agents/skills/mainmatter-content-review/references/l2-english-patterns.md
+++ b/.agents/skills/mainmatter-content-review/references/l2-english-patterns.md
@@ -1,0 +1,195 @@
+# L2 English patterns and translation smells
+
+Mainmatter's team is international. Most content authors speak English as a
+second language, typically with a strong technical vocabulary and occasional
+transfer patterns from German, French, Italian, Spanish, or Russian. This
+reference catalogues the patterns to scan for.
+
+These are frequency-ordered (most common at the top). Not all are errors —
+some are acceptable variants in international English. Flag the ones that
+read as clearly non-native, and leave the ones that are defensible as
+stylistic.
+
+## Articles (the, a, an)
+
+Article usage is the single most common L2 slip across native-German,
+Slavic, and East Asian writers.
+
+**Missing definite article**
+- "We migrated Redis Query Engine from C to Rust" → "the Redis Query
+  Engine".
+- "Company behind Ember Initiative" → "the Ember Initiative".
+
+**Extra definite article**
+- "We work with the Svelte and the Rust" → "with Svelte and Rust".
+- "The developers prefer the TypeScript" → "developers prefer TypeScript".
+
+**Missing indefinite article**
+- "Mainmatter is engineering consultancy" → "is an engineering
+  consultancy".
+
+**Overuse with abstract nouns**
+- "The machine learning is everywhere" → "Machine learning is everywhere".
+
+## Prepositions
+
+Prepositions don't transfer cleanly between languages. Common errors:
+
+| Wrong | Right |
+|---|---|
+| discuss about X | discuss X |
+| depend of X | depend on X |
+| consist in X | consist of X |
+| suffer of X | suffer from X |
+| in the internet | on the internet |
+| in time (for deadlines) | on time |
+| in the weekend | on the weekend (US) / at the weekend (UK) |
+| different than | different from (or "different to" in UK) |
+| married with X | married to X |
+| responsible of X | responsible for X |
+| since 3 years | for 3 years |
+| capable to do X | capable of doing X |
+| interested to do X | interested in doing X |
+
+## Verb patterns (common L2 miss)
+
+English verb patterns are quirky. L2 writers often produce grammatically
+close-but-wrong constructions:
+
+- "support them deliver" → "help them deliver" or "support them in
+  delivering". ("Support" doesn't take bare infinitive.)
+- "help to do X" vs. "help do X" — both acceptable. Don't flag.
+- "allow to do X" (no object) → "allow us to do X" (object required).
+- "let to do X" → "let us do X" (no "to" after "let").
+- "make to do X" → "make us do X" (no "to" after "make" as causative).
+- "suggest me to do X" → "suggest that I do X" / "suggest I do X".
+- "explain me X" → "explain X to me".
+- "discuss with X about Y" → "discuss Y with X".
+
+## Word order
+
+English adjective order and adverb placement rarely match other languages:
+
+- "a red big ball" → "a big red ball" (opinion, size, age, shape, color,
+  origin, material, purpose).
+- "I often am doing X" → "I am often doing X" or "I often do X".
+- "We have since long time worked with..." → "We have worked with ... for
+  a long time".
+
+## False friends
+
+These land especially often from German, French, Italian, Spanish:
+
+| Written | Probably meant | Source language |
+|---|---|---|
+| actually | currently / now | German "aktuell" |
+| eventually | possibly / maybe | German "eventuell", FR "éventuellement" |
+| sensible | sensitive | French/German "sensible" |
+| sympathic / sympathetic | likeable | German/French/Italian |
+| control (verb) | check / verify | French "contrôler", German "kontrollieren" |
+| realize | carry out / implement | French/Italian "réaliser" |
+| pretend | claim | French "prétendre" |
+| assist at | attend | French "assister à" |
+| demand | ask | French "demander" |
+| deception | disappointment | French "déception" |
+| library | bookshop | French "librairie" → "library" is often meant the other way |
+| formation | training | French "formation" |
+| memory (for computer RAM vs. recollection) | usually fine, but check context | |
+| actuality | current events / news | |
+| engagement | commitment / appointment | French "engagement" |
+
+**Heads up:** when a word looks like a false friend but the sentence makes
+sense under the native meaning, flag it gently and ask — don't assert.
+
+## Translation calques
+
+Literal word-for-word translations of native-language idioms:
+
+- "in the last time" → "recently" (DE "in letzter Zeit")
+- "since always" → "always" / "as long as I can remember" (FR "depuis toujours")
+- "make a formation" → "do a training" / "take a course" (FR "faire une formation")
+- "take a decision" → "make a decision" (FR "prendre une décision"; UK often accepts "take")
+- "informations" (plural) → "information" (uncountable in EN; DE/FR both use plural)
+- "a news" → "some news" / "a piece of news" (uncountable)
+- "staffs" (plural of staff) → "staff" (collective)
+- "advices" → "advice" (uncountable)
+- "equipments" → "equipment" (uncountable)
+- "feedbacks" → "feedback" (uncountable)
+- "trainings" → usually "training" (uncountable). Mainmatter content does
+  sometimes use "trainings" as count noun for individual training events,
+  which is acceptable jargon but flag if mixed with the uncountable use.
+
+## Count vs. uncountable nouns
+
+Common uncountables that L2 writers pluralize:
+
+- advice, information, feedback, equipment, research, progress, evidence,
+  software, hardware, knowledge, homework, furniture, luggage
+
+Acceptable count-noun use within tech jargon:
+- "trainings" (individual training events)
+- "softwares" — never acceptable, always flag
+
+## Tense and aspect
+
+- Present perfect vs. simple past. "I have worked on this yesterday" →
+  "I worked on this yesterday". Present perfect doesn't combine with a
+  specific past time.
+- Will vs. going to. Both acceptable in international English; flag only
+  if clearly wrong.
+- Progressive with stative verbs. "I am knowing this" → "I know this".
+
+## Punctuation transfer
+
+- **German**: comma before every subordinate clause ("We decided, that we
+  would migrate"). Remove the comma before "that".
+- **French**: spaces before `?`, `!`, `:`, `;`. Remove the spaces in English.
+- **Spanish/Italian/German**: double punctuation (`?!`, `!!`). Flag in
+  published content; acceptable in social posts if deliberate.
+- **German**: quotes as „X" or "X" → use straight or curly English quotes.
+- **French**: `«guillemets»` → curly or straight English quotes.
+
+## Capitalization
+
+- Days of week, months, nationalities — capitalized in English. L2 writers
+  from Romance languages often leave them lowercase.
+- Job titles — capitalize only when part of a specific name (President Smith)
+  or a formal title directly preceding a name.
+- After a colon: lowercase in English unless a proper noun or a full
+  quotation follows.
+
+## Phrase-level smells
+
+- "As well" at the start of a sentence → usually "Also" or restructure.
+  "As well" at sentence-end is fine.
+- "Permit me to..." → "Let me..." / "May I...".
+- "I am writing you" → "I am writing to you".
+- "Thanks you" → "Thank you".
+- "Waiting for your news" → "Looking forward to hearing from you".
+- "Please find attached" — fine in formal email, stiff in marketing copy.
+
+## When not to flag
+
+- **International English variants**: "whilst" (UK) vs. "while" (US) — both
+  fine. "amongst" vs. "among" — both fine. "spelt" vs. "spelled" — both
+  fine.
+- **Mild formality**: L2 writers sometimes sound slightly more formal than
+  native speakers. This is often a feature, not a bug, in B2B content.
+- **Oxford comma**: consistent use of either style is fine.
+- **Technical shorthand**: "stood up a service", "spun up a cluster" — these
+  are domain-correct even if they sound odd.
+
+## How to flag in the review
+
+For L2 patterns, the explanation should be specific:
+
+Good:
+> "support them deliver" is ungrammatical. "Support" doesn't take a bare
+> infinitive. Use "help them deliver" or "support them in delivering".
+
+Not:
+> This sounds non-native.
+
+The author is likely to want to understand the rule so they avoid the same
+mistake next time. A one-line explanation is the right length — not a grammar
+lecture.

--- a/.agents/skills/mainmatter-content-review/references/l2-english-patterns.md
+++ b/.agents/skills/mainmatter-content-review/references/l2-english-patterns.md
@@ -1,63 +1,56 @@
 # L2 English patterns and translation smells
 
-Mainmatter's team is international. Most content authors speak English as a
-second language, typically with a strong technical vocabulary and occasional
-transfer patterns from German, French, Italian, Spanish, or Russian. This
-reference catalogues the patterns to scan for.
+Mainmatter's team is international. Most content authors speak English as a second language, typically with a strong technical vocabulary and occasional transfer patterns from German, French, Italian, Spanish, or Russian. This reference catalogues the patterns to scan for.
 
-These are frequency-ordered (most common at the top). Not all are errors —
-some are acceptable variants in international English. Flag the ones that
-read as clearly non-native, and leave the ones that are defensible as
-stylistic.
+These are frequency-ordered (most common at the top). Not all are errors — some are acceptable variants in international English. Flag the ones that read as clearly non-native, and leave the ones that are defensible as stylistic.
 
 ## Articles (the, a, an)
 
-Article usage is the single most common L2 slip across native-German,
-Slavic, and East Asian writers.
+Article usage is the single most common L2 slip across native-German, Slavic, and East Asian writers.
 
 **Missing definite article**
-- "We migrated Redis Query Engine from C to Rust" → "the Redis Query
-  Engine".
+
+- "We migrated Redis Query Engine from C to Rust" → "the Redis Query Engine".
 - "Company behind Ember Initiative" → "the Ember Initiative".
 
 **Extra definite article**
+
 - "We work with the Svelte and the Rust" → "with Svelte and Rust".
 - "The developers prefer the TypeScript" → "developers prefer TypeScript".
 
 **Missing indefinite article**
-- "Mainmatter is engineering consultancy" → "is an engineering
-  consultancy".
+
+- "Mainmatter is engineering consultancy" → "is an engineering consultancy".
 
 **Overuse with abstract nouns**
+
 - "The machine learning is everywhere" → "Machine learning is everywhere".
 
 ## Prepositions
 
 Prepositions don't transfer cleanly between languages. Common errors:
 
-| Wrong | Right |
-|---|---|
-| discuss about X | discuss X |
-| depend of X | depend on X |
-| consist in X | consist of X |
-| suffer of X | suffer from X |
-| in the internet | on the internet |
-| in time (for deadlines) | on time |
-| in the weekend | on the weekend (US) / at the weekend (UK) |
-| different than | different from (or "different to" in UK) |
-| married with X | married to X |
-| responsible of X | responsible for X |
-| since 3 years | for 3 years |
-| capable to do X | capable of doing X |
-| interested to do X | interested in doing X |
+| Wrong                   | Right                                     |
+| ----------------------- | ----------------------------------------- |
+| discuss about X         | discuss X                                 |
+| depend of X             | depend on X                               |
+| consist in X            | consist of X                              |
+| suffer of X             | suffer from X                             |
+| in the internet         | on the internet                           |
+| in time (for deadlines) | on time                                   |
+| in the weekend          | on the weekend (US) / at the weekend (UK) |
+| different than          | different from (or "different to" in UK)  |
+| married with X          | married to X                              |
+| responsible of X        | responsible for X                         |
+| since 3 years           | for 3 years                               |
+| capable to do X         | capable of doing X                        |
+| interested to do X      | interested in doing X                     |
 
 ## Verb patterns (common L2 miss)
 
-English verb patterns are quirky. L2 writers often produce grammatically
-close-but-wrong constructions:
+English verb patterns are quirky. L2 writers often produce grammatically close-but-wrong constructions:
 
-- "support them deliver" → "help them deliver" or "support them in
-  delivering". ("Support" doesn't take bare infinitive.)
+- "support them deliver" → "help them deliver" or "support them in delivering". ("Support" doesn't take bare infinitive.)
 - "help to do X" vs. "help do X" — both acceptable. Don't flag.
 - "allow to do X" (no object) → "allow us to do X" (object required).
 - "let to do X" → "let us do X" (no "to" after "let").
@@ -70,18 +63,16 @@ close-but-wrong constructions:
 
 English adjective order and adverb placement rarely match other languages:
 
-- "a red big ball" → "a big red ball" (opinion, size, age, shape, color,
-  origin, material, purpose).
+- "a red big ball" → "a big red ball" (opinion, size, age, shape, color, origin, material, purpose).
 - "I often am doing X" → "I am often doing X" or "I often do X".
-- "We have since long time worked with..." → "We have worked with ... for
-  a long time".
+- "We have since long time worked with..." → "We have worked with ... for a long time".
 
 ## False friends
 
 These land especially often from German, French, Italian, Spanish:
 
 | Written | Probably meant | Source language |
-|---|---|---|
+| --- | --- | --- |
 | actually | currently / now | German "aktuell" |
 | eventually | possibly / maybe | German "eventuell", FR "éventuellement" |
 | sensible | sensitive | French/German "sensible" |
@@ -94,12 +85,11 @@ These land especially often from German, French, Italian, Spanish:
 | deception | disappointment | French "déception" |
 | library | bookshop | French "librairie" → "library" is often meant the other way |
 | formation | training | French "formation" |
-| memory (for computer RAM vs. recollection) | usually fine, but check context | |
-| actuality | current events / news | |
+| memory (for computer RAM vs. recollection) | usually fine, but check context |  |
+| actuality | current events / news |  |
 | engagement | commitment / appointment | French "engagement" |
 
-**Heads up:** when a word looks like a false friend but the sentence makes
-sense under the native meaning, flag it gently and ask — don't assert.
+**Heads up:** when a word looks like a false friend but the sentence makes sense under the native meaning, flag it gently and ask — don't assert.
 
 ## Translation calques
 
@@ -115,53 +105,42 @@ Literal word-for-word translations of native-language idioms:
 - "advices" → "advice" (uncountable)
 - "equipments" → "equipment" (uncountable)
 - "feedbacks" → "feedback" (uncountable)
-- "trainings" → usually "training" (uncountable). Mainmatter content does
-  sometimes use "trainings" as count noun for individual training events,
-  which is acceptable jargon but flag if mixed with the uncountable use.
+- "trainings" → usually "training" (uncountable). Mainmatter content does sometimes use "trainings" as count noun for individual training events, which is acceptable jargon but flag if mixed with the uncountable use.
 
 ## Count vs. uncountable nouns
 
 Common uncountables that L2 writers pluralize:
 
-- advice, information, feedback, equipment, research, progress, evidence,
-  software, hardware, knowledge, homework, furniture, luggage
+- advice, information, feedback, equipment, research, progress, evidence, software, hardware, knowledge, homework, furniture, luggage
 
 Acceptable count-noun use within tech jargon:
+
 - "trainings" (individual training events)
 - "softwares" — never acceptable, always flag
 
 ## Tense and aspect
 
-- Present perfect vs. simple past. "I have worked on this yesterday" →
-  "I worked on this yesterday". Present perfect doesn't combine with a
-  specific past time.
-- Will vs. going to. Both acceptable in international English; flag only
-  if clearly wrong.
+- Present perfect vs. simple past. "I have worked on this yesterday" → "I worked on this yesterday". Present perfect doesn't combine with a specific past time.
+- Will vs. going to. Both acceptable in international English; flag only if clearly wrong.
 - Progressive with stative verbs. "I am knowing this" → "I know this".
 
 ## Punctuation transfer
 
-- **German**: comma before every subordinate clause ("We decided, that we
-  would migrate"). Remove the comma before "that".
+- **German**: comma before every subordinate clause ("We decided, that we would migrate"). Remove the comma before "that".
 - **French**: spaces before `?`, `!`, `:`, `;`. Remove the spaces in English.
-- **Spanish/Italian/German**: double punctuation (`?!`, `!!`). Flag in
-  published content; acceptable in social posts if deliberate.
+- **Spanish/Italian/German**: double punctuation (`?!`, `!!`). Flag in published content; acceptable in social posts if deliberate.
 - **German**: quotes as „X" or "X" → use straight or curly English quotes.
 - **French**: `«guillemets»` → curly or straight English quotes.
 
 ## Capitalization
 
-- Days of week, months, nationalities — capitalized in English. L2 writers
-  from Romance languages often leave them lowercase.
-- Job titles — capitalize only when part of a specific name (President Smith)
-  or a formal title directly preceding a name.
-- After a colon: lowercase in English unless a proper noun or a full
-  quotation follows.
+- Days of week, months, nationalities — capitalized in English. L2 writers from Romance languages often leave them lowercase.
+- Job titles — capitalize only when part of a specific name (President Smith) or a formal title directly preceding a name.
+- After a colon: lowercase in English unless a proper noun or a full quotation follows.
 
 ## Phrase-level smells
 
-- "As well" at the start of a sentence → usually "Also" or restructure.
-  "As well" at sentence-end is fine.
+- "As well" at the start of a sentence → usually "Also" or restructure. "As well" at sentence-end is fine.
 - "Permit me to..." → "Let me..." / "May I...".
 - "I am writing you" → "I am writing to you".
 - "Thanks you" → "Thank you".
@@ -170,26 +149,21 @@ Acceptable count-noun use within tech jargon:
 
 ## When not to flag
 
-- **International English variants**: "whilst" (UK) vs. "while" (US) — both
-  fine. "amongst" vs. "among" — both fine. "spelt" vs. "spelled" — both
-  fine.
-- **Mild formality**: L2 writers sometimes sound slightly more formal than
-  native speakers. This is often a feature, not a bug, in B2B content.
+- **International English variants**: "whilst" (UK) vs. "while" (US) — both fine. "amongst" vs. "among" — both fine. "spelt" vs. "spelled" — both fine.
+- **Mild formality**: L2 writers sometimes sound slightly more formal than native speakers. This is often a feature, not a bug, in B2B content.
 - **Oxford comma**: consistent use of either style is fine.
-- **Technical shorthand**: "stood up a service", "spun up a cluster" — these
-  are domain-correct even if they sound odd.
+- **Technical shorthand**: "stood up a service", "spun up a cluster" — these are domain-correct even if they sound odd.
 
 ## How to flag in the review
 
 For L2 patterns, the explanation should be specific:
 
 Good:
-> "support them deliver" is ungrammatical. "Support" doesn't take a bare
-> infinitive. Use "help them deliver" or "support them in delivering".
+
+> "support them deliver" is ungrammatical. "Support" doesn't take a bare infinitive. Use "help them deliver" or "support them in delivering".
 
 Not:
+
 > This sounds non-native.
 
-The author is likely to want to understand the rule so they avoid the same
-mistake next time. A one-line explanation is the right length — not a grammar
-lecture.
+The author is likely to want to understand the rule so they avoid the same mistake next time. A one-line explanation is the right length — not a grammar lecture.

--- a/.agents/skills/mainmatter-content-review/references/mainmatter-voice.md
+++ b/.agents/skills/mainmatter-content-review/references/mainmatter-voice.md
@@ -1,14 +1,8 @@
 # Mainmatter voice
 
-The Mainmatter voice is **confident, technically grounded, approachable, and
-insightful**. It speaks credibly to developers who will scrutinize every
-technical claim, and to engineering leaders who need to understand the business
-case. Good Mainmatter writing earns trust with specifics, respects the reader's
-time, and avoids both marketing fluff and gratuitous jargon.
+The Mainmatter voice is **confident, technically grounded, approachable, and insightful**. It speaks credibly to developers who will scrutinize every technical claim, and to engineering leaders who need to understand the business case. Good Mainmatter writing earns trust with specifics, respects the reader's time, and avoids both marketing fluff and gratuitous jargon.
 
-This guide captures the patterns observed in published Mainmatter content
-(case studies, blog posts, landing pages). Use it as a reference when reviewing
-content, not a rulebook — the author's personal voice matters too.
+This guide captures the patterns observed in published Mainmatter content (case studies, blog posts, landing pages). Use it as a reference when reviewing content, not a rulebook — the author's personal voice matters too.
 
 ## What the Mainmatter voice sounds like
 
@@ -16,99 +10,69 @@ content, not a rulebook — the author's personal voice matters too.
 
 Strong claims are paired with specifics a skeptical reader can verify:
 
-> Key modules have already been ported and released to the public, validating
-> the approach and demonstrating tangible benefits.
+> Key modules have already been ported and released to the public, validating the approach and demonstrating tangible benefits.
 
 > Team led by Luca Palmieri, author of "Zero to Production in Rust".
 
-Flag: claims that sound big but carry no evidence. "Industry-leading expertise"
-means nothing. "Organizers of EuroRust, Europe's Rust conference" means
-something.
+Flag: claims that sound big but carry no evidence. "Industry-leading expertise" means nothing. "Organizers of EuroRust, Europe's Rust conference" means something.
 
 ### 2. Concrete, not abstract
 
 Mainmatter writes about real systems, real engineers, real outcomes:
 
-> We started by deconstructing the extensive C codebase of the query engine
-> into modular components, prioritizing the less entangled "leaf" modules for
-> early migration.
+> We started by deconstructing the extensive C codebase of the query engine into modular components, prioritizing the less entangled "leaf" modules for early migration.
 
-> A performance test implemented by Discourse inspired the
-> build-start-rebuild-perf tool, which provides metrics about your
-> application's build time.
+> A performance test implemented by Discourse inspired the build-start-rebuild-perf tool, which provides metrics about your application's build time.
 
-Flag: abstract verbs with no object. "We help clients succeed" — at what?
-"We accelerate transformation" — which transformation?
+Flag: abstract verbs with no object. "We help clients succeed" — at what? "We accelerate transformation" — which transformation?
 
 ### 3. Technical without walls of jargon
 
-Technical terms are used precisely, and named without over-explaining to
-readers who know them:
+Technical terms are used precisely, and named without over-explaining to readers who know them:
 
-> We setup a CI pipeline covering tests, linting, sanitizers (including Miri),
-> and coverage tracking.
+> We setup a CI pipeline covering tests, linting, sanitizers (including Miri), and coverage tracking.
 
-A developer reads this and trusts the writer. A manager reads it and gets the
-shape of the work without being drowned. When a term needs unpacking for
-non-specialists, the unpacking is short:
+A developer reads this and trusts the writer. A manager reads it and gets the shape of the work without being drowned. When a term needs unpacking for non-specialists, the unpacking is short:
 
-> context-engineering — the practice of providing AI the tools, context, and
-> direction it needs to be efficient.
+> context-engineering — the practice of providing AI the tools, context, and direction it needs to be efficient.
 
-Flag: either extreme. Jargon walls that alienate managers, or over-explanation
-that patronizes developers.
+Flag: either extreme. Jargon walls that alienate managers, or over-explanation that patronizes developers.
 
 ### 4. Active voice, precise verbs
 
-> We migrated the Redis Query Engine from C to Rust.
-> Mainmatter embeds expert Rust engineers into client teams.
-> The Ember Initiative allocates time to migrate addons to v2.
+> We migrated the Redis Query Engine from C to Rust. Mainmatter embeds expert Rust engineers into client teams. The Ember Initiative allocates time to migrate addons to v2.
 
-Flag: passive where active works. "Improvements were made to performance" →
-"We cut p95 latency by 4×". "Can be accelerated" → "accelerates".
+Flag: passive where active works. "Improvements were made to performance" → "We cut p95 latency by 4×". "Can be accelerated" → "accelerates".
 
 ### 5. Business outcome paired with technical reality
 
 A strong Mainmatter sentence often names both sides:
 
-> Incremental migration of C and C++ codebases to Rust, improving memory
-> safety, reliability, and maintainability without disrupting day-to-day
-> operations.
+> Incremental migration of C and C++ codebases to Rust, improving memory safety, reliability, and maintainability without disrupting day-to-day operations.
 
-Technical content: incremental migration, memory safety. Business content:
-doesn't disrupt operations. Both.
+Technical content: incremental migration, memory safety. Business content: doesn't disrupt operations. Both.
 
-Flag: content that lands only on one side. Pure marketing ("improves
-business outcomes") or pure technical ("migrates the AST parser to Rolldown")
-both miss the Mainmatter register when selling a service.
+Flag: content that lands only on one side. Pure marketing ("improves business outcomes") or pure technical ("migrates the AST parser to Rolldown") both miss the Mainmatter register when selling a service.
 
 ### 6. Direct invitations and acknowledgements
 
-Mainmatter content addresses the reader directly and ends with a concrete
-next step:
+Mainmatter content addresses the reader directly and ends with a concrete next step:
 
-> We're here to guide you through that transition as teammates, so you don't
-> have to navigate it alone.
+> We're here to guide you through that transition as teammates, so you don't have to navigate it alone.
 
-> If you're facing challenges with Ember.js and need a helping hand,
-> reach out!
+> If you're facing challenges with Ember.js and need a helping hand, reach out!
 
-Flag: endings that trail off, or that pivot into generic CTAs unrelated to
-the post's argument.
+Flag: endings that trail off, or that pivot into generic CTAs unrelated to the post's argument.
 
 ### 7. Honest about trade-offs
 
 Mainmatter writes about what's hard, not just what's good:
 
-> It's not as simple as just getting everyone a Claude account and then
-> expecting velocity to double overnight.
+> It's not as simple as just getting everyone a Claude account and then expecting velocity to double overnight.
 
-> Contributing to Embroider usually involves a steep learning curve — it's
-> the kind of project that requires more than just a few hours and good
-> intentions.
+> Contributing to Embroider usually involves a steep learning curve — it's the kind of project that requires more than just a few hours and good intentions.
 
-Flag: content that claims everything is easy, or that hides the real cost of
-a decision.
+Flag: content that claims everything is easy, or that hides the real cost of a decision.
 
 ## What the Mainmatter voice avoids
 
@@ -116,25 +80,16 @@ a decision.
 
 Never reinforce, usually flag:
 
-- "cutting-edge", "world-class", "best-in-class", "industry-leading",
-  "state-of-the-art", "next-generation", "revolutionary", "game-changing",
-  "premium" (as filler), "innovative" (as filler)
-- "seamless", "robust", "scalable", "holistic", "end-to-end" — acceptable
-  when the word is technically exact, lazy filler otherwise
+- "cutting-edge", "world-class", "best-in-class", "industry-leading", "state-of-the-art", "next-generation", "revolutionary", "game-changing", "premium" (as filler), "innovative" (as filler)
+- "seamless", "robust", "scalable", "holistic", "end-to-end" — acceptable when the word is technically exact, lazy filler otherwise
 
-If a sentence still says something when you delete the adjective, the
-adjective was filler.
+If a sentence still says something when you delete the adjective, the adjective was filler.
 
 ### Business buzzwords
 
-Flag: "synergize", "stakeholder alignment", "leverage synergies",
-"value proposition" (when used as filler), "mission-critical" (unless
-technically accurate), "transformation journey", "digital transformation"
-(as filler).
+Flag: "synergize", "stakeholder alignment", "leverage synergies", "value proposition" (when used as filler), "mission-critical" (unless technically accurate), "transformation journey", "digital transformation" (as filler).
 
-"Leverage" itself is borderline — Mainmatter content does use it occasionally
-when it means "make use of a specific advantage". Flag only when it's filler
-for "use".
+"Leverage" itself is borderline — Mainmatter content does use it occasionally when it means "make use of a specific advantage". Flag only when it's filler for "use".
 
 ### AI-slop phrases
 
@@ -168,83 +123,68 @@ Usually cut or flag:
 
 ### Overclaiming and overhedging
 
-Both are weaknesses. Mainmatter voice is confident where it has evidence and
-honest where it doesn't:
+Both are weaknesses. Mainmatter voice is confident where it has evidence and honest where it doesn't:
 
-- Overclaiming: "the only Rust consultancy that can..." → soften to
-  "one of few", or name what specifically is unique.
-- Overhedging: "we might possibly be able to help you potentially improve" →
-  pick one verb and commit.
+- Overclaiming: "the only Rust consultancy that can..." → soften to "one of few", or name what specifically is unique.
+- Overhedging: "we might possibly be able to help you potentially improve" → pick one verb and commit.
 
 ## Formatting conventions
 
-- **Headings**: sentence case dominates blog posts; Title Case dominates
-  product/landing pages. Flag mixes within one document.
-- **Em dash**: `—` (U+2014), not `--`. Used for asides and emphasis.
-  Mainmatter uses them liberally, which is fine.
-- **Oxford comma**: preferred but not mandatory. Flag when absence creates
-  ambiguity.
-- **Curly vs. straight quotes**: Mainmatter content mostly uses curly
-  quotes ("", ''). Don't force a rewrite, but flag if one document mixes.
-- **Italics for emphasis**: yes, used for emphasis on relational words
-  (*you*, *your*) or for book titles ("Zero to Production in Rust" — note
-  this one is in quotes in Mainmatter copy).
-- **Links**: embedded inline, not numbered endnotes. Descriptive link text,
-  not "click here" or "this link".
+- **Headings**: sentence case dominates blog posts; Title Case dominates product/landing pages. Flag mixes within one document.
+- **Em dash**: `—` (U+2014), not `--`. Used for asides and emphasis. Mainmatter uses them liberally, which is fine.
+- **Oxford comma**: preferred but not mandatory. Flag when absence creates ambiguity.
+- **Curly vs. straight quotes**: Mainmatter content mostly uses curly quotes ("", ''). Don't force a rewrite, but flag if one document mixes.
+- **Italics for emphasis**: yes, used for emphasis on relational words (_you_, _your_) or for book titles ("Zero to Production in Rust" — note this one is in quotes in Mainmatter copy).
+- **Links**: embedded inline, not numbered endnotes. Descriptive link text, not "click here" or "this link".
 
 ## People and team
 
-When introducing a Mainmatter team member in content, name both the role and
-a specific credential:
+When introducing a Mainmatter team member in content, name both the role and a specific credential:
 
-> Team led by Chris Manson, member of the Ember.js Framework Core Team.
-> Team led by Luca Palmieri, author of "Zero to Production in Rust".
-> Team led by Paolo Ricciuti, Svelte core team member, author of SvelteLab.
+> Team led by Chris Manson, member of the Ember.js Framework Core Team. Team led by Luca Palmieri, author of "Zero to Production in Rust". Team led by Paolo Ricciuti, Svelte core team member, author of SvelteLab.
 
-Flag: name-drops without context, or generic titles like "expert" without
-substantiation.
+Flag: name-drops without context, or generic titles like "expert" without substantiation.
 
 ## Examples of voice corrections
 
 ### Example 1: marketing filler → concrete claim
 
 Before:
-> Mainmatter is a world-class engineering consultancy that delivers
-> cutting-edge solutions to help clients unlock their potential.
+
+> Mainmatter is a world-class engineering consultancy that delivers cutting-edge solutions to help clients unlock their potential.
 
 After:
-> Mainmatter is an engineering consultancy specializing in Rust, Ember.js,
-> and Svelte. We help teams modernize codebases, migrate between
-> technologies, and build production systems that scale.
+
+> Mainmatter is an engineering consultancy specializing in Rust, Ember.js, and Svelte. We help teams modernize codebases, migrate between technologies, and build production systems that scale.
 
 ### Example 2: passive → active
 
 Before:
+
 > Performance improvements were delivered through the migration.
 
 After:
+
 > The migration cut p95 query latency by 4× and reduced memory usage by 30%.
 
 ### Example 3: vague → specific evidence
 
 Before:
+
 > We have deep experience in the Rust ecosystem.
 
 After:
-> We organize EuroRust, maintain "100 Exercises to Learn Rust", and migrated
-> the Redis Query Engine from C to Rust.
+
+> We organize EuroRust, maintain "100 Exercises to Learn Rust", and migrated the Redis Query Engine from C to Rust.
 
 ### Example 4: AI-slop frame → direct
 
 Before:
-> It's not just about writing code — it's about shaping the systems that
-> turn ideas into products. Let's dive into how we do that.
+
+> It's not just about writing code — it's about shaping the systems that turn ideas into products. Let's dive into how we do that.
 
 After:
-> Our work is about shaping the systems and processes that reliably turn
-> ideas into running products. Here's how.
 
-(Note: Mainmatter content does occasionally use the "not X but Y" frame —
-for example Marco's AI hype post — so this is a soft flag. If it appears
-once as a deliberate rhetorical beat, fine. If it appears three times in
-one post, flag at least two.)
+> Our work is about shaping the systems and processes that reliably turn ideas into running products. Here's how.
+
+(Note: Mainmatter content does occasionally use the "not X but Y" frame — for example Marco's AI hype post — so this is a soft flag. If it appears once as a deliberate rhetorical beat, fine. If it appears three times in one post, flag at least two.)

--- a/.agents/skills/mainmatter-content-review/references/mainmatter-voice.md
+++ b/.agents/skills/mainmatter-content-review/references/mainmatter-voice.md
@@ -1,0 +1,250 @@
+# Mainmatter voice
+
+The Mainmatter voice is **confident, technically grounded, approachable, and
+insightful**. It speaks credibly to developers who will scrutinize every
+technical claim, and to engineering leaders who need to understand the business
+case. Good Mainmatter writing earns trust with specifics, respects the reader's
+time, and avoids both marketing fluff and gratuitous jargon.
+
+This guide captures the patterns observed in published Mainmatter content
+(case studies, blog posts, landing pages). Use it as a reference when reviewing
+content, not a rulebook — the author's personal voice matters too.
+
+## What the Mainmatter voice sounds like
+
+### 1. Confident, with evidence
+
+Strong claims are paired with specifics a skeptical reader can verify:
+
+> Key modules have already been ported and released to the public, validating
+> the approach and demonstrating tangible benefits.
+
+> Team led by Luca Palmieri, author of "Zero to Production in Rust".
+
+Flag: claims that sound big but carry no evidence. "Industry-leading expertise"
+means nothing. "Organizers of EuroRust, Europe's Rust conference" means
+something.
+
+### 2. Concrete, not abstract
+
+Mainmatter writes about real systems, real engineers, real outcomes:
+
+> We started by deconstructing the extensive C codebase of the query engine
+> into modular components, prioritizing the less entangled "leaf" modules for
+> early migration.
+
+> A performance test implemented by Discourse inspired the
+> build-start-rebuild-perf tool, which provides metrics about your
+> application's build time.
+
+Flag: abstract verbs with no object. "We help clients succeed" — at what?
+"We accelerate transformation" — which transformation?
+
+### 3. Technical without walls of jargon
+
+Technical terms are used precisely, and named without over-explaining to
+readers who know them:
+
+> We setup a CI pipeline covering tests, linting, sanitizers (including Miri),
+> and coverage tracking.
+
+A developer reads this and trusts the writer. A manager reads it and gets the
+shape of the work without being drowned. When a term needs unpacking for
+non-specialists, the unpacking is short:
+
+> context-engineering — the practice of providing AI the tools, context, and
+> direction it needs to be efficient.
+
+Flag: either extreme. Jargon walls that alienate managers, or over-explanation
+that patronizes developers.
+
+### 4. Active voice, precise verbs
+
+> We migrated the Redis Query Engine from C to Rust.
+> Mainmatter embeds expert Rust engineers into client teams.
+> The Ember Initiative allocates time to migrate addons to v2.
+
+Flag: passive where active works. "Improvements were made to performance" →
+"We cut p95 latency by 4×". "Can be accelerated" → "accelerates".
+
+### 5. Business outcome paired with technical reality
+
+A strong Mainmatter sentence often names both sides:
+
+> Incremental migration of C and C++ codebases to Rust, improving memory
+> safety, reliability, and maintainability without disrupting day-to-day
+> operations.
+
+Technical content: incremental migration, memory safety. Business content:
+doesn't disrupt operations. Both.
+
+Flag: content that lands only on one side. Pure marketing ("improves
+business outcomes") or pure technical ("migrates the AST parser to Rolldown")
+both miss the Mainmatter register when selling a service.
+
+### 6. Direct invitations and acknowledgements
+
+Mainmatter content addresses the reader directly and ends with a concrete
+next step:
+
+> We're here to guide you through that transition as teammates, so you don't
+> have to navigate it alone.
+
+> If you're facing challenges with Ember.js and need a helping hand,
+> reach out!
+
+Flag: endings that trail off, or that pivot into generic CTAs unrelated to
+the post's argument.
+
+### 7. Honest about trade-offs
+
+Mainmatter writes about what's hard, not just what's good:
+
+> It's not as simple as just getting everyone a Claude account and then
+> expecting velocity to double overnight.
+
+> Contributing to Embroider usually involves a steep learning curve — it's
+> the kind of project that requires more than just a few hours and good
+> intentions.
+
+Flag: content that claims everything is easy, or that hides the real cost of
+a decision.
+
+## What the Mainmatter voice avoids
+
+### Empty marketing adjectives
+
+Never reinforce, usually flag:
+
+- "cutting-edge", "world-class", "best-in-class", "industry-leading",
+  "state-of-the-art", "next-generation", "revolutionary", "game-changing",
+  "premium" (as filler), "innovative" (as filler)
+- "seamless", "robust", "scalable", "holistic", "end-to-end" — acceptable
+  when the word is technically exact, lazy filler otherwise
+
+If a sentence still says something when you delete the adjective, the
+adjective was filler.
+
+### Business buzzwords
+
+Flag: "synergize", "stakeholder alignment", "leverage synergies",
+"value proposition" (when used as filler), "mission-critical" (unless
+technically accurate), "transformation journey", "digital transformation"
+(as filler).
+
+"Leverage" itself is borderline — Mainmatter content does use it occasionally
+when it means "make use of a specific advantage". Flag only when it's filler
+for "use".
+
+### AI-slop phrases
+
+Flag on sight:
+
+- "It's not just X — it's Y"
+- "Let's dive in" / "Let's unpack"
+- "In today's fast-paced world"
+- "Navigate the complexities of"
+- "It's worth noting that"
+- "Whether you're a X or a Y"
+- "Unlock the potential of"
+- "Elevate your workflow"
+- "Gone are the days when..."
+- "In an era of..."
+- "A testament to..."
+- Heavy reliance on the "not X, but Y" rhetorical frame
+- Bullet-listing every idea instead of writing paragraphs that flow
+
+### Filler words that weaken claims
+
+Usually cut or flag:
+
+- "very", "really", "quite", "rather", "somewhat", "fairly"
+- "simply", "just" (unless used for contrast: "not just X, but Y")
+- "basically", "essentially" (often filler)
+- "In order to" → "To"
+- "Due to the fact that" → "Because"
+- "At this point in time" → "Now"
+- "A large number of" → "Many"
+
+### Overclaiming and overhedging
+
+Both are weaknesses. Mainmatter voice is confident where it has evidence and
+honest where it doesn't:
+
+- Overclaiming: "the only Rust consultancy that can..." → soften to
+  "one of few", or name what specifically is unique.
+- Overhedging: "we might possibly be able to help you potentially improve" →
+  pick one verb and commit.
+
+## Formatting conventions
+
+- **Headings**: sentence case dominates blog posts; Title Case dominates
+  product/landing pages. Flag mixes within one document.
+- **Em dash**: `—` (U+2014), not `--`. Used for asides and emphasis.
+  Mainmatter uses them liberally, which is fine.
+- **Oxford comma**: preferred but not mandatory. Flag when absence creates
+  ambiguity.
+- **Curly vs. straight quotes**: Mainmatter content mostly uses curly
+  quotes ("", ''). Don't force a rewrite, but flag if one document mixes.
+- **Italics for emphasis**: yes, used for emphasis on relational words
+  (*you*, *your*) or for book titles ("Zero to Production in Rust" — note
+  this one is in quotes in Mainmatter copy).
+- **Links**: embedded inline, not numbered endnotes. Descriptive link text,
+  not "click here" or "this link".
+
+## People and team
+
+When introducing a Mainmatter team member in content, name both the role and
+a specific credential:
+
+> Team led by Chris Manson, member of the Ember.js Framework Core Team.
+> Team led by Luca Palmieri, author of "Zero to Production in Rust".
+> Team led by Paolo Ricciuti, Svelte core team member, author of SvelteLab.
+
+Flag: name-drops without context, or generic titles like "expert" without
+substantiation.
+
+## Examples of voice corrections
+
+### Example 1: marketing filler → concrete claim
+
+Before:
+> Mainmatter is a world-class engineering consultancy that delivers
+> cutting-edge solutions to help clients unlock their potential.
+
+After:
+> Mainmatter is an engineering consultancy specializing in Rust, Ember.js,
+> and Svelte. We help teams modernize codebases, migrate between
+> technologies, and build production systems that scale.
+
+### Example 2: passive → active
+
+Before:
+> Performance improvements were delivered through the migration.
+
+After:
+> The migration cut p95 query latency by 4× and reduced memory usage by 30%.
+
+### Example 3: vague → specific evidence
+
+Before:
+> We have deep experience in the Rust ecosystem.
+
+After:
+> We organize EuroRust, maintain "100 Exercises to Learn Rust", and migrated
+> the Redis Query Engine from C to Rust.
+
+### Example 4: AI-slop frame → direct
+
+Before:
+> It's not just about writing code — it's about shaping the systems that
+> turn ideas into products. Let's dive into how we do that.
+
+After:
+> Our work is about shaping the systems and processes that reliably turn
+> ideas into running products. Here's how.
+
+(Note: Mainmatter content does occasionally use the "not X but Y" frame —
+for example Marco's AI hype post — so this is a soft flag. If it appears
+once as a deliberate rhetorical beat, fine. If it appears three times in
+one post, flag at least two.)

--- a/.agents/skills/mainmatter-content-review/references/terminology.md
+++ b/.agents/skills/mainmatter-content-review/references/terminology.md
@@ -1,56 +1,43 @@
 # Mainmatter terminology and canonical spellings
 
-Canonical spellings for names, products, and terms that appear in Mainmatter
-content. When a document gets any of these wrong, flag it as `must-fix`
-(typos in proper nouns are always must-fix).
+Canonical spellings for names, products, and terms that appear in Mainmatter content. When a document gets any of these wrong, flag it as `must-fix` (typos in proper nouns are always must-fix).
 
 This list is not exhaustive. Extend it when new terms come up.
 
 ## Company and brand
 
-- **Mainmatter** — one word, capital M, no capital M in the middle. Never
-  "MainMatter", "mainmatter" (except in domains/URLs), "Main Matter",
-  "Mainmater".
+- **Mainmatter** — one word, capital M, no capital M in the middle. Never "MainMatter", "mainmatter" (except in domains/URLs), "Main Matter", "Mainmater".
 - **Mainmatter GmbH** — legal entity, capitalised exactly like this.
-- Treat Mainmatter as **singular** in prose: "Mainmatter is", "Mainmatter
-  offers", "Mainmatter specializes". Not "Mainmatter are".
+- Treat Mainmatter as **singular** in prose: "Mainmatter is", "Mainmatter offers", "Mainmatter specializes". Not "Mainmatter are".
 
 ## Technologies Mainmatter works on
 
 - **Rust** — capital R. "rust" is wrong.
-- **Ember.js** — with the `.js`. `Ember` alone is acceptable when the
-  context is already clear (e.g., "the Ember Initiative"). `Embers` is never
-  right. "EmberJS" and "Ember JS" both wrong.
+- **Ember.js** — with the `.js`. `Ember` alone is acceptable when the context is already clear (e.g., "the Ember Initiative"). `Embers` is never right. "EmberJS" and "Ember JS" both wrong.
 - **Ember** (the framework, shorthand) — fine when context is set.
 - **Svelte** — capital S. "svelte" is wrong.
 - **SvelteKit** — one word, camelCase. "Svelte Kit", "SvelteKIT" wrong.
 - **TypeScript** — one word, camelCase. "Typescript" wrong.
-- **JavaScript** — one word, camelCase. "Javascript", "javascript" wrong.
-  (`javascript:` URLs are a separate, lowercase-required case.)
+- **JavaScript** — one word, camelCase. "Javascript", "javascript" wrong. (`javascript:` URLs are a separate, lowercase-required case.)
 - **Vite** — capital V. "vite" wrong.
 - **Vitest** — capital V.
 - **Embroider** — capital E.
-- **Rolldown**, **Rollup**, **Babel**, **Webpack** (not "webpack" or
-  "WebPack"), **esbuild** (lowercase), **pnpm** (lowercase).
+- **Rolldown**, **Rollup**, **Babel**, **Webpack** (not "webpack" or "WebPack"), **esbuild** (lowercase), **pnpm** (lowercase).
 - **Node.js** — with the `.js`, capital N.
 - **Git**, **GitHub**, **GitLab** — capital G and capital H/L.
 
 ## Mainmatter engineers and founders (common names in content)
 
-Be careful with these. Misspelling a team member's name is always
-must-fix. If uncertain, flag with a note rather than silently guessing.
+Be careful with these. Misspelling a team member's name is always must-fix. If uncertain, flag with a note rather than silently guessing.
 
 - **Marco Otte-Witte** — hyphenated surname. Founder.
-- **Luca Palmieri** — two `l`s in surname? No, one. "Palmiere" wrong.
-  Author of "Zero to Production in Rust".
+- **Luca Palmieri** — two `l`s in surname? No, one. "Palmiere" wrong. Author of "Zero to Production in Rust".
 - **Chris Manson** — one `n` at end. Ember.js Framework Core Team member.
 - **Paolo Ricciuti** — double `c`, single `t`. Svelte core team member.
 - **Marine Dunstetter** — "Marine" not "Marina".
-- **Jonas Metzener** — double `z`? No, single. Check canonical source
-  when uncertain.
+- **Jonas Metzener** — double `z`? No, single. Check canonical source when uncertain.
 
-If a name spelling is uncertain, write: "Author name spelling — please
-verify against canonical source." Don't assume.
+If a name spelling is uncertain, write: "Author name spelling — please verify against canonical source." Don't assume.
 
 ## Products, initiatives, events Mainmatter runs or sponsors
 
@@ -58,9 +45,7 @@ verify against canonical source." Don't assume.
 - **EmberFest** — one word, capital E and F.
 - **Svelte Summit** — two words.
 - **Ember Initiative** — two words, both capitalised.
-- **Ember Vite Codemod** / **ember-vite-codemod** — casing depends on
-  context: human prose uses Title Case ("Ember Vite Codemod"), package
-  name uses kebab-case ("ember-vite-codemod").
+- **Ember Vite Codemod** / **ember-vite-codemod** — casing depends on context: human prose uses Title Case ("Ember Vite Codemod"), package name uses kebab-case ("ember-vite-codemod").
 - **100 Exercises to Learn Rust** — exact title, in quotes in prose.
 - **Zero to Production in Rust** — exact title, in quotes in prose.
 - **rust-exercises.com** — lowercase, hyphenated domain.
@@ -91,34 +76,26 @@ Canonical forms as they appear in navigation and landing pages:
 ## Industry and tech terms Mainmatter uses
 
 - **open source** (noun) — two words. "We contribute to open source".
-- **open-source** (adjective before noun) — hyphenated. "An open-source
-  library".
+- **open-source** (adjective before noun) — hyphenated. "An open-source library".
 - **codebase** — one word. "Code base" is wrong in Mainmatter content.
-- **frontend** / **backend** — one word (modern convention). Mainmatter
-  content uses these as one word; flag two-word or hyphenated versions
-  for consistency.
-- **full-stack** (adjective) — hyphenated. **full stack** (noun) — two
-  words, though this one varies.
+- **frontend** / **backend** — one word (modern convention). Mainmatter content uses these as one word; flag two-word or hyphenated versions for consistency.
+- **full-stack** (adjective) — hyphenated. **full stack** (noun) — two words, though this one varies.
 - **cloud-native** (adjective) — hyphenated.
 - **multi-framework** — hyphenated.
 - **end-to-end** — hyphenated.
-- **real-time** (adjective) — hyphenated. **in real time** (adverb) —
-  no hyphen.
-- **machine learning** — two words; "machine-learning" when used as
-  adjective ("machine-learning model").
+- **real-time** (adjective) — hyphenated. **in real time** (adverb) — no hyphen.
+- **machine learning** — two words; "machine-learning" when used as adjective ("machine-learning model").
 - **AI** — uppercase. Avoid "A.I." and "ai".
-- **PR** — short for pull request, uppercase. On first use in a post for
-  a non-technical audience, expand to "pull request (PR)".
+- **PR** — short for pull request, uppercase. On first use in a post for a non-technical audience, expand to "pull request (PR)".
 - **API** — uppercase.
 - **CI / CD / CI/CD** — uppercase.
 
 ## Preferred terminology
 
-Mainmatter content consistently uses certain framings. Nudge toward these
-when close synonyms appear:
+Mainmatter content consistently uses certain framings. Nudge toward these when close synonyms appear:
 
 | Prefer | Over |
-|---|---|
+| --- | --- |
 | engineering consultancy | software agency, development shop, dev shop |
 | engineers | developers (when distinguishing from non-engineers; both OK) |
 | migration | transformation (when it's literally a migration) |
@@ -144,10 +121,6 @@ Flag if a suggested rewrite pushes a field past its limit.
 
 ## Capitalisation conventions
 
-- **Blog post titles** in URLs and page headings: observe the author's
-  choice. Mainmatter has used both Title Case and sentence case over time.
-  Flag only within-document inconsistency.
-- **Section headings** within a blog post: usually Title Case on landing
-  pages, sentence case in blog bodies. Check the rest of the document
-  and match.
+- **Blog post titles** in URLs and page headings: observe the author's choice. Mainmatter has used both Title Case and sentence case over time. Flag only within-document inconsistency.
+- **Section headings** within a blog post: usually Title Case on landing pages, sentence case in blog bodies. Check the rest of the document and match.
 - **Mainmatter product names and services**: Title Case (as listed above).

--- a/.agents/skills/mainmatter-content-review/references/terminology.md
+++ b/.agents/skills/mainmatter-content-review/references/terminology.md
@@ -1,0 +1,153 @@
+# Mainmatter terminology and canonical spellings
+
+Canonical spellings for names, products, and terms that appear in Mainmatter
+content. When a document gets any of these wrong, flag it as `must-fix`
+(typos in proper nouns are always must-fix).
+
+This list is not exhaustive. Extend it when new terms come up.
+
+## Company and brand
+
+- **Mainmatter** — one word, capital M, no capital M in the middle. Never
+  "MainMatter", "mainmatter" (except in domains/URLs), "Main Matter",
+  "Mainmater".
+- **Mainmatter GmbH** — legal entity, capitalised exactly like this.
+- Treat Mainmatter as **singular** in prose: "Mainmatter is", "Mainmatter
+  offers", "Mainmatter specializes". Not "Mainmatter are".
+
+## Technologies Mainmatter works on
+
+- **Rust** — capital R. "rust" is wrong.
+- **Ember.js** — with the `.js`. `Ember` alone is acceptable when the
+  context is already clear (e.g., "the Ember Initiative"). `Embers` is never
+  right. "EmberJS" and "Ember JS" both wrong.
+- **Ember** (the framework, shorthand) — fine when context is set.
+- **Svelte** — capital S. "svelte" is wrong.
+- **SvelteKit** — one word, camelCase. "Svelte Kit", "SvelteKIT" wrong.
+- **TypeScript** — one word, camelCase. "Typescript" wrong.
+- **JavaScript** — one word, camelCase. "Javascript", "javascript" wrong.
+  (`javascript:` URLs are a separate, lowercase-required case.)
+- **Vite** — capital V. "vite" wrong.
+- **Vitest** — capital V.
+- **Embroider** — capital E.
+- **Rolldown**, **Rollup**, **Babel**, **Webpack** (not "webpack" or
+  "WebPack"), **esbuild** (lowercase), **pnpm** (lowercase).
+- **Node.js** — with the `.js`, capital N.
+- **Git**, **GitHub**, **GitLab** — capital G and capital H/L.
+
+## Mainmatter engineers and founders (common names in content)
+
+Be careful with these. Misspelling a team member's name is always
+must-fix. If uncertain, flag with a note rather than silently guessing.
+
+- **Marco Otte-Witte** — hyphenated surname. Founder.
+- **Luca Palmieri** — two `l`s in surname? No, one. "Palmiere" wrong.
+  Author of "Zero to Production in Rust".
+- **Chris Manson** — one `n` at end. Ember.js Framework Core Team member.
+- **Paolo Ricciuti** — double `c`, single `t`. Svelte core team member.
+- **Marine Dunstetter** — "Marine" not "Marina".
+- **Jonas Metzener** — double `z`? No, single. Check canonical source
+  when uncertain.
+
+If a name spelling is uncertain, write: "Author name spelling — please
+verify against canonical source." Don't assume.
+
+## Products, initiatives, events Mainmatter runs or sponsors
+
+- **EuroRust** — one word, capital E and R. "EuroRust" not "Euro Rust".
+- **EmberFest** — one word, capital E and F.
+- **Svelte Summit** — two words.
+- **Ember Initiative** — two words, both capitalised.
+- **Ember Vite Codemod** / **ember-vite-codemod** — casing depends on
+  context: human prose uses Title Case ("Ember Vite Codemod"), package
+  name uses kebab-case ("ember-vite-codemod").
+- **100 Exercises to Learn Rust** — exact title, in quotes in prose.
+- **Zero to Production in Rust** — exact title, in quotes in prose.
+- **rust-exercises.com** — lowercase, hyphenated domain.
+
+## Service names (from Mainmatter's site)
+
+Canonical forms as they appear in navigation and landing pages:
+
+- **Rust Consulting**
+- **C-to-Rust Migrations** — with hyphens, capital C and R.
+- **Rust Team Augmentation**
+- **Cloud-Native Rust Systems** — "cloud-native" hyphenated as adjective.
+- **Rust Training and Workshops**
+- **Svelte Consulting**
+- **Svelte 5 Migrations** — with the version number.
+- **Svelte Training and Workshops**
+- **Svelte Team Augmentation**
+- **Ember.js Consulting**
+- **Ember.js Vite Migrations**
+- **Ember.js Future-Proofing** — hyphenated.
+- **Ember.js Multi-Framework Architectures** — hyphenated.
+- **Team Reinforcement**
+- **Launch Your Idea**
+- **Tech Modernization**
+- **Strategic Advice**
+- **Workshops**
+
+## Industry and tech terms Mainmatter uses
+
+- **open source** (noun) — two words. "We contribute to open source".
+- **open-source** (adjective before noun) — hyphenated. "An open-source
+  library".
+- **codebase** — one word. "Code base" is wrong in Mainmatter content.
+- **frontend** / **backend** — one word (modern convention). Mainmatter
+  content uses these as one word; flag two-word or hyphenated versions
+  for consistency.
+- **full-stack** (adjective) — hyphenated. **full stack** (noun) — two
+  words, though this one varies.
+- **cloud-native** (adjective) — hyphenated.
+- **multi-framework** — hyphenated.
+- **end-to-end** — hyphenated.
+- **real-time** (adjective) — hyphenated. **in real time** (adverb) —
+  no hyphen.
+- **machine learning** — two words; "machine-learning" when used as
+  adjective ("machine-learning model").
+- **AI** — uppercase. Avoid "A.I." and "ai".
+- **PR** — short for pull request, uppercase. On first use in a post for
+  a non-technical audience, expand to "pull request (PR)".
+- **API** — uppercase.
+- **CI / CD / CI/CD** — uppercase.
+
+## Preferred terminology
+
+Mainmatter content consistently uses certain framings. Nudge toward these
+when close synonyms appear:
+
+| Prefer | Over |
+|---|---|
+| engineering consultancy | software agency, development shop, dev shop |
+| engineers | developers (when distinguishing from non-engineers; both OK) |
+| migration | transformation (when it's literally a migration) |
+| modernization | digital transformation |
+| training / workshop | boot camp (unless specifically a boot camp) |
+| codebase assessment | code audit (both fine, but "assessment" is more common) |
+| client | customer (for consulting engagements) |
+| teammate | resource (always flag "resources" used to mean people) |
+
+This is a soft preference. Author's choice wins if the alternate reads well.
+
+## SEO and metadata length constraints
+
+When reviewing or rewriting structured metadata, respect platform limits:
+
+- **<title>** / SEO title: ≤ 60 characters to avoid truncation in search.
+- **meta description**: ≤ 160 characters.
+- **Open Graph title**: ≤ 90 characters (60 is safer).
+- **Open Graph description**: ≤ 200 characters (160 is safer).
+- **schema.org description**: no hard limit, but keep to 1–2 sentences.
+
+Flag if a suggested rewrite pushes a field past its limit.
+
+## Capitalisation conventions
+
+- **Blog post titles** in URLs and page headings: observe the author's
+  choice. Mainmatter has used both Title Case and sentence case over time.
+  Flag only within-document inconsistency.
+- **Section headings** within a blog post: usually Title Case on landing
+  pages, sentence case in blog bodies. Check the rest of the document
+  and match.
+- **Mainmatter product names and services**: Title Case (as listed above).

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills


### PR DESCRIPTION
This adds the skill @KevinBongart wrote to the mainmatter.com repo so we can just run it locally when we are writing some blog post