### PR TITLE
Reduce body text line height for readability

### DIFF
--- a/src/assets/css/base/_global.scss
+++ b/src/assets/css/base/_global.scss
@@ -134,7 +134,7 @@ table {
 html,
 body {
   min-height: 100%;
-  line-height: 2;
+  line-height: 1.6;
   font-family: var(--font-base);
   font-size: 1rem;
   color: var(--color-body-text);
@@ -149,7 +149,7 @@ html {
 
 body {
   font-size: 1rem;
-  line-height: 2;
+  line-height: 1.6;
 
   &.menu-open {
     overflow: hidden;
@@ -226,7 +226,7 @@ button {
 
 @media (min-width: $breakpoint-l) {
   body {
-    line-height: 2;
+    line-height: 1.6;
     font-size: 1.125rem;
   }
 }

--- a/src/assets/css/base/_typography.scss
+++ b/src/assets/css/base/_typography.scss
@@ -55,12 +55,12 @@ h5,
 
 body {
   font-size: 1.5rem;
-  line-height: 2;
+  line-height: 1.6;
 }
 
 .large {
   font-size: clamp(1.5rem, 1rem + 1.0417vw, 1.75rem);
-  line-height: 2;
+  line-height: 1.6;
 }
 
 .strong {
@@ -69,20 +69,20 @@ body {
 
 .medium {
   font-size: 1.2rem;
-  line-height: 2;
+  line-height: 1.6;
   font-weight: 400;
 }
 
 .small {
   font-size: 1rem;
   font-weight: 700;
-  line-height: 2;
+  line-height: 1.6;
 }
 
 .caption {
   font-size: 1.5rem;
   font-weight: 700;
-  line-height: 2;
+  line-height: 1.6;
 }
 
 .text--accent {

--- a/src/assets/css/components/_color-hero.scss
+++ b/src/assets/css/components/_color-hero.scss
@@ -89,7 +89,7 @@
 
 .color-hero__text {
   font-size: 1.2rem;
-  line-height: 2;
+  line-height: 1.6;
   font-weight: 400;
   max-width: 45rem;
 }

--- a/src/assets/css/components/_quote.scss
+++ b/src/assets/css/components/_quote.scss
@@ -111,12 +111,12 @@
 
   & .quote__text {
     font-weight: inherit;
-    line-height: 2;
+    line-height: 1.6;
     font-size: 1.2rem;
   }
 
   & .quote__source {
-    line-height: 2;
+    line-height: 1.6;
     font-size: 1.2rem;
   }
 }


### PR DESCRIPTION
## Summary

Reduce body text line height from `2` to `1.6`.

This applies to global body text, typography utility classes, color hero text, and quote content.

## Why

A line height of 2.0 introduces excessive spacing between lines, making paragraphs harder to scan and reducing visual cohesion.

A line height of 1.6 improves readability by keeping related lines visually connected while still providing sufficient breathing room for longer-form content. It also reduces unnecessary page height.