### PR TITLE
Unify workshop card content widths

### DIFF
--- a/src/assets/css/components/_workshops-landing.scss
+++ b/src/assets/css/components/_workshops-landing.scss
@@ -127,11 +127,6 @@
   pointer-events: auto;
 }
 
-.workshop-card--full .workshop-card__main,
-.workshop-card--full .workshop-card__description {
-  max-width: none;
-}
-
 .workshop-card__title {
   order: 2;
   margin-bottom: 1rem;
@@ -566,10 +561,6 @@
   .workshop-card__main,
   .workshop-card__details {
     align-self: first baseline;
-  }
-
-  .workshop-card--full {
-    grid-template-columns: 1fr;
   }
 
   .workshop-card__title {

--- a/src/components/workshop-card.njk
+++ b/src/components/workshop-card.njk
@@ -10,9 +10,7 @@
     {% set ticketPrice = dates[0].price %}
   {% endif %}
 
-  <article
-    class="workshop-card {% if not price and not hasUpcomingDates %}workshop-card--full{% endif %}"
-  >
+  <article class="workshop-card">
     <a
       class="workshop-card__overlay-link"
       href="/training/{{ workshop.fileSlug }}/"


### PR DESCRIPTION
Removed the full-width layout for workshop cards without dates or prices.

This gives all workshop descriptions a consistent width and improves alignment across the training pages.