### PR TITLE
Refine blog cta mobile padding and font sizing

### DIFF
--- a/src/assets/css/components/_cta-banner.scss
+++ b/src/assets/css/components/_cta-banner.scss
@@ -95,56 +95,6 @@
   margin-bottom: 1.5rem;
 }
 
-.service-cta--blog {
-  .cta-banner__wrapper {
-    padding: 4rem 6rem;
-  }
-
-  .cta-banner__main {
-    max-width: none;
-    padding: 0;
-  }
-
-  .cta-banner__title {
-    font-size: 2.7rem;
-
-    a {
-      color: var(--color-white);
-    }
-  }
-
-  .cta-banner__text {
-    margin-top: 1rem;
-
-    a {
-      text-decoration: underline;
-      font-weight: 400;
-    }
-  }
-
-  @media (min-width: $breakpoint-l) {
-    .cta-banner__main {
-      display: grid;
-      grid-template-columns: minmax(0, 1fr) auto;
-      column-gap: 3rem;
-      align-items: center;
-      width: 100%;
-    }
-
-    .cta-banner__title,
-    .cta-banner__text {
-      grid-column: 1;
-    }
-
-    .btn-primary {
-      grid-column: 2;
-      grid-row: 1 / span 2;
-      margin-top: 0;
-      white-space: nowrap;
-    }
-  }
-}
-
 .cta-banner__whirlwind {
   background-color: #fdfebc;
   box-shadow:
@@ -266,5 +216,76 @@
 @media (min-width: $breakpoint-s) {
   .cta__input {
     min-width: 32rem;
+  }
+}
+
+.service-cta--blog {
+  .cta-banner__wrapper {
+    padding: 4rem 6rem;
+  }
+
+  .cta-banner__main {
+    max-width: none;
+    padding: 0;
+  }
+
+  .cta-banner__title {
+    font-size: 2.7rem;
+
+    a {
+      color: var(--color-white);
+    }
+  }
+
+  .cta-banner__text {
+    margin-top: 1rem;
+    font-size: clamp(1.125rem, 1.0214rem + 0.442vw, 1.375rem);
+
+    a {
+      text-decoration: underline;
+      font-weight: 400;
+    }
+  }
+
+  @media (max-width: $breakpoint-m) {
+    & .cta-banner__wrapper {
+      padding: 3rem 4rem;
+    }
+
+    & .cta-banner__title {
+      font-size: 2.4rem;
+    }
+  }
+
+  @media (max-width: $breakpoint-s) {
+    & .cta-banner__wrapper {
+      padding: 2rem;
+    }
+
+    & .cta-banner__title {
+      font-size: 2rem;
+    }
+  }
+
+  @media (min-width: $breakpoint-l) {
+    .cta-banner__main {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) auto;
+      column-gap: 3rem;
+      align-items: center;
+      width: 100%;
+    }
+
+    .cta-banner__title,
+    .cta-banner__text {
+      grid-column: 1;
+    }
+
+    .btn-primary {
+      grid-column: 2;
+      grid-row: 1 / span 2;
+      margin-top: 0;
+      white-space: nowrap;
+    }
   }
 }


### PR DESCRIPTION
- Added responsive `.service-cta--blog` styles in `src/assets/css/components/_cta-banner.scss`
- Preserved the custom desktop blog CTA layout and padding
- Reduced `.service-cta__wrapper` padding at `max-width: $breakpoint-m` and `max-width: $breakpoint-s`
- Lowered `.cta-banner__title` font size on smaller screens
- Applied a `clamp()`-based font-size to `.service-cta--blog .cta-banner__text` for smoother scaling
- Scoped the new breakpoint rules inside `.service-cta--blog` so only the blog CTA is affected