### PR TITLE
Fix duplicate newsletter CTAs on tagged posts

### DIFF
--- a/src/components/newsletter-cta.njk
+++ b/src/components/newsletter-cta.njk
@@ -2,14 +2,12 @@
 
 {%- macro newsletterCta(tags) -%}
   {% if tags %}
-    {% for tag in tags %}
-      {% if tag === "rust" %}
-        {% include "global/rust-newsletter-cta.njk" %}
-      {% elif tag === "svelte" %}
-        {% include "global/svelte-newsletter-cta.njk" %}
-      {% else %}
-        {{ defaultNewsletterCta() }}
-      {% endif %}
-    {% endfor %}
+    {% if tags | length === 1 and tags[0] === "rust" %}
+      {% include "global/rust-newsletter-cta.njk" %}
+    {% elif tags | length === 1 and tags[0] === "svelte" %}
+      {% include "global/svelte-newsletter-cta.njk" %}
+    {% else %}
+      {{ defaultNewsletterCta() }}
+    {% endif %}
   {% endif %}
 {%- endmacro -%}


### PR DESCRIPTION
Fixes #2821

- Render one newsletter CTA per blog post.
- Use the Rust or Svelte newsletter only when that is the post's only tag.
- Fall back to the general Mainmatter newsletter for posts with multiple tags.