### PR TITLE
Nav bar: constrain width / improve scroll state

### DIFF
--- a/src/assets/css/components/_nav.scss
+++ b/src/assets/css/components/_nav.scss
@@ -116,8 +116,8 @@
 .nav__wrapper {
   display: grid;
   align-items: stretch;
-  margin: 0.75rem 5%;
-  min-width: 90%;
+  margin-top: 0.75rem;
+  margin-bottom: 0.75rem;
 }
 
 .nav__link-text {

--- a/src/assets/css/components/_nav.scss
+++ b/src/assets/css/components/_nav.scss
@@ -319,6 +319,11 @@
       line-height: 1.5rem;
     }
 
+       .nav__cta {
+      margin: 0.2rem 0;
+      padding: 0.7rem 1.75rem;
+    }
+
     .nav__expandable {
       --icon-caret-color: var(--color-black);
 

--- a/src/assets/css/components/_nav.scss
+++ b/src/assets/css/components/_nav.scss
@@ -45,13 +45,22 @@
 
 .nav__item {
   color: var(--color-white);
-  transition: color 0.4s ease;
+  transition:
+    color 0.4s ease,
+    line-height 0.4s ease;
 }
 
 .nav__item,
 .nav__cta {
   font-size: inherit;
-  transition: line-height 0.4s ease;
+}
+
+.nav__cta {
+  transition:
+    color 0.5s ease,
+    line-height 0.4s ease,
+    margin 0.4s ease,
+    padding 0.4s ease;
 }
 
 .nav__item a,
@@ -319,7 +328,7 @@
       line-height: 1.5rem;
     }
 
-       .nav__cta {
+    .nav__cta {
       margin: 0.2rem 0;
       padding: 0.7rem 1.75rem;
     }
@@ -349,6 +358,10 @@
   .nav__wrapper,
   .nav__logo svg,
   .nav__item,
+  .nav__item a,
+  .nav__item button,
+  .nav__link-text,
+  .nav__cta,
   .nav__list--pinned,
   .nav__list--pinned .nav__item,
   .nav__list--pinned .nav__item svg path,

--- a/src/assets/css/components/_nav.scss
+++ b/src/assets/css/components/_nav.scss
@@ -46,7 +46,6 @@
 .nav__item {
   color: var(--color-white);
   transition:
-    color 0.4s ease,
     line-height 0.4s ease;
 }
 

--- a/src/assets/css/components/_nav.scss
+++ b/src/assets/css/components/_nav.scss
@@ -7,9 +7,10 @@
   width: 100%;
   anchor-scope: --nav-overflow;
   transition:
-    background 0.3s ease,
-    padding 0.3s ease;
-  background: transparent;
+    background-color 0.4s ease,
+    box-shadow 0.4s ease;
+  background-color: transparent;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0);
   --nav-underline-weight: 0.125rem;
   --nav-underline-offset: 0.55rem;
 }
@@ -28,6 +29,9 @@
   color: var(--color-white);
   position: relative;
   top: -0.15em;
+  transition:
+    color 0.4s ease,
+    height 0.4s ease;
 }
 
 .nav button {
@@ -41,11 +45,13 @@
 
 .nav__item {
   color: var(--color-white);
+  transition: color 0.4s ease;
 }
 
 .nav__item,
 .nav__cta {
   font-size: inherit;
+  transition: line-height 0.4s ease;
 }
 
 .nav__item a,
@@ -65,12 +71,13 @@
   white-space: nowrap;
 }
 
