### PR TITLE
Fix blog cta styles so link formatting applies at all screen sizes

### DIFF
--- a/src/assets/css/components/_cta-banner.scss
+++ b/src/assets/css/components/_cta-banner.scss
@@ -114,6 +114,15 @@
   }
 
   .cta-banner__text {
+    margin-top: 0.75rem;
+
+    a {
+      text-decoration: underline;
+      font-weight: 400;
+    }
+  }
+
+  .cta-banner__text {
     margin-top: 1rem;
   }
 
@@ -129,15 +138,6 @@
     .cta-banner__title,
     .cta-banner__text {
       grid-column: 1;
-    }
-
-    .cta-banner__text {
-      margin-top: 0.75rem;
-
-      a {
-        text-decoration: underline;
-        font-weight: 400;
-      }
     }
 
     .btn-primary {

--- a/src/assets/css/components/_cta-banner.scss
+++ b/src/assets/css/components/_cta-banner.scss
@@ -114,16 +114,12 @@
   }
 
   .cta-banner__text {
-    margin-top: 0.75rem;
+    margin-top: 1rem;
 
     a {
       text-decoration: underline;
       font-weight: 400;
     }
-  }
-
-  .cta-banner__text {
-    margin-top: 1rem;
   }
 
   @media (min-width: $breakpoint-l) {


### PR DESCRIPTION
- Moved the .service-cta--blog .cta-banner__text block out of the @media (min-width: $breakpoint-l) scope.
- Ensures the underline and font-weight: 400 link styles apply on all viewport sizes for the blog CTA.
- Keeps the blog CTA text styling consistent across mobile and desktop.