-.nav__list--pinned {
-  color: var(--color-aqua);
+.nav__list--pinned .nav__item {
+  color: var(--color-white);
 }
 
 .nav__list--pinned .nav__item svg path {
   fill: var(--color-aqua);
+  transition: fill 0.4s ease;
 }
 
 .nav__item svg {
@@ -118,6 +125,7 @@
   align-items: stretch;
   margin-top: 0.75rem;
   margin-bottom: 0.75rem;
+  transition: margin 0.4s ease;
 }
 
 .nav__link-text {
@@ -271,20 +279,26 @@
     border-left: 2px solid var(--color-aqua);
     margin-left: 1.5rem;
     padding-left: 1.5rem;
+    transition: border-color 0.4s ease;
   }
 
   .nav__scrolled {
     position: fixed;
-    background: var(--color-white);
+    background-color: var(--color-white);
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+
+    .nav__wrapper {
+      margin-top: 0.125rem;
+      margin-bottom: 0.125rem;
+    }
 
     & :has(#nav-overflow:popover-open) .nav__expandable {
       text-decoration-color: var(--color-purple);
       color: var(--color-purple);
     }
 
-    .nav__list--pinned {
-      color: var(--color-purple);
+    .nav__list--pinned .nav__item {
+      color: var(--color-black);
     }
 
     .nav__list--pinned .nav__item svg path {
@@ -293,10 +307,16 @@
 
     .nav__logo svg {
       color: var(--color-purple);
+      height: 1.5rem;
     }
 
     .nav__item {
       color: var(--color-black);
+    }
+
+    .nav__item,
+    .nav__cta {
+      line-height: 1.5rem;
     }
 
     .nav__expandable {
@@ -316,6 +336,19 @@
       color: var(--color-purple);
       text-decoration-color: var(--color-purple);
     }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nav,
+  .nav__wrapper,
+  .nav__logo svg,
+  .nav__item,
+  .nav__list--pinned,
+  .nav__list--pinned .nav__item,
+  .nav__list--pinned .nav__item svg path,
+  .nav__list--pinned + .nav__list .nav__item:first-child {
+    transition-duration: 0.01ms;
   }
 }
 

--- a/src/assets/css/components/_nav.scss
+++ b/src/assets/css/components/_nav.scss
@@ -45,8 +45,7 @@
 
 .nav__item {
   color: var(--color-white);
-  transition:
-    line-height 0.4s ease;
+  transition: line-height 0.4s ease;
 }
 
 .nav__item,

--- a/src/assets/js/nav.js
+++ b/src/assets/js/nav.js
@@ -1,28 +1,14 @@
-// Scrolling event listener for the sticky nav bar. Only appiles class="nav__scrolled" on breakpoints larger than breakpoint-m
+// Scrolling event listener for the sticky nav bar.
 
 const nav = document.querySelector(".nav");
-
-const throttle = (fn, delay) => {
-  let now = Date.now();
-  let timer;
-  return (...args) => {
-    clearTimeout(timer);
-    if (now + delay - Date.now() <= 0) {
-      fn.call(null, ...args);
-      now = Date.now();
-    } else {
-      timer = setTimeout(() => {
-        fn.call(null, ...args);
-        now = Date.now();
-      }, delay);
-    }
-  };
-};
+const scrollEnterThreshold = 24;
+const scrollExitThreshold = 4;
+let isScrollFramePending = false;
 
 const handleScroll = () => {
-  if (window.scrollY > 10) {
+  if (window.scrollY > scrollEnterThreshold) {
     nav.classList.add("nav__scrolled");
-  } else {
+  } else if (window.scrollY <= scrollExitThreshold) {
     nav.classList.remove("nav__scrolled");
   }
 };
@@ -30,4 +16,18 @@ const handleScroll = () => {
 // Run once immediately to handle reloads mid-page
 handleScroll();
 
-window.addEventListener("scroll", throttle(handleScroll, 100), { passive: true });
+window.addEventListener(
+  "scroll",
+  () => {
+    if (isScrollFramePending) {
+      return;
+    }
+
+    isScrollFramePending = true;
+    window.requestAnimationFrame(() => {
+      handleScroll();
+      isScrollFramePending = false;
+    });
+  },
+  { passive: true }
+);


### PR DESCRIPTION
## Summary

Constrain the navigation wrapper to the existing `container--xl` maximum width and improve its sticky scroll state (smoother animation + less height).

## Why

The navigation previously overrode the container's maximum width on large screens. Its transition into the sticky white state was also abrupt and unstable near the scroll threshold.

These changes:

- Limit the navigation width to `86rem`
- Keep it centered on wide screens
- Preserve its responsive width on smaller screens
- Align it with other XL page sections
- Smooth the sticky navigation transitions
- Reduce its height after scrolling
- Respect reduced-motion preferences

The `nav.js` update:

- Replaces the 100ms throttle with `requestAnimationFrame`